### PR TITLE
(GH-2) Allow Showing Up To 5 Levels on Right Nav

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -16,7 +16,7 @@ namespace Docs
             //.AddSetting("ValidateAbsoluteLinks", true)
             //.AddSetting("ValidateLinksAsError", true)
             .AddSetting(Constants.EditLink, ConfigureEditLink())
-            .AddSetting(WebKeys.GatherHeadingsLevel, 3)
+            .AddSetting(WebKeys.GatherHeadingsLevel, 5)
             .ConfigureSite("chocolatey", "docs", "master")
             .ConfigureDeployment(deployBranch: "gh-pages")
             .AddShortcode("Children", typeof(ChildrenShortcode))


### PR DESCRIPTION
On each documentation page, a right navigation is present that
supplies a TOC for the headings inside of that document. Right now, it
only goes down 3 levels (to support up to an h3 element). Most of the
time this is ok, but some of our documents contain up to an h5. This
change allows for those levels to be shown as well, making our TOC more
navigatable and accurate.