### PR TITLE
(GH-27) Add Breadcrumbs

### DIFF
--- a/input/_breadcrumbs.cshtml
+++ b/input/_breadcrumbs.cshtml
@@ -1,0 +1,20 @@
+@{
+IDocument root = OutputPages["en-us/index.html"].First();
+
+<h1 class="title">@(Document.GetString(Keys.Title) ?? Document.GetTitle())</h1>                 
+<nav aria-label="breadcrumb">
+	<ol class="breadcrumb">
+		@foreach (IDocument parent in OutputPages.GetAncestorsOf(Document, Document.IdEquals(root)).Reverse().Skip(1))
+		{
+			string breadcrumbTitle = parent.GetTitle();
+			if (breadcrumbTitle == root.GetTitle()) {
+				breadcrumbTitle = "Chocolatey";
+			}
+
+			<li class="breadcrumb-item @(Document.IdEquals(root) ? "d-none" : null)">@Html.DocumentLink(parent, parent.GetString(Constants.BreadcrumbTitle, breadcrumbTitle))</li>
+		}
+		
+		<li class="breadcrumb-item active @(Document.IdEquals(root) ? "d-none" : null)" aria-current="page">@(Document.GetString(Keys.Title) ?? Document.GetTitle())</li>
+	</ol>
+</nav>
+}

--- a/input/_layout.cshtml
+++ b/input/_layout.cshtml
@@ -130,10 +130,14 @@
                     </nav>
                 </div>
                 <div class="col-md-9 col-xl-10 py-3 py-md-5 mx-auto">
-                    <h1 class="title ml-md-4 d-xl-none">@(Document.GetString(Keys.Title) ?? Document.GetTitle())</h1>
+                    <div class="ml-md-4 d-xl-none">
+                        @Html.Partial("_breadcrumbs")
+                    </div>
                     <div class="row">
                         <div id="mainContent" class="col-xl-10 pl-md-5 order-2 order-xl-1">
-                             <h1 class="title d-none d-xl-block">@(Document.GetString(Keys.Title) ?? Document.GetTitle())</h1>
+                             <div class="d-none d-xl-block">
+                                @Html.Partial("_breadcrumbs")
+                             </div>
                             @RenderBody()
                         </div>
                         @{

--- a/input/assets/css/_base.scss
+++ b/input/assets/css/_base.scss
@@ -31,6 +31,17 @@ h1, h2, h3 {
 
 h1, h2 {
     color: $primary;
+}
+
+.breadcrumb {
+    margin-bottom: $spacer;
+
+    .breadcrumb-item.active {
+        color: var(--text);
+    }
+}
+
+h1:not(.title), h2, .breadcrumb {
     padding-bottom: $spacer / 2;
     border-bottom: 3px solid $primary-opacity;
 }
@@ -75,7 +86,7 @@ img {
 }
 
 #mainContent {
-    h1 + h1 {
+    h1:not(.title):first-of-type {
         display: none;
     }
 
@@ -122,5 +133,9 @@ footer {
         h2:first-of-type {
             margin-top: $spacer * 2;
         }
+    }
+
+    .breadcrumb {
+        margin-bottom: $spacer * 2;
     }
 }

--- a/src/Constants.cs
+++ b/src/Constants.cs
@@ -9,6 +9,7 @@ namespace Docs
     public const string EditLink = nameof(EditLink);
     public const string Description = nameof(Description);
     public const string ShowInSidebar = nameof(ShowInSidebar);
+    public const string BreadcrumbTitle = nameof(BreadcrumbTitle);
 
     public static class Emojis
     {


### PR DESCRIPTION
Adds a breadcrumb trail to each page below the top heading for easier
navigation.

Code inspired by:
https://github.com/statiqdev/statiqdev.github.io/blob/6a58b2f6d7741b1f03a450b2783b6a5dc091b18c/input/_layout.cshtml#L113

![breadcrumb-light](https://user-images.githubusercontent.com/42750725/96492468-4c5b7580-1209-11eb-854f-bb21b214d117.png)

![breadcrumb-dark](https://user-images.githubusercontent.com/42750725/96492481-51b8c000-1209-11eb-8203-cbbcda0d6c27.png)


Fixes #27