### PR TITLE
(#31) Allow left navigation to toggle on click

### DIFF
--- a/input/_layout.cshtml
+++ b/input/_layout.cshtml
@@ -78,53 +78,65 @@
                                 <li class="nav-item">
                                     @if(root.ShowLink())
                                     {
-                                        <a class="nav-link @(Document.IdEquals(root) ? "active active-page" : null)" href="@root.GetLink()">@root.GetTitle()</a>
+                                        <a class="nav-link pl-c2 @(Document.IdEquals(root) ? "active active-page" : null)" href="@root.GetLink()">@root.GetTitle()</a>
                                     }
                                     else
                                     {
                                         @root.GetTitle()
                                     }
                                 </li>
-                                <li class="nav-item">
+                                
                                     @foreach (IDocument document in OutputPages.GetChildrenOf(root).OnlyVisible())
                                     {
                                         DocumentList<IDocument> documentChildren = OutputPages.GetChildrenOf(document);
 
                                         @if(documentChildren.Any()) {
-                                            <a class="nav-link nav-link-collapse @(Document.IdEquals(document) ||  OutputPages.GetDescendantsOf(document).Any(x => Document.IdEquals(x)) ? "active" : null) @(Document.IdEquals(document) ? "active-page" : null)" role="button" aria-expanded="false" href="@document.GetLink()" data-href="#id-@document.Id">@document.GetTitle()</a>
-                                            <div class="collapse" id="id-@document.Id">
-                                                <ul class="navbar-nav">
-                                                    @foreach (IDocument child in documentChildren.OnlyVisible())
-                                                    {
-                                                        <li class="nav-item">
-                                                            @if(OutputPages.GetChildrenOf(child).Any()) {
-                                                                <a class="nav-link nav-link-collapse @(Document.IdEquals(child) || OutputPages.GetDescendantsOf(child).Any(x => Document.IdEquals(x)) ? "active" : null) @(Document.IdEquals(child) ? "active-page" : null)" role="button" aria-expanded="false" data-href="#id-@child.Id" href="@child.GetLink()" data-href="#id-@child.Id">@child.GetTitle()</a>
-                                                                <div class="collapse" id="id-@child.Id">
-                                                                    <ul class="navbar-nav">
-                                                                        @foreach (IDocument childChild in OutputPages.GetChildrenOf(child).OnlyVisible())
-                                                                        {
-                                                                            <li class="nav-item">
-                                                                                <a class="nav-link @(Document.IdEquals(childChild) ? "active active-page" : null)" href="@childChild.GetLink()">@childChild.GetTitle()</a>
-                                                                            </li>
-                                                                        }
-                                                                    </ul>
-                                                                </div>
+                                            <li class="nav-item">
+                                                <div class="nav-link nav-link-collapse d-flex @(Document.IdEquals(document) ||  OutputPages.GetDescendantsOf(document).Any(x => Document.IdEquals(x)) ? "active" : null) @(Document.IdEquals(document) ? "active-page" : null)">
+                                                    <div class="btn btn-collapse collapsed" role="button" data-toggle="collapse" aria-expanded="false" href="#id-@document.Id"></div>
+                                                    <a href="@document.GetLink()">@document.GetTitle()</a>
+                                                </div>
+                                                <div class="collapse" id="id-@document.Id">
+                                                    <ul class="navbar-nav">
+                                                        @foreach (IDocument child in documentChildren.OnlyVisible())
+                                                        {
+                                                            @if(OutputPages.GetChildrenOf(child).Any())
+                                                            {
+                                                                <li class="nav-item">
+                                                                    <div class="nav-link nav-link-collapse d-flex @(Document.IdEquals(child) ||  OutputPages.GetDescendantsOf(child).Any(x => Document.IdEquals(x)) ? "active" : null) @(Document.IdEquals(child) ? "active-page" : null)">
+                                                                        <div class="btn btn-collapse pl-c2 collapsed" role="button" data-toggle="collapse" aria-expanded="false" href="#id-@child.Id"></div>
+                                                                        <a href="@document.GetLink()">@child.GetTitle()</a>
+                                                                    </div>
+                                                                    <div class="collapse" id="id-@child.Id">
+                                                                        <ul class="navbar-nav">
+                                                                            @foreach (IDocument childChild in OutputPages.GetChildrenOf(child).OnlyVisible())
+                                                                            {
+                                                                                <li class="nav-item">
+                                                                                    <a class="nav-link pl-c4 @(Document.IdEquals(childChild) ? "active active-page" : null)" href="@childChild.GetLink()">@childChild.GetTitle()</a>
+                                                                                </li>
+                                                                            }
+                                                                        </ul>
+                                                                    </div>
+                                                                </li>
                                                             }
                                                             else
                                                             {
-                                                                <a class="nav-link @(Document.IdEquals(child) ? "active active-page" : null)" href="@child.GetLink()">@child.GetTitle()</a>
-                                                            } 
-                                                        </li>
-                                                    }
-                                                </ul>
-                                            </div>
+                                                                <li class="nav-item">
+                                                                    <a class="nav-link pl-5 @(Document.IdEquals(child) ? "active active-page" : null)" href="@child.GetLink()">@child.GetTitle()</a>
+                                                                </li>
+                                                            }
+                                                        }
+                                                    </ul>
+                                                </div>
+                                            </li>
                                         }
                                         else
                                         {
-                                            <a class="nav-link @(Document.IdEquals(document) ? "active active-page" : null)" href="@document.GetLink()">@document.GetTitle()</a>
+                                            <li class="nav-item">
+                                                <a class="nav-link pl-c2 @(Document.IdEquals(document) ? "active active-page" : null)" href="@document.GetLink()">@document.GetTitle()</a>
+                                            </li>
                                         }
                                     }
-                                </li>
                             </ul>
                         </div>
                     </nav>

--- a/input/assets/css/_base.scss
+++ b/input/assets/css/_base.scss
@@ -104,6 +104,15 @@ img {
     }
 }
 
+/*Utilities*/
+.pl-c2 {
+    padding-left: $spacer * 2 !important;
+}
+
+.pl-c4 {
+    padding-left: $spacer * 4 !important;
+}
+
 /*Gitter*/
 .gitter-chat-embed, .gitter-open-chat-button {
     z-index: 9999;

--- a/input/assets/css/_icons.scss
+++ b/input/assets/css/_icons.scss
@@ -1,4 +1,4 @@
-.nav-link-collapse, .btn-collapse {
+.btn-collapse {
     &:before {
         font-family: "Font Awesome 5 Free";
         display: inline-block;
@@ -11,14 +11,14 @@
     }
 
     // Angle right
-    &.nav-link:not(.active), &.btn.collapsed {
+    &.btn.collapsed {
         &:before {
             content: "\f105";
         }
     }
 
     // Angle down
-    &.nav-link.active, &.btn:not(.collapsed) {
+    &.btn:not(.collapsed) {
         &:before {
             content: "\f107";
         }

--- a/input/assets/css/_left-navigation.scss
+++ b/input/assets/css/_left-navigation.scss
@@ -29,29 +29,55 @@
             .nav-link {
                 color: $gray-900;
                 color: var(--text);
-                padding: $spacer;
+                padding: 0;
                 border-left: 6px solid transparent;
 
-                &.active, &:hover {
+                &.active, &:hover, &.nav-link-open {
                     border-color: $primary;
                     color: $primary;
+
+                    .btn-collapse:before, a {
+                        color: $primary;
+                    }
                 }
                 
-                &.active-page, &:hover {
+                &.active-page, &:hover, &.active-child {
                     background: $primary-opacity;
                 }
 
-                &.active {
+                &.active, &.active-child, &.nav-link-open {
                     font-weight: bold;
+                }
+
+                &:not(.nav-link-collapse) {
+                    padding: $spacer;
+                }
+
+                .btn-collapse {
+                    padding: $spacer 0 0 $spacer;
+
+                    &:before {
+                        color: $gray-900;
+                        color: var(--text);
+                        transition: $theme-transition;
+                    }
+                }
+            
+                a {
+                    width: 100%;
+                    padding: $spacer .25rem $spacer 0;
+                    color: $gray-900;
+                    color: var(--text);
+                    transition: $theme-transition;
                 }
             }
 
-            .collapse .nav-link:not(.active) {
+            .collapse .nav-link {
                 border-left: 6px solid $primary;
             }
 
-             > .navbar-nav {
-                 > .nav-item {
+            > .navbar-nav {
+                > .nav-item {
                     > .nav-link {
                         &:not(.nav-link-collapse) {
                             padding-left: $spacer * 2;
@@ -61,7 +87,7 @@
                         > .navbar-nav {
                             > .nav-item {
                                 > .nav-link {
-                                    &.nav-link-collapse {
+                                    &.nav-link-collapse .btn-collapse {
                                         padding-left: $spacer * 2;
                                     }
 
@@ -73,7 +99,7 @@
                                     > .navbar-nav {
                                         > .nav-item {
                                             > .nav-link {
-                                                &.nav-link-collapse {
+                                                &.nav-link-collapse .btn-collapse {
                                                     padding-left: $spacer * 3;
                                                 }
 

--- a/input/assets/js/custom.js
+++ b/input/assets/js/custom.js
@@ -55,8 +55,30 @@ if (!$('h2:first-of-type').hasClass('title-child')) {
 }
 
 // Left navigation
-$.each($('.nav-link-collapse.active'), function () {
-    $($(this).attr('data-href')).collapse('show');
+$.each(leftSidebarNav.find('.nav-link-collapse.active'), function (i, value) {
+    var showActiveNav = $($(this).find('.btn-collapse').attr('href'));
+    
+    showActiveNav.collapse('show');
+
+    // If the nav is collapsed, highlight the collapsed parent
+    $(this).find('.btn-collapse').click(function() {
+        $('.active-child').removeClass('active-child');
+
+        if (!$(this).hasClass('collapsed')) {
+            $(this).parent().addClass('active-child');
+        } else {
+            $($(this).attr('href')).find('.nav-link-collapse.active').addClass('active-child');
+        }
+    });
+});
+
+// When nav item is expanded, add class to parent for styling purposes
+leftSidebarNav.find('.btn-collapse').click(function() {
+    if ($(this).hasClass('collapsed')) {
+        $(this).parent().addClass('nav-link-open');
+    } else {
+        $(this).parent().removeClass('nav-link-open');
+    }
 });
 
 // Find new height for navigation scroll after collapse has shown/hidden


### PR DESCRIPTION
Support has been added to allow the user to click the carrot icons in
the left navigation to expand/collapse items without navigating to the
page. The styling has been enhanced to support this and allow the user
to tell where they are in the navigation.

Fixes #31 