### PR TITLE
(GH-52) Make Cookie Work Across All Domains

### DIFF
--- a/input/assets/js/custom.js
+++ b/input/assets/js/custom.js
@@ -138,7 +138,8 @@ Prism.highlightAll();
 
 // Cookie Notice
 const cookieNoticeAlert = $('#cookieNoticeAlert'),
-      cookieNotice = getCookie('chocolatey_hide_cookies_notice');
+      cookieNoticeName = 'chocolatey_hide_cookies_notice',
+      cookieNotice = getCookie(cookieNoticeName);
 
 if (cookieNotice) {
     cookieNoticeAlert.remove();
@@ -147,7 +148,11 @@ if (cookieNotice) {
 }
 
 cookieNoticeAlert.find('button').click(function() {
-    document.cookie = "chocolatey_hide_cookies_notice" + "=true; path=/;";
+    if (~location.hostname.indexOf('chocolatey.org')) {
+        document.cookie = cookieNoticeName + '=true; path=/; domain=chocolatey.org;';
+    } else {
+        document.cookie = cookieNoticeName + '=true; path=/;';
+    }
 });
 
 // Search


### PR DESCRIPTION
The cookie set by the cookie banner notice has been set to have the
domain of chocolatey.org. This will allow the cookie to be read and
used on the main chocolatey.org and any subdomain.

If the cookie is set on a local environment, it will not be set with
this property. This has been done so that the cookie still works and
can be tested while running locally. The cross domain
functionality will only work on the actual live site.

Fixes #52 