### PR TITLE
(GH-6) Enhance Search on Mobile

### DIFF
--- a/input/_layout.cshtml
+++ b/input/_layout.cshtml
@@ -264,7 +264,7 @@
                 apiKey: '8148a7b5d009b8590bb85191c6f1823c',
                 indexName: 'chocolatey',
                 inputSelector: '#searchQuery',
-                debug: false // Set debug to true if you want to inspect the dropdown
+                debug: true // Set debug to true if you want to inspect the dropdown
             });
         </script>
     </body>

--- a/input/assets/css/_base.scss
+++ b/input/assets/css/_base.scss
@@ -127,6 +127,11 @@ img {
         border-color: var(--border)
     }
 
+    .modal-header, .modal-body, .modal-footer {
+        background: $white;
+        background: var(--background-light);
+    }
+
     .modal-header {
         .close {
             color: var(--text);

--- a/input/assets/css/_search.scss
+++ b/input/assets/css/_search.scss
@@ -177,7 +177,8 @@
                 max-width: 100vw;
 
                 .modal-content {
-                    min-height: 100vh;
+                    height: 100vh; // Fallback
+                    height: calc(var(--vh, 1vh) * 100);
                     border-radius: 0;
                 }
             }

--- a/input/assets/js/custom.js
+++ b/input/assets/js/custom.js
@@ -111,6 +111,7 @@ $('.collapse').on('shown.bs.collapse', function () {
 showCollapsedHash();
 
 // Functions based on viewport
+getWindowVHHeight();
 toggleRightSidebarNav();
 toggleStickyTop();
 getLeftSidebarNavHeight();
@@ -284,6 +285,7 @@ $.each($('.btn-collapse-target'), function() {
 });
 
 $(window).on("resize", function () {
+    getWindowVHHeight();
     toggleRightSidebarNav();
     toggleStickyTop();
     getLeftSidebarNavHeight();
@@ -293,6 +295,11 @@ $(window).on("resize", function () {
 leftSidebarNav.find('.loader-container').fadeOut(3000, function () {
     $(this).remove();
 });
+
+function getWindowVHHeight() {
+    let vh = window.innerHeight * 0.01;
+    $('html').css('--vh', vh + 'px');
+}
 
 function toggleRightSidebarNav() {
     const rightSidebar =  $('#rightSidebar');


### PR DESCRIPTION
Previously on mobile, the height of the search modal was set with css
`min-height: 100vh`. This is causing a few problems as this property
does not account for the addition of the address bar and other items
added to the browser when the user scrolls up or down. In return, this
is hiding some of the bottom of the modal.

The alternative that has been added is configuring the height with some
JS, which is much more accurate and accommodates for any added entities
by the browser.

Solution:
https://css-tricks.com/the-trick-to-viewport-units-on-mobile/

Also, as a test/fix `debug` has been set to `true` on the search
configuration. This was done because when a user presses "done" on
mobile (after using the search box), focus is taken away, and the
search results disappear. This will potentially allow the results to
stay and allow the user click (tap) them.