### PR TITLE
(GH-58) Set an Expiration Date on Cookie

### DIFF
--- a/input/_layout.cshtml
+++ b/input/_layout.cshtml
@@ -218,7 +218,8 @@
         </div>
         <div id="cookieNoticeAlert" class="alert alert-primary alert-dismissible alert-dismissible-center alert-btn-center fade show d-none" role="alert">
             <p class="mb-0"><strong>docs.chocolatey.org uses cookies to enhance the user experience of the site.</strong></p>
-            <button type="button" class="btn btn-light btn-sm" data-dismiss="alert" aria-label="Close">I accept</button>
+            <button type="button" class="btn btn-light btn-sm d-none d-md-inline-block" data-dismiss="alert" aria-label="Close">I accept</button>
+            <button type="button" class="btn btn-light d-md-none" data-dismiss="alert" aria-label="Close">I accept</button>
         </div>
         <div class="modal fade" id="searchBox" tabindex="-1" role="dialog" aria-labelledby="searchBox" aria-describedby="Search documentation" aria-hidden="true">
             <div class="modal-dialog" role="document">

--- a/input/assets/js/custom.js
+++ b/input/assets/js/custom.js
@@ -162,9 +162,9 @@ if (cookieNotice) {
 
 cookieNoticeAlert.find('button').click(function() {
     if (~location.hostname.indexOf('chocolatey.org')) {
-        document.cookie = cookieNoticeName + '=true; path=/; domain=chocolatey.org;';
+        document.cookie = cookieNoticeName + '=true; ' + getCookieExpirationNever() + 'path=/; domain=chocolatey.org;';
     } else {
-        document.cookie = cookieNoticeName + '=true; path=/;';
+        document.cookie = cookieNoticeName + '=true;' + getCookieExpirationNever() + 'path=/;';
     }
 });
 
@@ -295,6 +295,13 @@ $(window).on("resize", function () {
 leftSidebarNav.find('.loader-container').fadeOut(3000, function () {
     $(this).remove();
 });
+
+function getCookieExpirationNever() {
+    var d = new Date();
+    // 100 years in milliseconds: 100 years * 365 days * 24 hours * 60 minutes * 60 seconds * 1000ms
+    d.setTime(d.getTime() + (100 * 365 * 24 * 60 * 60 * 1000));
+    return 'expires=' + d.toUTCString() + ';';
+}
 
 function getWindowVHHeight() {
     let vh = window.innerHeight * 0.01;


### PR DESCRIPTION
This adds an expiration date to the cookie notice so that the cookie
persist through multiple user sessions, actually 100 years. This is
inline with how it is set on chocolatey.org.

Without setting an expiration date, the cookie is reset every time the
user starts a new session.

A slight update to the cookie notice button has been made to stay
inline with chocolatey.org and make the button slightly larger on
mobile, making it easier to tap.

Fixes #58 