### PR TITLE
(GH-63) Install Mousetrap JS

### DIFF
--- a/bundleconfig.json
+++ b/bundleconfig.json
@@ -24,6 +24,7 @@
         "node_modules/bootstrap/dist/js/bootstrap.bundle.js",
         "node_modules/anchor-js/anchor.js",
         "node_modules/choco-theme/js/prism.min.js",
+        "node_modules/mousetrap/mousetrap.js",
         "node_modules/choco-theme/js/chocolatey.js"
       ]
     }

--- a/input/_layout.cshtml
+++ b/input/_layout.cshtml
@@ -108,7 +108,7 @@
             </ul>
             <form id="searchBox" class="form-inline d-none d-md-flex" role="search">
                 <i class="fas fa-search" aria-hidden="true"></i>
-                <input type="search" class="form-control" id="searchQuery" placeholder="Search..." aria-label="Search" autofocus />
+                <input type="search" class="form-control" id="searchQuery" placeholder="Search..." aria-label="Search" />
                 <span class="d-none d-md-flex search-key-container">
                     <span class="badge badge-key badge-primary search-key"></span>
                     <span class="badge badge-key badge-primary">k</span>


### PR DESCRIPTION
### ⚠️ This PR must be merged after https://github.com/chocolatey/choco-theme/pull/8

Installs Mousetrap JS to be used to control keyboard shortcuts and
maintain browser compatibility. This should prevent the cross browser
incompatibilities currently being seen, and reduce odd bugs.

Mousetrap is a well documented library and could be used in the future
for additional keyboard shortcuts.

Fixes #63 