### PR TITLE
(theme) Add Responsiveness to Video iframes

### DIFF
--- a/input/en-us/chocolatey-gui/business_features/admin-only-sources.md
+++ b/input/en-us/chocolatey-gui/business_features/admin-only-sources.md
@@ -17,4 +17,6 @@ If this setting has been set to true on a source, Chocolatey GUI will no longer 
 
 Below is a short video which shows this feature in action:
 
-<iframe width="700" height="506" src="https://www.youtube.com/embed/MBXnFdNMG28" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
+<div class="embed-responsive embed-responsive-700by506">
+    <iframe class="embed-responsive-item" width="700" height="506" src="https://www.youtube.com/embed/MBXnFdNMG28" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
+</div>

--- a/input/en-us/chocolatey-gui/commands/feature.md
+++ b/input/en-us/chocolatey-gui/commands/feature.md
@@ -45,7 +45,9 @@ Normal:
 
 Below is a short video which shows this in action:
 
-<iframe width="700" height="506" src="https://www.youtube.com/embed/_AkDNQFoCtc" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
+<div class="embed-responsive embed-responsive-700by506">
+     <iframe  class="embed-responsive-item" width="700" height="506" src="https://www.youtube.com/embed/_AkDNQFoCtc" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
+</div>
 
 ## Feature Options
 

--- a/input/en-us/chocolatey-gui/setup/configuration/features/AllowNonAdminAccessToSettings.md
+++ b/input/en-us/chocolatey-gui/setup/configuration/features/AllowNonAdminAccessToSettings.md
@@ -25,7 +25,9 @@ When this setting is turned off, a non-admin user will no longer be able to acce
 
 Below is a short video which shows this feature in action:
 
-<iframe width="700" height="506" src="https://www.youtube.com/embed/VCTHWo7cgW0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
+<div class="embed-responsive embed-responsive-700by506">
+    <iframe class="embed-responsive-item" width="700" height="506" src="https://www.youtube.com/embed/VCTHWo7cgW0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
+</div>
 
 ## Example
 


### PR DESCRIPTION
### ⚠️ This PR must be merged after https://github.com/chocolatey/choco-theme/pulls/10

This wraps each iframe in an embed div that will help to scale the
video on any viewport. A custom viewport has been added since the
videos in the GUI docs are at a non-standard size.

For future embed implementations, different classes may need to be
used based on the video ratio aspects.

For more information see:
https://getbootstrap.com/docs/4.5/utilities/embed/