### PR TITLE
(#81) Add CCM Deployments API worked example

### DIFF
--- a/input/en-us/central-management/usage/api.md
+++ b/input/en-us/central-management/usage/api.md
@@ -207,3 +207,119 @@ Methods for querying or managing mappings between Computer objects and Software 
 | :----: | :---------------------------------------- |
 |  GET   | /api/services/app/WebLog/GetLatestWebLogs |
 |  POST  | /api/services/app/WebLog/DownloadWebLogs  |
+
+## Examples
+
+### Creating An _All Computers_ Group and Deploy Application Upgrades
+
+From a completely fresh CCM instance with at least one computer checking into Central Management, this process will:
+
+- Create a new group containing all the computers currently registered to Central Management.
+- Create a new deployment with a single step, which will upgrade all Chocolatey-managed applications to the latest available versions.
+- Start the deployment.
+
+The process involves a couple of intermediary steps as well, since we're using the raw REST API endpoints here (see below).
+
+#### 1. Get All CCM-Managed Computers
+
+```powershell
+$params = @{
+    Uri        = "https://$CCmServerHostname/api/services/app/Computers/GetAll"
+    Method     = 'GET'
+    WebSession = $Session
+}
+$ComputerList = Invoke-RestMethod @params
+```
+
+#### 2. Create an _All Computers_ Group
+
+```powershell
+# Create group in CCM
+$GroupName = 'All Clients'
+$Params = @{
+    Uri         = "https://$CcmServerHostname/api/services/app/Groups/CreateOrEdit"
+    Method      = 'POST'
+    WebSession  = $Session
+    ContentType = 'application/json'
+    Body        = @{
+        name        = $GroupName
+        description = 'All CCM client machines'
+        groups      = @()
+        computers   = @(
+            $ComputerList.result | Select-Object -Property @{ Name = 'computerId'; Expression = { "$($_.id)" } }
+        )
+    } | ConvertTo-Json
+}
+$null = Invoke-RestMethod @params
+
+# Retrieve created group information
+$params = @{
+    Uri        = "https://$CcmServerHostname/api/services/app/Groups/GetAll"
+    Method     = "GET"
+    WebSession = $Session
+}
+$Group = Invoke-RestMethod @params |
+    Select-Object -ExpandProperty result |
+    Where-Object Name -EQ $GroupName
+```
+
+#### 3. Create a New Deployment
+
+```powershell
+$params = @{
+    Uri         = "https://$CcmServerHostname/api/services/app/DeploymentPlans/CreateOrEdit"
+    Method      = "POST"
+    WebSession  = $Session
+    ContentType = 'application/json'
+    Body        = @{ name = "Upgrade Chocolatey-Managed Applications [$(Get-Date)]" } | ConvertTo-Json
+}
+$deployment = (Invoke-RestMethod @params).result
+```
+
+#### 4. Add a Deployment Step
+
+```powershell
+$params = @{
+    Uri         = "https://$CcmServerHostname/api/services/app/DeploymentSteps/CreateOrEdit"
+    Method      = "POST"
+    WebSession  = $Session
+    ContentType = 'application/json'
+    Body        = @{
+        deploymentPlanId               = $deployment.Id
+        name                           = "Choco Upgrade All"
+        validExitCodes                 = "0, 1605, 1614, 1641, 3010"
+        executionTimeoutInSeconds      = 14400
+        machineContactTimeoutInMinutes = "0"
+        failOnError                    = $true
+        requireSuccessOnAllComputers   = $false
+        deploymentStepGroups           = @(
+            @{ groupId = $Group.Id; groupName = $Group.Name }
+        )
+        # Syntax for basic deployment steps is "<ChocoCommand>|<PackageName>"
+        script                         = "upgrade|all"
+    } | ConvertTo-Json
+}
+$null = Invoke-RestMethod @params
+```
+
+#### 5. Move Deployment to Ready & Start the Deployment
+
+```powershell
+$params = @{
+    Uri         = "https://$CcmServerHostname/api/services/app/DeploymentPlans/MoveToReady"
+    Method      = "POST"
+    WebSession  = $Session
+    ContentType = 'application/json'
+    Body        = @{ id = $deployment.Id } | ConvertTo-Json
+}
+$null = Invoke-RestMethod @params
+
+$params = @{
+    Uri         = "https://$CcmServerHostname/api/services/app/DeploymentPlans/Start"
+    Method      = "POST"
+    WebSession  = $Session
+    ContentType = 'application/json'
+    Body        = @{ id = $deployment.Id } | ConvertTo-Json
+}
+$null = Invoke-RestMethod @params
+```


### PR DESCRIPTION
Added a worked example with a brief description for the CCM Deployments API endpoints (and some related auxiliary endpoints needed for the example).

Resolves #81