### PR TITLE
(GH-88) Add Styling to Custom 404 Page

### DIFF
--- a/input/404.md
+++ b/input/404.md
@@ -1,11 +1,23 @@
 ---
 Title: Page Not Found
+NoSidebar: true
 ---
 
-<div class="container sub-content py-3 py-md-5 d-flex flex-column justify-content-center text-center">
-    <div class="row">
-        <div class="col-md-8 col-xl-6 mx-auto">
-            <p>We were unable to find this page. This could be as a result of the recent changes to the site, where we have moved some files around. Please verify that the link you are using is what you expect, or please try searching for the page you are looking for in the search box above.  If you are still having problems, please reach out to the Chocolatey Team, and we will do our best to fix this problem.</p>
+<main id="centered-layout" class="position-relative d-sm-flex">
+    <div class="container py-3 py-md-5 d-flex flex-column justify-content-center">
+        <div class="row">
+            <div class="col-md-8 col-xl-6 mx-auto">
+                <div class="card card-body p-md-5">
+                    <div class="text-center">
+                        <img class="mb-3" width="300" src="/assets/images/global-shared/404.svg" title="404 Page Not Found" alt="404 Page Not Found" >
+                        <h3 class="text-uppercase bg-primary-opacity text-primary d-inline-block p-2 mt-0">Oops! Page not found.</h3>
+                    </div>
+                    <p class="text-reset">
+                        We were unable to find this page. This could be as a result of the recent changes to the site, where we have moved some files around. Please verify that the link you are using is what you expect.  If you are still having problems, please reach out to the Chocolatey Team, and we will do our best to fix this problem.
+                    </p>
+                    <div class="text-center"><a role="button" class="btn btn-primary" href="/en-us/">Back to Docs</a></div>
+                </div>
+            </div>
         </div>
     </div>
-</div>
+</main>

--- a/input/_layout.cshtml
+++ b/input/_layout.cshtml
@@ -118,169 +118,176 @@
                 <button type="button" class="navbar-toggler btn d-md-none" data-toggle="collapse" data-target="#leftSidebar" aria-expanded="false" aria-controls="leftSidebar" aria-label="Toggle navigation"><i class="fas fa-bars"></i></button>
             </nav>
         </header>
-        <main>
-            <div class="container-fluid">
-                <div class="row">
-                    <div id="leftSidebarNav" class="col-md-3 col-xl-2 p-0">
-                        <div class="loader-container"><div class="loader"></div></div>
-                        @{
-                            IDocument root = OutputPages["en-us/index.html"].First();
-                        }
-                        <nav class="navbar navbar-expand-md p-0">
-                            <div id="leftSidebar" class="collapse navbar-collapse">
-                                @Html.Partial("_globalnavigation")
-                                <ul class="navbar-nav">
-                                    <li class="nav-item">
-                                        @if(root.ShowLink())
+        @if (Document.GetBool(Constants.NoSidebar))
+        {
+            @RenderBody()
+        }
+        else
+        {
+            <main>
+                <div class="container-fluid">
+                    <div class="row">
+                        <div id="leftSidebarNav" class="col-md-3 col-xl-2 p-0">
+                            <div class="loader-container"><div class="loader"></div></div>
+                            @{
+                                IDocument root = OutputPages["en-us/index.html"].First();
+                            }
+                            <nav class="navbar navbar-expand-md p-0">
+                                <div id="leftSidebar" class="collapse navbar-collapse">
+                                    @Html.Partial("_globalnavigation")
+                                    <ul class="navbar-nav">
+                                        <li class="nav-item">
+                                            @if(root.ShowLink())
+                                            {
+                                                <a class="nav-link pl-c2 @(Document.IdEquals(root) ? "active active-page" : null)" href="@root.GetLink()">@root.GetTitle()</a>
+                                            }
+                                            else
+                                            {
+                                                @root.GetTitle()
+                                            }
+                                        </li>
+                                        @foreach (IDocument document in OutputPages.GetChildrenOf(root).OnlyVisible())
                                         {
-                                            <a class="nav-link pl-c2 @(Document.IdEquals(root) ? "active active-page" : null)" href="@root.GetLink()">@root.GetTitle()</a>
-                                        }
-                                        else
-                                        {
-                                            @root.GetTitle()
-                                        }
-                                    </li>
-                                    @foreach (IDocument document in OutputPages.GetChildrenOf(root).OnlyVisible())
-                                    {
-                                        DocumentList<IDocument> documentChildren = OutputPages.GetChildrenOf(document);
+                                            DocumentList<IDocument> documentChildren = OutputPages.GetChildrenOf(document);
 
-                                        @if(documentChildren.Any()) {
-                                            <li class="nav-item">
-                                                <div class="nav-link nav-link-collapse d-flex align-items-start @(Document.IdEquals(document) ||  OutputPages.GetDescendantsOf(document).Any(x => Document.IdEquals(x)) ? "active" : null) @(Document.IdEquals(document) ? "active-page" : null)">
-                                                    <button class="btn btn-collapse collapsed" type="button" data-toggle="collapse" aria-expanded="false" aria-controls="id-@document.Id" aria-label="collapse or expand navigation" href="#id-@document.Id"></button>
-                                                    <a href="@document.GetLink()">@document.GetTitle()</a>
-                                                </div>
-                                                <div class="collapse" id="id-@document.Id">
-                                                    <ul class="navbar-nav">
-                                                        @foreach (IDocument child in documentChildren.OnlyVisible())
+                                            @if(documentChildren.Any()) {
+                                                <li class="nav-item">
+                                                    <div class="nav-link nav-link-collapse d-flex align-items-start @(Document.IdEquals(document) ||  OutputPages.GetDescendantsOf(document).Any(x => Document.IdEquals(x)) ? "active" : null) @(Document.IdEquals(document) ? "active-page" : null)">
+                                                        <button class="btn btn-collapse collapsed" type="button" data-toggle="collapse" aria-expanded="false" aria-controls="id-@document.Id" aria-label="collapse or expand navigation" href="#id-@document.Id"></button>
+                                                        <a href="@document.GetLink()">@document.GetTitle()</a>
+                                                    </div>
+                                                    <div class="collapse" id="id-@document.Id">
+                                                        <ul class="navbar-nav">
+                                                            @foreach (IDocument child in documentChildren.OnlyVisible())
+                                                            {
+                                                                @if(OutputPages.GetChildrenOf(child).Any())
+                                                                {
+                                                                    <li class="nav-item">
+                                                                        <div class="nav-link nav-link-collapse d-flex align-items-start @(Document.IdEquals(child) ||  OutputPages.GetDescendantsOf(child).Any(x => Document.IdEquals(x)) ? "active" : null) @(Document.IdEquals(child) ? "active-page" : null)">
+                                                                            <button class="btn btn-collapse collapsed pl-c175" type="button" data-toggle="collapse" aria-expanded="false" aria-controls="id-@child.Id" aria-label="collapse or expand navigation" href="#id-@child.Id"></button>
+                                                                            <a href="@child.GetLink()">@child.GetTitle()</a>
+                                                                        </div>
+                                                                        <div class="collapse" id="id-@child.Id">
+                                                                            <ul class="navbar-nav">
+                                                                                @foreach (IDocument grandChild in OutputPages.GetChildrenOf(child).OnlyVisible())
+                                                                                {
+                                                                                    @if(OutputPages.GetChildrenOf(grandChild).Any())
+                                                                                    {
+                                                                                        <li class="nav-item">
+                                                                                            <div class="nav-link nav-link-collapse d-flex align-items-start @(Document.IdEquals(grandChild) ||  OutputPages.GetDescendantsOf(grandChild).Any(x => Document.IdEquals(x)) ? "active" : null) @(Document.IdEquals(grandChild) ? "active-page" : null)">
+                                                                                                <button class="btn btn-collapse collapsed pl-c275" type="button" data-toggle="collapse" aria-expanded="false" aria-controls="id-@grandChild.Id" aria-label="collapse or expand navigation" href="#id-@grandChild.Id"></button>
+                                                                                                <a href="@grandChild.GetLink()">@grandChild.GetTitle()</a>
+                                                                                            </div>
+                                                                                            <div class="collapse" id="id-@grandChild.Id">
+                                                                                                <ul class="navbar-nav">
+                                                                                                    @foreach (IDocument greatGrandChild in OutputPages.GetChildrenOf(grandChild).OnlyVisible())
+                                                                                                    {
+                                                                                                        @if(OutputPages.GetChildrenOf(greatGrandChild).Any())
+                                                                                                        {
+                                                                                                            <li class="nav-item">
+                                                                                                                <div class="nav-link nav-link-collapse d-flex align-items-start @(Document.IdEquals(greatGrandChild) ||  OutputPages.GetDescendantsOf(greatGrandChild).Any(x => Document.IdEquals(x)) ? "active" : null) @(Document.IdEquals(greatGrandChild) ? "active-page" : null)">
+                                                                                                                    <button class="btn btn-collapse pl-c375 collapsed" type="button" data-toggle="collapse" aria-expanded="false" aria-controls="id-@greatGrandChild.Id" aria-label="collapse or expand navigation" href="#id-@greatGrandChild.Id"></button>
+                                                                                                                    <a href="@greatGrandChild.GetLink()">@greatGrandChild.GetTitle()</a>
+                                                                                                                </div>
+                                                                                                                <div class="collapse" id="id-@greatGrandChild.Id">
+                                                                                                                    <ul class="navbar-nav">
+                                                                                                                        @foreach (IDocument greatGreatGrandChild in OutputPages.GetChildrenOf(greatGrandChild).OnlyVisible())
+                                                                                                                        {
+                                                                                                                            <li class="nav-item">
+                                                                                                                                <a class="nav-link pl-c6 @(Document.IdEquals(greatGreatGrandChild) ? "active active-page" : null)" href="@greatGreatGrandChild.GetLink()">@greatGreatGrandChild.GetTitle()</a>
+                                                                                                                            </li>
+                                                                                                                        }
+                                                                                                                    </ul>
+                                                                                                                </div>
+                                                                                                            </li>
+                                                                                                        }
+                                                                                                        else
+                                                                                                        {
+                                                                                                            <li class="nav-item">
+                                                                                                                <a class="nav-link pl-c5 @(Document.IdEquals(greatGrandChild) ? "active active-page" : null)" href="@greatGrandChild.GetLink()">@greatGrandChild.GetTitle()</a>
+                                                                                                            </li>
+                                                                                                        }
+                                                                                                    }
+                                                                                                </ul>
+                                                                                            </div>
+                                                                                        </li>
+                                                                                    }
+                                                                                    else
+                                                                                    {
+                                                                                        <li class="nav-item">
+                                                                                            <a class="nav-link pl-c4 @(Document.IdEquals(grandChild) ? "active active-page" : null)" href="@grandChild.GetLink()">@grandChild.GetTitle()</a>
+                                                                                        </li>
+                                                                                    }
+                                                                                }
+                                                                            </ul>
+                                                                        </div>
+                                                                    </li>
+                                                                }
+                                                                else
+                                                                {
+                                                                    <li class="nav-item">
+                                                                        <a class="nav-link pl-5 @(Document.IdEquals(child) ? "active active-page" : null)" href="@child.GetLink()">@child.GetTitle()</a>
+                                                                    </li>
+                                                                }
+                                                            }
+                                                        </ul>
+                                                    </div>
+                                                </li>
+                                            }
+                                            else
+                                            {
+                                                <li class="nav-item">
+                                                    <a class="nav-link pl-c2 @(Document.IdEquals(document) ? "active active-page" : null)" href="@document.GetLink()">@document.GetTitle()</a>
+                                                </li>
+                                            }
+                                        }
+                                    </ul>
+                                </div>
+                            </nav>
+                        </div>
+                        <div class="col-md-9 col-xl-10 py-3 py-md-5 mx-auto">
+                            <div class="ml-md-4 d-xl-none">
+                                @Html.Partial("_breadcrumbs")
+                            </div>
+                            <div class="row">
+                                <div id="mainContent" class="col-xl-10 pl-md-5 order-2 order-xl-1">
+                                    <div class="d-none d-xl-block">
+                                        @Html.Partial("_breadcrumbs")
+                                    </div>
+                                    @RenderBody()
+                                    @Html.Partial("_childpages")
+                                </div>
+                                @{
+                                    IReadOnlyList<IDocument> headings = Document.GetDocumentList(Statiq.Html.HtmlKeys.Headings);
+                                    if (headings.Count > 1)
+                                    {
+                                        <div id="rightSidebarNav" class="col-xl-2 pl-md-5 pl-xl-3 order-1 order-xl-2">
+                                            <button class="btn btn-link btn-collapse font-weight-bold w-100 d-xl-none mb-2" type="button" data-toggle="collapse" data-target="#rightSidebar" aria-expanded="false" aria-controls="rightSidebar">Jump to Section</button>
+                                            <div id="rightSidebar" class="sticky-top collapse">
+                                                <div class="card card-body py-0 px-xl-0 mb-3 border-0">
+                                                    @if (Document.ContainsKey("EditLink"))
+                                                    {
+                                                        <p class="font-weight-bold pt-3"><a href="@Document.GetString("EditLink")"><i class="fas fa-pencil-alt" aria-hidden="true"></i> Edit This Page</a></p>
+                                                        <hr class="m-0" />
+                                                    }
+                                                    <p class="font-weight-bold pt-3">On This Page</p>
+                                                    <ul class="list-unstyled pb-xl-3">
+                                                        @foreach (IDocument heading in headings)
                                                         {
-                                                            @if(OutputPages.GetChildrenOf(child).Any())
-                                                            {
-                                                                <li class="nav-item">
-                                                                    <div class="nav-link nav-link-collapse d-flex align-items-start @(Document.IdEquals(child) ||  OutputPages.GetDescendantsOf(child).Any(x => Document.IdEquals(x)) ? "active" : null) @(Document.IdEquals(child) ? "active-page" : null)">
-                                                                        <button class="btn btn-collapse collapsed pl-c175" type="button" data-toggle="collapse" aria-expanded="false" aria-controls="id-@child.Id" aria-label="collapse or expand navigation" href="#id-@child.Id"></button>
-                                                                        <a href="@child.GetLink()">@child.GetTitle()</a>
-                                                                    </div>
-                                                                    <div class="collapse" id="id-@child.Id">
-                                                                        <ul class="navbar-nav">
-                                                                            @foreach (IDocument grandChild in OutputPages.GetChildrenOf(child).OnlyVisible())
-                                                                            {
-                                                                                @if(OutputPages.GetChildrenOf(grandChild).Any())
-                                                                                {
-                                                                                    <li class="nav-item">
-                                                                                        <div class="nav-link nav-link-collapse d-flex align-items-start @(Document.IdEquals(grandChild) ||  OutputPages.GetDescendantsOf(grandChild).Any(x => Document.IdEquals(x)) ? "active" : null) @(Document.IdEquals(grandChild) ? "active-page" : null)">
-                                                                                            <button class="btn btn-collapse collapsed pl-c275" type="button" data-toggle="collapse" aria-expanded="false" aria-controls="id-@grandChild.Id" aria-label="collapse or expand navigation" href="#id-@grandChild.Id"></button>
-                                                                                            <a href="@grandChild.GetLink()">@grandChild.GetTitle()</a>
-                                                                                        </div>
-                                                                                        <div class="collapse" id="id-@grandChild.Id">
-                                                                                            <ul class="navbar-nav">
-                                                                                                @foreach (IDocument greatGrandChild in OutputPages.GetChildrenOf(grandChild).OnlyVisible())
-                                                                                                {
-                                                                                                    @if(OutputPages.GetChildrenOf(greatGrandChild).Any())
-                                                                                                    {
-                                                                                                        <li class="nav-item">
-                                                                                                            <div class="nav-link nav-link-collapse d-flex align-items-start @(Document.IdEquals(greatGrandChild) ||  OutputPages.GetDescendantsOf(greatGrandChild).Any(x => Document.IdEquals(x)) ? "active" : null) @(Document.IdEquals(greatGrandChild) ? "active-page" : null)">
-                                                                                                                <button class="btn btn-collapse pl-c375 collapsed" type="button" data-toggle="collapse" aria-expanded="false" aria-controls="id-@greatGrandChild.Id" aria-label="collapse or expand navigation" href="#id-@greatGrandChild.Id"></button>
-                                                                                                                <a href="@greatGrandChild.GetLink()">@greatGrandChild.GetTitle()</a>
-                                                                                                            </div>
-                                                                                                            <div class="collapse" id="id-@greatGrandChild.Id">
-                                                                                                                <ul class="navbar-nav">
-                                                                                                                    @foreach (IDocument greatGreatGrandChild in OutputPages.GetChildrenOf(greatGrandChild).OnlyVisible())
-                                                                                                                    {
-                                                                                                                        <li class="nav-item">
-                                                                                                                            <a class="nav-link pl-c6 @(Document.IdEquals(greatGreatGrandChild) ? "active active-page" : null)" href="@greatGreatGrandChild.GetLink()">@greatGreatGrandChild.GetTitle()</a>
-                                                                                                                        </li>
-                                                                                                                    }
-                                                                                                                </ul>
-                                                                                                            </div>
-                                                                                                        </li>
-                                                                                                    }
-                                                                                                    else
-                                                                                                    {
-                                                                                                        <li class="nav-item">
-                                                                                                            <a class="nav-link pl-c5 @(Document.IdEquals(greatGrandChild) ? "active active-page" : null)" href="@greatGrandChild.GetLink()">@greatGrandChild.GetTitle()</a>
-                                                                                                        </li>
-                                                                                                    }
-                                                                                                }
-                                                                                            </ul>
-                                                                                        </div>
-                                                                                    </li>
-                                                                                }
-                                                                                else
-                                                                                {
-                                                                                    <li class="nav-item">
-                                                                                        <a class="nav-link pl-c4 @(Document.IdEquals(grandChild) ? "active active-page" : null)" href="@grandChild.GetLink()">@grandChild.GetTitle()</a>
-                                                                                    </li>
-                                                                                }
-                                                                            }
-                                                                        </ul>
-                                                                    </div>
-                                                                </li>
-                                                            }
-                                                            else
-                                                            {
-                                                                <li class="nav-item">
-                                                                    <a class="nav-link pl-5 @(Document.IdEquals(child) ? "active active-page" : null)" href="@child.GetLink()">@child.GetTitle()</a>
-                                                                </li>
-                                                            }
+                                                            <li class="level-@heading.GetString(Statiq.Html.HtmlKeys.Level)"><a href="#@(heading.GetString(Statiq.Html.HtmlKeys.HeadingId))">@(await heading.GetContentStringAsync())</a></li>
                                                         }
                                                     </ul>
                                                 </div>
-                                            </li>
-                                        }
-                                        else
-                                        {
-                                            <li class="nav-item">
-                                                <a class="nav-link pl-c2 @(Document.IdEquals(document) ? "active active-page" : null)" href="@document.GetLink()">@document.GetTitle()</a>
-                                            </li>
-                                        }
-                                    }
-                                </ul>
-                            </div>
-                        </nav>
-                    </div>
-                    <div class="col-md-9 col-xl-10 py-3 py-md-5 mx-auto">
-                        <div class="ml-md-4 d-xl-none">
-                            @Html.Partial("_breadcrumbs")
-                        </div>
-                        <div class="row">
-                            <div id="mainContent" class="col-xl-10 pl-md-5 order-2 order-xl-1">
-                                <div class="d-none d-xl-block">
-                                    @Html.Partial("_breadcrumbs")
-                                </div>
-                                @RenderBody()
-                                @Html.Partial("_childpages")
-                            </div>
-                            @{
-                                IReadOnlyList<IDocument> headings = Document.GetDocumentList(Statiq.Html.HtmlKeys.Headings);
-                                if (headings.Count > 1)
-                                {
-                                    <div id="rightSidebarNav" class="col-xl-2 pl-md-5 pl-xl-3 order-1 order-xl-2">
-                                        <button class="btn btn-link btn-collapse font-weight-bold w-100 d-xl-none mb-2" type="button" data-toggle="collapse" data-target="#rightSidebar" aria-expanded="false" aria-controls="rightSidebar">Jump to Section</button>
-                                        <div id="rightSidebar" class="sticky-top collapse">
-                                            <div class="card card-body py-0 px-xl-0 mb-3 border-0">
-                                                @if (Document.ContainsKey("EditLink"))
-                                                {
-                                                    <p class="font-weight-bold pt-3"><a href="@Document.GetString("EditLink")"><i class="fas fa-pencil-alt" aria-hidden="true"></i> Edit This Page</a></p>
-                                                    <hr class="m-0" />
-                                                }
-                                                <p class="font-weight-bold pt-3">On This Page</p>
-                                                <ul class="list-unstyled pb-xl-3">
-                                                    @foreach (IDocument heading in headings)
-                                                    {
-                                                        <li class="level-@heading.GetString(Statiq.Html.HtmlKeys.Level)"><a href="#@(heading.GetString(Statiq.Html.HtmlKeys.HeadingId))">@(await heading.GetContentStringAsync())</a></li>
-                                                    }
-                                                </ul>
                                             </div>
                                         </div>
-                                    </div>
+                                    }
                                 }
-                            }
+                            </div>
                         </div>
                     </div>
                 </div>
-            </div>
-        </main>
+            </main>
+        }
         <footer class="p-3 small text-center">
             <span>© @DateTime.Today.Year Chocolatey Software, Inc.</span><br />
             <span>Deployed from <a href="https://github.com/chocolatey/docs/commit/@VersionUtilities.GetSha()">@VersionUtilities.GetCommit()</a></span><br />


### PR DESCRIPTION
### Changes from choco-theme will need to utilized for this https://github.com/chocolatey/choco-theme/pull/22

There have been changes made to the main layout to support pages that
do not contain a sidebar. If the page does not contain a sidebar, and
should be a full page width, then the front matter `NoSidebar: true`
should be added to said page.

This adds custom styles to the 404 page to make it fit better with the
theme, and keep consistent with the blog.

![404-not-found](https://user-images.githubusercontent.com/42750725/102024382-51dfc280-3d57-11eb-84af-442a0a15a164.png)
