### PR TITLE
added hint where to find the NugetApiKey for users reading the online doc

### DIFF
--- a/input/en-us/quick-deployment/setup/desktop-readme.md
+++ b/input/en-us/quick-deployment/setup/desktop-readme.md
@@ -111,7 +111,7 @@ You can also call `Get-Help C:\choco-setup\files\Set-QDEnvironment.ps1 -Full` fo
 
 | Parameter Name           | Description                                                                                                                                                                          |
 | :----------------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `-NexusApiKey`           | The api key for your nexus installation.                                                                                                                                             |
+| `-NexusApiKey`           | The api key for your nexus installation. This can be found in the Readme file on the desktop of your QDE.                                                                            |
 | `-CertificateThumbprint` | If using a thumbprint, specify it with this parameter.                                                                                                                               |
 | `-CertificateSubject`    | If using a subject name for your certificate, specify it with this parameter (**NOTE** this does not include the 'CN=' portion of the subject returned by the certificate provider). |
 | `-CertificateDnsName`    | If using a wildcard certificate this _must_ be included with either `-CertificateThumbprint` or `-CertificateSubject`.                                                               |
@@ -262,7 +262,7 @@ This will be encrypted. To setup, do the following:
 > In that case, substitute the hostname for the new FQDN.
 
 ```powershell
-choco apikey add --key="'{{NexusApiKey}}'" --source="'https://chocoserver:8443/repository/ChocolateyInternal/'"
+choco apikey add --key="'{{NugetApiKey}}'" --source="'https://chocoserver:8443/repository/ChocolateyInternal/'"
 ```
 
 ### Update pre-configured Jenkins jobs with the new API Key


### PR DESCRIPTION
1. Standardize on jinja2-style for REPLACE_ME-type values
2. The NugetApiKey variable was called NexusApiKey in one place (fixed, consistency)
3. Added the information where to find the Nuget/Nexus API key as I didn't know when following the online readme

Number 1 and 3 are things that irritated me personally when setting up QDE so I fixed them.
Number 2 is just something I noticed when preparing the PR just now.

I think the docs should standardize on one convention of values that the user must replace inside of commands or files etc. - since the Jinja2-style is used more often currently and because it is more compact I chose that one. When I first ran the `Set-QDEnvironment.ps1` script in my QDE i replaced the Thumbprint and DNS-Name with my own valued but not the ApiKey as I thought maybe the script itself expects that jinja2-style placeholder. Making the values the user should replace use one stlye-convention removes this possible mistake.