### PR TITLE
(GH-103) Change links pointing to the previous choco, verifier, and validator wikis to point to the docs.

### DIFF
--- a/input/en-us/community-repository/moderation/index.md
+++ b/input/en-us/community-repository/moderation/index.md
@@ -59,7 +59,7 @@ Requirements represent the minimum quality of a package that is acceptable. When
 * Does the package install correctly?
 * Does the package uninstall correctly? (this means the package, not the underlying software. We'd like to have that as well but it's more a guideline at the moment than a requirement. Patience, we will get there).
 * Brand New Packages **ONLY** (no approved or existing version in history, prereleases do not count)
-  * Package Id naming - if the naming doesn't follow our conventions, it is grounds for rejecting immediately with the suggestion they resubmit with suggested name. Note that they may have had prereleases already, and it's still okay to move forward with the rejected status as long as the name of the name of package hasn't been previously approved. See https://github.com/chocolatey/choco/wiki/CreatePackages#naming-your-package
+  * Package Id naming - if the naming doesn't follow our conventions, it is grounds for rejecting immediately with the suggestion they resubmit with suggested name. Note that they may have had prereleases already, and it's still okay to move forward with the rejected status as long as the name of the name of package hasn't been previously approved. See [Naming your package](xref:create-packages#naming-your-package)
     * suggest the id split if over 25 chars with no "-" in the id
     * flag on "." in name (unless .portable/.install)
 
@@ -194,7 +194,7 @@ You can only ever require a maintainer to make changes if there are findings fro
 
 The validator checks quite a few items ([validator rules](xref:package-validator)) and leaves a few for you to check. Ensure you have looked over the notes that it has left.
 
-With the exception of included binaries, a review that doesn't flag should take under a minute. If you are holding a package, you can refer the maintainer to this link to save time: https://github.com/chocolatey/choco/wiki/Moderation
+With the exception of included binaries, a review that doesn't flag should take under a minute. If you are holding a package, you can refer the maintainer to this link to save time: https://docs.chocolatey.org/en-us/community-repository/moderation
 
 ##### Requirements
 
@@ -217,7 +217,7 @@ Always be explicit that you are waiting on the maintainer to fix and resubmit th
 * Not a package duplicating another existing package
     > :memo: **NOTE** December 2015: Do not look for duplicate packages at this time. The validator will start handling that after the backlog is manageable.
 * Brand New Packages **ONLY** (no approved or existing version in history, prereleases do not count)
-  * Package Id naming - if the naming doesn't follow our conventions, it is grounds for rejecting immediately with the suggestion they resubmit with suggested name. Note that they may have had prereleases already, and it's still okay to move forward with the rejected status as long as the name of the name of package hasn't been previously approved. See https://github.com/chocolatey/choco/wiki/CreatePackages#naming-your-package
+  * Package Id naming - if the naming doesn't follow our conventions, it is grounds for rejecting immediately with the suggestion they resubmit with suggested name. Note that they may have had prereleases already, and it's still okay to move forward with the rejected status as long as the name of the name of package hasn't been previously approved. See [Naming your package](xref:create-packages#naming-your-package)
     * suggest the id split if over 25 chars with no "-" in the id
     * flag on "." in name (unless .portable/.install)
 
@@ -262,7 +262,7 @@ This is not an achievable status.
 
 ### New Reviewers / Moderators
 
-* Understand the package creation process and the current recommendations, written at https://github.com/chocolatey/choco/wiki/CreatePackages
-* Become familiar with the package guidelines and all of the different Chocolatey functions available. https://github.com/chocolatey/choco/wiki/HelpersReference
+* Understand the package creation process and the current recommendations, written at [create packages](xref:create-packages).
+* Become familiar with the package guidelines and all of the different Chocolatey functions available. [Helper reference](xref:powershell-reference)
 * Join the [chocolatey-moderators at google groups dot com](https://groups.google.com/forum/#!forum/chocolatey-moderators) mailing list. This is necessary for communication with other moderators and receiving messages regarding changes in moderation.
 * Join Gitter and hang out in the [Chocolatey.org Gitter](https://gitter.im/chocolatey/chocolatey.org) and [Choco Gitter](https://gitter.im/chocolatey/choco) rooms from time to time.

--- a/input/en-us/community-repository/moderation/index.md
+++ b/input/en-us/community-repository/moderation/index.md
@@ -20,7 +20,7 @@ By safety - we check that the package scripts do not do anything devious and tha
 
 ## Requirements and Guidelines
 
-While probably the most comprehensive, this list may not be fully up-to-date. This should serve as a most general understanding, knowing that the [validator](https://github.com/chocolatey/package-validator/wiki) may be checking for newer things than are written here and that reviewers/moderators may find newer things to check from time to time.
+While probably the most comprehensive, this list may not be fully up-to-date. This should serve as a most general understanding, knowing that the [validator](xref:package-validator) may be checking for newer things than are written here and that reviewers/moderators may find newer things to check from time to time.
 
 > :memo: **NOTE** Moderators tend to get somewhat picky about properly stating the license, authors (software vendors), and copyright attributions. They are very important to protect both maintainers and the software vendors.
 
@@ -192,7 +192,7 @@ Typically a package goes into the moderation queue when submitted.You can get to
 
 You can only ever require a maintainer to make changes if there are findings from the requirements section. Guidelines are strong suggestions that will improve the quality of the package, but consider that a quality over time. A maintainer is NOT required to make changes based on guidelines/suggestions. This deserves to be said twice: **"A moderator cannot hold up a package based on guidelines/suggestions *alone*"**.
 
-The validator checks quite a few items (https://github.com/chocolatey/package-validator/wiki) and leaves a few for you to check. Ensure you have looked over the notes that it has left.
+The validator checks quite a few items ([validator rules](xref:package-validator)) and leaves a few for you to check. Ensure you have looked over the notes that it has left.
 
 With the exception of included binaries, a review that doesn't flag should take under a minute. If you are holding a package, you can refer the maintainer to this link to save time: https://github.com/chocolatey/choco/wiki/Moderation
 

--- a/input/en-us/community-repository/moderation/package-validator/index.md
+++ b/input/en-us/community-repository/moderation/package-validator/index.md
@@ -5,7 +5,7 @@ Title: Package Validator Moderation Service
 Description: Information on the Package Validator Moderation Service
 ---
 
-Here you will find a collection of more information and resources for when things fail validation. A comprehensive set of how items are reviewed is found at https://github.com/chocolatey/choco/wiki/Moderation#requirements
+Here you will find a collection of more information and resources for when things fail validation. A comprehensive set of how items are reviewed is found at [the moderation docs](xref:moderation#requirements).
 
 NOTE: If you find you are getting flagged for many of these items, you should consider using choco new to generate and adapt updated templates that have all of the latest recommendations.
 

--- a/input/en-us/community-repository/moderation/package-validator/rules/cpmr0016.md
+++ b/input/en-us/community-repository/moderation/package-validator/rules/cpmr0016.md
@@ -14,7 +14,7 @@ In an automation script (`.ps1`/`.psm1`), the use of `chocolateyInstallArguments
 
 ## Recommended Solution
 
-The package should instead use package parameters - see [[How to Parse Package Parameters|https://github.com/chocolatey/choco/wiki/How-To-Parse-PackageParameters-Argument]] and an example package to review for how to add information to the description would be the [[Git package|https://chocolatey.org/packages/git]].
+The package should instead use package parameters - see [How to Parse Package Parameters](xref:parse-package-parameters) and an example package to review for how to add information to the description would be the [Git package](https://chocolatey.org/packages/git).
 
 ## Reasoning
 
@@ -35,4 +35,4 @@ This behavior is unnecessary as Chocolatey already does this in the background. 
 $installArguments = " /Q /IAcceptSQLServerLicenseTerms /ACTION=install /INSTANCEID=SQLEXPRESS /INSTANCENAME=SQLEXPRESS /UPDATEENABLED=FALSE "
 ~~~
 
-The consumer will decide to override install arguments or append to the current set with `--install-arguments`/`--ia` and `--override-arguments`/`-o`, see https://github.com/chocolatey/choco/wiki/CommandsInstall#options-and-switches
+The consumer will decide to override install arguments or append to the current set with `--install-arguments`/`--ia` and `--override-arguments`/`-o`, see the [install command docs](xref:choco-command-install#options-and-switches)

--- a/input/en-us/community-repository/moderation/package-validator/rules/cpmr0033.md
+++ b/input/en-us/community-repository/moderation/package-validator/rules/cpmr0033.md
@@ -14,8 +14,8 @@ The nuspec is missing (or has commented out) the `iconUrl`, which points to an i
 
 ## Recommended Solution
 
-Add `<iconUrl>url_here</iconUrl>` to the nuspec following the [icon guidelines](https://github.com/chocolatey/choco/wiki/CreatePackages#package-icon-guidelines). If your nuspec file is missing this field, you should run `choco new testpkg` and look at the output from that (ensure you have the [latest version of Chocolatey](https://chocolatey.org/packages?q=id%3Achocolatey)).
+Add `<iconUrl>url_here</iconUrl>` to the nuspec following the [icon guidelines](xref:create-packages#package-icon-guidelines). If your nuspec file is missing this field, you should run `choco new testpkg` and look at the output from that (ensure you have the [latest version of Chocolatey](https://chocolatey.org/packages?q=id%3Achocolatey)).
 
 ## Reasoning
 
-We really want to see the IconUrl being used. It adds to the quality of the package when it has an icon to show. It is best to provide the icon from a source you control such as your GitHub repository, however GitHub raw is not intended to serve as a CDN. So please use a static CDN service. For further information on how to setup your icon with a CDN URL, please see [icon guidelines](https://github.com/chocolatey/choco/wiki/CreatePackages#package-icon-guidelines). It's not as intuitive as you might hope.
+We really want to see the IconUrl being used. It adds to the quality of the package when it has an icon to show. It is best to provide the icon from a source you control such as your GitHub repository, however GitHub raw is not intended to serve as a CDN. So please use a static CDN service. For further information on how to setup your icon with a CDN URL, please see [icon guidelines](xref:create-packages#package-icon-guidelines). It's not as intuitive as you might hope.

--- a/input/en-us/community-repository/moderation/package-validator/rules/cpmr0061.md
+++ b/input/en-us/community-repository/moderation/package-validator/rules/cpmr0061.md
@@ -14,9 +14,9 @@ The package id includes dots and has not been found to be an `*.install`/`*.port
 
 ## Recommended Solution
 
-If this is a new package that has never been approved, moderators will review and reject the package for one that will be pushed with a new id that meets the [package naming guidelines](https://github.com/chocolatey/choco/wiki/CreatePackages#naming-your-package).
+If this is a new package that has never been approved, moderators will review and reject the package for one that will be pushed with a new id that meets the [package naming guidelines](xref:create-packages#naming-your-package).
 
-If this is an already existing package, there is really nothing you can do at this time aside from deprecate the current package in favor of a newly created one. Please see [deprecating a package](https://github.com/chocolatey/choco/wiki/How-To-Deprecate-A-Chocolatey-Package)
+If this is an already existing package, there is really nothing you can do at this time aside from deprecate the current package in favor of a newly created one. Please see [deprecating a package](xref:deprecate-a-package)
 
 ## Reasoning
 

--- a/input/en-us/community-repository/moderation/package-validator/rules/cpmr0069.md
+++ b/input/en-us/community-repository/moderation/package-validator/rules/cpmr0069.md
@@ -14,9 +14,9 @@ The package id is longer than 20 characters but does not include dashes (`-`) to
 
 ## Recommended Solution
 
-If this is a new package that has never been approved, moderators will review and reject the package for one that will be pushed with a new id that meets the [package naming guidelines](https://github.com/chocolatey/choco/wiki/CreatePackages#naming-your-package).
+If this is a new package that has never been approved, moderators will review and reject the package for one that will be pushed with a new id that meets the [package naming guidelines](xref:create-packages#naming-your-package).
 
-If this is an already existing package, there is really nothing you can do at this time aside from deprecate the current package in favor of a newly created one. Please see [deprecating a package](https://github.com/chocolatey/choco/wiki/How-To-Deprecate-A-Chocolatey-Package)
+If this is an already existing package, there is really nothing you can do at this time aside from deprecate the current package in favor of a newly created one. Please see [deprecating a package](xref:deprecate-a-package)
 
 ## Reasoning
 

--- a/input/en-us/faqs.md
+++ b/input/en-us/faqs.md
@@ -410,7 +410,7 @@ If you are a maintainer of a package and you would like to self-reject an older 
 
 The [validator](https://github.com/chocolatey/package-validator) is a service that checks the quality of a package based on requirements, guidelines and suggestions for creating packages for Chocolatey’s community feed. Many of the validation items will automatically roll back into choco and will be displayed when packaging a package. We like to think of the validator as unit testing. It is validating that everything is as it should be and meets the minimum requirements for a package on the community feed.
 
-What does the validator check? https://github.com/chocolatey/package-validator/wiki
+What does the validator check? See the [validator docs](xref:package-validator).
 
 ### What is the verifier?
 

--- a/input/en-us/guides/organizations/automate-package-internalization.md
+++ b/input/en-us/guides/organizations/automate-package-internalization.md
@@ -15,7 +15,7 @@ When running within an organization it is beneficial to use your own, internally
 When distributing software across your organization you need confidence and control of your package source. We do not recommend an organization use the [Chocolatey Community Repository](https://chocolatey.org "Chocolatey Community Repository") for the following reasons:
 
 * Trust.
-    When using packages within your organization you need to be sure that you can trust the creators and maintainers of those packages. While every package going through the Chocolatey Community Repository undergoes a [moderation process](https://github.com/chocolatey/choco/wiki/Moderation), the creators and maintainers are strangers to your organization.
+    When using packages within your organization you need to be sure that you can trust the creators and maintainers of those packages. While every package going through the Chocolatey Community Repository undergoes a [moderation process](xref:moderation), the creators and maintainers are strangers to your organization.
 * Stability.
     You need a stable and reliable connection to wherever your packages are stored and it needs to be always available during your business hours.
 * Control.

--- a/input/en-us/information/security.md
+++ b/input/en-us/information/security.md
@@ -169,8 +169,8 @@ Chocolatey.org has a community repository of packages known as the community fee
 
 In October 2014, the community repository had moderation turned on. All community packages (every version of a package) go through a [rigorous moderation process](xref:moderation) prior to any public consumption:
 
-- All package versions are run through an [automated validation process](https://github.com/chocolatey/package-validator/wiki) to determine quality.
 - All package versions are run through an [automated verification process](https://github.com/chocolatey/package-verifier/wiki) to determine if they work correctly (install, etc).
+- All package versions are run through an [automated validation process](xref:package-validator) to determine quality.
 - All packages versions are run through VirusTotal to determine if there are any flagging items. This includes downloading and unpacking any external resources (See the results on a package page in the Virus section - [https://chocolatey.org/packages/chocolatey#virus](https://chocolatey.org/packages/chocolatey#virus) as an example).
     > :memo: **NOTE** Only en-US installers are tested by default via Chocolatey's Package Scanner.
 - A human [reviews every package version](xref:moderation#reviewer-moderator-process) that is not a [trusted package](xref:faqs#what-is-a-trusted-package). This process verifies that packages are pulling from official distro sources or checksumming items versus the official distros and checking over scripts for malicious behavior.

--- a/input/en-us/information/security.md
+++ b/input/en-us/information/security.md
@@ -169,8 +169,8 @@ Chocolatey.org has a community repository of packages known as the community fee
 
 In October 2014, the community repository had moderation turned on. All community packages (every version of a package) go through a [rigorous moderation process](xref:moderation) prior to any public consumption:
 
-- All package versions are run through an [automated verification process](https://github.com/chocolatey/package-verifier/wiki) to determine if they work correctly (install, etc).
 - All package versions are run through an [automated validation process](xref:package-validator) to determine quality.
+- All package versions are run through an [automated verification process](xref:package-verifier-service) to determine if they work correctly (install, etc).
 - All packages versions are run through VirusTotal to determine if there are any flagging items. This includes downloading and unpacking any external resources (See the results on a package page in the Virus section - [https://chocolatey.org/packages/chocolatey#virus](https://chocolatey.org/packages/chocolatey#virus) as an example).
     > :memo: **NOTE** Only en-US installers are tested by default via Chocolatey's Package Scanner.
 - A human [reviews every package version](xref:moderation#reviewer-moderator-process) that is not a [trusted package](xref:faqs#what-is-a-trusted-package). This process verifies that packages are pulling from official distro sources or checksumming items versus the official distros and checking over scripts for malicious behavior.


### PR DESCRIPTION
Fixes: #103 

