### PR TITLE
Update getting-started.md

### DIFF
--- a/input/en-us/getting-started.md
+++ b/input/en-us/getting-started.md
@@ -110,9 +110,8 @@ Take a look at the [command reference](xref:choco-commands). We are going to be 
 
 Let's install [Notepad++](http://notepad-plus-plus.org/).
 
-1. Open a command line.
+1. Open a command line as an administrator.
 1. Type `choco install notepadplusplus` and press Enter.
-1. If you have UAC turned on or are not an administrator, Chocolatey is going to request administrative permission at some point (at least once during the process). Otherwise it will not be able to finish what it is doing successfully. If you don't have UAC turned on, it will just continue on without stopping to bother you.
 1. That's it. Pretty simple but powerful little concept!
 
 ### Overriding default install directory or other advanced install concepts


### PR DESCRIPTION
Remove info that Chocolatey will elevate its own permissions - I think this is outdated, at least it is no longer the case with 0.10.15 here?