### PR TITLE
(chocolatey/choco-theme#18) Bootstrap v5 & JS

### DIFF
--- a/bundleconfig.json
+++ b/bundleconfig.json
@@ -21,11 +21,29 @@
       "outputFileName": "input/assets/js/chocolatey.bundle.js",
       "inputFiles": [
         "node_modules/jquery/dist/jquery.js",
-        "node_modules/bootstrap/dist/js/bootstrap.bundle.js",
+        "node_modules/bootstrap/js/dist/dom/data.js",
+        "node_modules/bootstrap/js/dist/dom/event-handler.js",
+        "node_modules/bootstrap/js/dist/dom/manipulator.js",
+        "node_modules/bootstrap/js/dist/dom/selector-engine.js",
+        "node_modules/bootstrap/js/dist/alert.js",
+        "node_modules/bootstrap/js/dist/button.js",
+        "node_modules/bootstrap/js/dist/collapse.js",
         "node_modules/anchor-js/anchor.js",
         "node_modules/choco-theme/js/prism.min.js",
         "node_modules/mousetrap/mousetrap.js",
-        "node_modules/choco-theme/js/chocolatey.js"
+        "node_modules/choco-theme/js/chocolatey-theme-toggle.js",
+        "node_modules/choco-theme/js/chocolatey-functions.js",
+        "node_modules/choco-theme/js/chocolatey-docs.js",
+        "node_modules/choco-theme/js/chocolatey-alerts.js",
+        "node_modules/choco-theme/js/chocolatey-collapse-y-height.js",
+        "node_modules/choco-theme/js/chocolatey-anchors.js",
+        "node_modules/choco-theme/js/chocolatey-collapse-nested.js",
+        "node_modules/choco-theme/js/chocolatey-collapse-responsive.js",
+        "node_modules/choco-theme/js/chocolatey-code.js",
+        "node_modules/choco-theme/js/chocolatey-tables.js",
+        "node_modules/choco-theme/js/chocolatey-markdown.js",
+        "node_modules/choco-theme/js/chocolatey-algolia.js",
+        "node_modules/choco-theme/js/chocolatey-scrollspy.js"
       ]
     }
   ]

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -75,9 +75,16 @@ function compileJs() {
     var tasks = getBundles(regex.js).map(function (bundle) {
 
         return gulp.src(bundle.inputFiles, { base: '.' })
-            /*.pipe(babel({
-                presets: ['@babel/env']
-            }))*/
+            .pipe(babel({
+                "sourceType": "unambiguous",
+                "presets": [
+                    ["@babel/preset-env", { 
+                        "targets": {
+                            "ie": "10"
+                        }
+                    }
+                  ]]
+            }))
             .pipe(concat(bundle.outputFileName))
             .pipe(dest('.'));
     });

--- a/input/404.md
+++ b/input/404.md
@@ -10,7 +10,7 @@ NoSidebar: true
                 <div class="card card-body p-md-5">
                     <div class="text-center">
                         <img class="mb-3" width="300" src="/assets/images/global-shared/404.svg" title="404 Page Not Found" alt="404 Page Not Found" >
-                        <h3 class="text-uppercase bg-primary-opacity text-primary d-inline-block p-2 mt-0">Oops! Page not found.</h3>
+                        <h3 class="text-uppercase bg-primary-opacity-25 text-primary d-inline-block p-2 mt-0">Oops! Page not found.</h3>
                     </div>
                     <p class="text-reset">
                         We were unable to find this page. This could be as a result of the recent changes to the site, where we have moved some files around. Please verify that the link you are using is what you expect.  If you are still having problems, please reach out to the Chocolatey Team, and we will do our best to fix this problem.

--- a/input/_childpages.cshtml
+++ b/input/_childpages.cshtml
@@ -1,19 +1,19 @@
 @if (OutputPages.GetChildrenOf(Document).Any())
 {
-<h2 class="title-child d-none">Child Pages</h2>
-<div class="row mt-3 mt-md-4 ml-md-n5 ml-xl-n3">
+<h2 class="title-child d-none mb-3">Child Pages</h2>
+<div class="row ms-md-n5 ms-xl-n3">
 	@foreach (IDocument child in OutputPages.GetChildrenOf(Document).OnlyVisible())
 	{
 		object[] childTreePath = child.Get<object[]>(Keys.TreePath);
 
-		<div class="col-lg-6 col-xl-4 mb-4">
+		<div class="col-lg-6 col-xl-4 pb-4">
 			<a href="@child.GetLink()">
 			<div class="card card-body card-index">
 				<div class="circle">
 					<i class="fas fa-file" aria-hidden="true"></i>
 				</div>
-				<div class="d-flex flex-column pl-3">
-					<p class="h5 font-weight-bold card-title">@child.GetTitle()</p>
+				<div class="d-flex flex-column ps-3">
+					<p class="h5 fw-bold card-title">@child.GetTitle()</p>
 					@if (child.ContainsKey(WebKeys.Description))
 					{
 						<p class="card-content">@(child.Get(WebKeys.Description))</p>

--- a/input/_layout.cshtml
+++ b/input/_layout.cshtml
@@ -66,8 +66,8 @@
                 {
                     <div id="topNoticeAlert" class="alert alert-success alert-dismissible alert-dismissible-center fade show d-none" role="alert">
                         <p class="mb-0">@Html.Raw(topNoticeText)</p>
-                        <button type="button" class="close" data-dismiss="alert" aria-label="Close">
-                            <span aria-hidden="true">&times;</span>
+                        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close">
+                            <i class="fas fa-times" aria-hidden="true"></i>
                         </button>
                     </div>
                 }
@@ -82,7 +82,7 @@
                     <img class="d-md-none" src="@Context.GetLink("/assets/images/global-shared/logo.svg")" alt="Chocolatey" />
                     <img class="d-none d-md-block" src="@Context.GetLink("/assets/images/global-shared/logo-square.svg")" alt="Chocolatey" />
                 </a>
-                <ul class="navbar-nav ml-auto">
+                <ul class="navbar-nav ms-auto">
                     <li class="nav-item">
                         <a class="nav-link" href="https://github.com/chocolatey/docs" aria-label="Edit on GitHub"><i class="fab fa-2x fa-github" aria-hidden="true"></i></a>
                     </li>
@@ -110,12 +110,12 @@
                     <i class="fas fa-search" aria-hidden="true"></i>
                     <input type="search" class="form-control" id="searchQuery" placeholder="Search..." aria-label="Search" />
                     <span class="d-none d-md-flex search-key-container">
-                        <span class="badge badge-key badge-primary search-key"></span>
-                        <span class="badge badge-key badge-primary">k</span>
+                        <span class="badge badge-key bg-primary search-key"></span>
+                        <span class="badge badge-key bg-primary">k</span>
                     </span>
                 </form>
                 <button type="button" aria-label="Close search" class="btn btn-search-close btn-link d-none">Close</button>
-                <button type="button" class="navbar-toggler btn d-md-none" data-toggle="collapse" data-target="#leftSidebar" aria-expanded="false" aria-controls="leftSidebar" aria-label="Toggle navigation"><i class="fas fa-bars"></i></button>
+                <button type="button" class="navbar-toggler btn d-md-none" data-bs-toggle="collapse" data-bs-target="#leftSidebar" aria-expanded="false" aria-controls="leftSidebar" aria-label="Toggle navigation"><i class="fas fa-bars"></i></button>
             </nav>
         </header>
         @if (Document.GetBool(Constants.NoSidebar))
@@ -127,8 +127,8 @@
             <main>
                 <div class="container-fluid">
                     <div class="row">
-                        <div id="leftSidebarNav" class="col-md-3 col-xl-2 p-0">
-                            <div class="loader-container"><div class="loader"></div></div>
+                        <div class="col-md-3 col-xl-2 p-0 bg-theme-light">
+                            <div id="leftSidebarNav" class="sticky-md-top collapse-y-height">
                             @{
                                 IDocument root = OutputPages["en-us/index.html"].First();
                             }
@@ -139,7 +139,7 @@
                                         <li class="nav-item">
                                             @if(root.ShowLink())
                                             {
-                                                <a class="nav-link pl-c2 @(Document.IdEquals(root) ? "active active-page" : null)" href="@root.GetLink()">@root.GetTitle()</a>
+                                                <a class="nav-link ps-c2 @(Document.IdEquals(root) ? "active active-page" : null)" href="@root.GetLink()">@root.GetTitle()</a>
                                             }
                                             else
                                             {
@@ -149,52 +149,51 @@
                                         @foreach (IDocument document in OutputPages.GetChildrenOf(root).OnlyVisible())
                                         {
                                             DocumentList<IDocument> documentChildren = OutputPages.GetChildrenOf(document);
-
                                             @if(documentChildren.Any()) {
-                                                <li class="nav-item">
-                                                    <div class="nav-link nav-link-collapse d-flex align-items-start @(Document.IdEquals(document) ||  OutputPages.GetDescendantsOf(document).Any(x => Document.IdEquals(x)) ? "active" : null) @(Document.IdEquals(document) ? "active-page" : null)">
-                                                        <button class="btn btn-collapse collapsed" type="button" data-toggle="collapse" aria-expanded="false" aria-controls="id-@document.Id" aria-label="collapse or expand navigation" href="#id-@document.Id"></button>
+                                                <li class="nav-item @(Document.IdEquals(document) || OutputPages.GetDescendantsOf(document).Any(x => Document.IdEquals(x)) ? "active" : null)">
+                                                    <div class="nav-link nav-link-collapse d-flex @(Document.IdEquals(document) || OutputPages.GetDescendantsOf(document).Any(x => Document.IdEquals(x)) ? "active" : null) @(Document.IdEquals(document) ? "active-page" : null)">
+                                                        <button class="btn btn-collapse rounded-0 border-0 ps-3 @(Document.IdEquals(document) || OutputPages.GetDescendantsOf(document).Any(x => Document.IdEquals(x)) ? null : "collapsed")" type="button" data-bs-toggle="collapse" aria-expanded="@(Document.IdEquals(document) || OutputPages.GetDescendantsOf(document).Any(x => Document.IdEquals(x)) ? "true" : "false")" aria-controls="id-@document.Id" aria-label="collapse or expand navigation" href="#id-@document.Id"></button>
                                                         <a href="@document.GetLink()">@document.GetTitle()</a>
                                                     </div>
-                                                    <div class="collapse" id="id-@document.Id">
+                                                    <div class="collapse @(Document.IdEquals(document) || OutputPages.GetDescendantsOf(document).Any(x => Document.IdEquals(x)) ? "show" : null)" id="id-@document.Id">
                                                         <ul class="navbar-nav">
                                                             @foreach (IDocument child in documentChildren.OnlyVisible())
                                                             {
                                                                 @if(OutputPages.GetChildrenOf(child).Any())
                                                                 {
                                                                     <li class="nav-item">
-                                                                        <div class="nav-link nav-link-collapse d-flex align-items-start @(Document.IdEquals(child) ||  OutputPages.GetDescendantsOf(child).Any(x => Document.IdEquals(x)) ? "active" : null) @(Document.IdEquals(child) ? "active-page" : null)">
-                                                                            <button class="btn btn-collapse collapsed pl-c175" type="button" data-toggle="collapse" aria-expanded="false" aria-controls="id-@child.Id" aria-label="collapse or expand navigation" href="#id-@child.Id"></button>
+                                                                        <div class="nav-link nav-link-collapse d-flex @(Document.IdEquals(child) || OutputPages.GetDescendantsOf(child).Any(x => Document.IdEquals(x)) ? "active" : null) @(Document.IdEquals(child) ? "active-page" : null)">
+                                                                            <button class="btn btn-collapse rounded-0 border-0 ps-c2 @(Document.IdEquals(child) || OutputPages.GetDescendantsOf(child).Any(x => Document.IdEquals(x)) ? null : "collapsed")" type="button" data-bs-toggle="collapse" aria-expanded="@(Document.IdEquals(child) || OutputPages.GetDescendantsOf(child).Any(x => Document.IdEquals(x)) ? "true" : "false")" aria-controls="id-@child.Id" aria-label="collapse or expand navigation" href="#id-@child.Id"></button>
                                                                             <a href="@child.GetLink()">@child.GetTitle()</a>
                                                                         </div>
-                                                                        <div class="collapse" id="id-@child.Id">
+                                                                        <div class="collapse @(Document.IdEquals(child) || OutputPages.GetDescendantsOf(child).Any(x => Document.IdEquals(x)) ? "show" : null)" id="id-@child.Id">
                                                                             <ul class="navbar-nav">
                                                                                 @foreach (IDocument grandChild in OutputPages.GetChildrenOf(child).OnlyVisible())
                                                                                 {
                                                                                     @if(OutputPages.GetChildrenOf(grandChild).Any())
                                                                                     {
                                                                                         <li class="nav-item">
-                                                                                            <div class="nav-link nav-link-collapse d-flex align-items-start @(Document.IdEquals(grandChild) ||  OutputPages.GetDescendantsOf(grandChild).Any(x => Document.IdEquals(x)) ? "active" : null) @(Document.IdEquals(grandChild) ? "active-page" : null)">
-                                                                                                <button class="btn btn-collapse collapsed pl-c275" type="button" data-toggle="collapse" aria-expanded="false" aria-controls="id-@grandChild.Id" aria-label="collapse or expand navigation" href="#id-@grandChild.Id"></button>
+                                                                                            <div class="nav-link nav-link-collapse d-flex @(Document.IdEquals(grandChild) || OutputPages.GetDescendantsOf(grandChild).Any(x => Document.IdEquals(x)) ? "active" : null) @(Document.IdEquals(grandChild) ? "active-page" : null)">
+                                                                                                <button class="btn btn-collapse rounded-0 border-0 ps-5 @(Document.IdEquals(grandChild) || OutputPages.GetDescendantsOf(grandChild).Any(x => Document.IdEquals(x)) ? null : "collapsed")" type="button" data-bs-toggle="collapse" aria-expanded="@(Document.IdEquals(grandChild) || OutputPages.GetDescendantsOf(grandChild).Any(x => Document.IdEquals(x)) ? "true" : "false")" aria-controls="id-@grandChild.Id" aria-label="collapse or expand navigation" href="#id-@grandChild.Id"></button>
                                                                                                 <a href="@grandChild.GetLink()">@grandChild.GetTitle()</a>
                                                                                             </div>
-                                                                                            <div class="collapse" id="id-@grandChild.Id">
+                                                                                            <div class="collapse @(Document.IdEquals(grandChild) || OutputPages.GetDescendantsOf(grandChild).Any(x => Document.IdEquals(x)) ? "show" : null)" id="id-@grandChild.Id">
                                                                                                 <ul class="navbar-nav">
                                                                                                     @foreach (IDocument greatGrandChild in OutputPages.GetChildrenOf(grandChild).OnlyVisible())
                                                                                                     {
                                                                                                         @if(OutputPages.GetChildrenOf(greatGrandChild).Any())
                                                                                                         {
                                                                                                             <li class="nav-item">
-                                                                                                                <div class="nav-link nav-link-collapse d-flex align-items-start @(Document.IdEquals(greatGrandChild) ||  OutputPages.GetDescendantsOf(greatGrandChild).Any(x => Document.IdEquals(x)) ? "active" : null) @(Document.IdEquals(greatGrandChild) ? "active-page" : null)">
-                                                                                                                    <button class="btn btn-collapse pl-c375 collapsed" type="button" data-toggle="collapse" aria-expanded="false" aria-controls="id-@greatGrandChild.Id" aria-label="collapse or expand navigation" href="#id-@greatGrandChild.Id"></button>
+                                                                                                                <div class="nav-link nav-link-collapse d-flex @(Document.IdEquals(greatGrandChild) || OutputPages.GetDescendantsOf(greatGrandChild).Any(x => Document.IdEquals(x)) ? "active" : null) @(Document.IdEquals(greatGrandChild) ? "active-page" : null)">
+                                                                                                                    <button class="btn btn-collapse rounded-0 border-0 ps-c4 @(Document.IdEquals(greatGrandChild) || OutputPages.GetDescendantsOf(greatGrandChild).Any(x => Document.IdEquals(x)) ? null : "collapsed")" type="button" data-bs-toggle="collapse" aria-expanded="@(Document.IdEquals(greatGrandChild) || OutputPages.GetDescendantsOf(greatGrandChild).Any(x => Document.IdEquals(x)) ? "true" : "false")" aria-controls="id-@greatGrandChild.Id" aria-label="collapse or expand navigation" href="#id-@greatGrandChild.Id"></button>
                                                                                                                     <a href="@greatGrandChild.GetLink()">@greatGrandChild.GetTitle()</a>
                                                                                                                 </div>
-                                                                                                                <div class="collapse" id="id-@greatGrandChild.Id">
+                                                                                                                <div class="collapse @(Document.IdEquals(greatGrandChild) || OutputPages.GetDescendantsOf(greatGrandChild).Any(x => Document.IdEquals(x)) ? "show" : null)" id="id-@greatGrandChild.Id">
                                                                                                                     <ul class="navbar-nav">
                                                                                                                         @foreach (IDocument greatGreatGrandChild in OutputPages.GetChildrenOf(greatGrandChild).OnlyVisible())
                                                                                                                         {
                                                                                                                             <li class="nav-item">
-                                                                                                                                <a class="nav-link pl-c6 @(Document.IdEquals(greatGreatGrandChild) ? "active active-page" : null)" href="@greatGreatGrandChild.GetLink()">@greatGreatGrandChild.GetTitle()</a>
+                                                                                                                                <a class="nav-link ps-c6 @(Document.IdEquals(greatGreatGrandChild) ? "active active-page" : null)" href="@greatGreatGrandChild.GetLink()">@greatGreatGrandChild.GetTitle()</a>
                                                                                                                             </li>
                                                                                                                         }
                                                                                                                     </ul>
@@ -204,7 +203,7 @@
                                                                                                         else
                                                                                                         {
                                                                                                             <li class="nav-item">
-                                                                                                                <a class="nav-link pl-c5 @(Document.IdEquals(greatGrandChild) ? "active active-page" : null)" href="@greatGrandChild.GetLink()">@greatGrandChild.GetTitle()</a>
+                                                                                                                <a class="nav-link ps-c5 @(Document.IdEquals(greatGrandChild) ? "active active-page" : null)" href="@greatGrandChild.GetLink()">@greatGrandChild.GetTitle()</a>
                                                                                                             </li>
                                                                                                         }
                                                                                                     }
@@ -215,7 +214,7 @@
                                                                                     else
                                                                                     {
                                                                                         <li class="nav-item">
-                                                                                            <a class="nav-link pl-c4 @(Document.IdEquals(grandChild) ? "active active-page" : null)" href="@grandChild.GetLink()">@grandChild.GetTitle()</a>
+                                                                                            <a class="nav-link ps-c4 @(Document.IdEquals(grandChild) ? "active active-page" : null)" href="@grandChild.GetLink()">@grandChild.GetTitle()</a>
                                                                                         </li>
                                                                                     }
                                                                                 }
@@ -226,7 +225,7 @@
                                                                 else
                                                                 {
                                                                     <li class="nav-item">
-                                                                        <a class="nav-link pl-5 @(Document.IdEquals(child) ? "active active-page" : null)" href="@child.GetLink()">@child.GetTitle()</a>
+                                                                        <a class="nav-link ps-5 @(Document.IdEquals(child) ? "active active-page" : null)" href="@child.GetLink()">@child.GetTitle()</a>
                                                                     </li>
                                                                 }
                                                             }
@@ -237,20 +236,21 @@
                                             else
                                             {
                                                 <li class="nav-item">
-                                                    <a class="nav-link pl-c2 @(Document.IdEquals(document) ? "active active-page" : null)" href="@document.GetLink()">@document.GetTitle()</a>
+                                                    <a class="nav-link ps-c2 @(Document.IdEquals(document) ? "active active-page" : null)" href="@document.GetLink()">@document.GetTitle()</a>
                                                 </li>
                                             }
                                         }
                                     </ul>
                                 </div>
                             </nav>
+                            </div>
                         </div>
                         <div class="col-md-9 col-xl-10 py-3 py-md-5 mx-auto">
-                            <div class="ml-md-4 d-xl-none">
+                            <div class="ms-md-4 d-xl-none">
                                 @Html.Partial("_breadcrumbs")
                             </div>
                             <div class="row">
-                                <div id="mainContent" class="col-xl-10 pl-md-5 order-2 order-xl-1">
+                                <div id="mainContent" class="col-xl-10 ps-md-5 order-2 order-xl-1">
                                     <div class="d-none d-xl-block">
                                         @Html.Partial("_breadcrumbs")
                                     </div>
@@ -264,20 +264,39 @@
                                     IReadOnlyList<IDocument> headings = Document.GetDocumentList(Statiq.Html.HtmlKeys.Headings);
                                     if (headings.Count > 1)
                                     {
-                                        <div id="rightSidebarNav" class="col-xl-2 pl-md-5 pl-xl-3 order-1 order-xl-2">
-                                            <button class="btn btn-link btn-collapse font-weight-bold w-100 d-xl-none mb-2" type="button" data-toggle="collapse" data-target="#rightSidebar" aria-expanded="false" aria-controls="rightSidebar">Jump to Section</button>
-                                            <div id="rightSidebar" class="sticky-top collapse">
-                                                <div class="card card-body py-0 px-xl-0 mb-3 border-0">
+                                        <div id="rightSidebarNav" class="col-xl-2 ps-md-5 ps-xl-3 order-1 order-xl-2">
+                                            <button class="btn btn-link btn-collapse fw-bold w-100 d-xl-none mb-2" type="button" data-bs-toggle="collapse" data-bs-target="#rightSidebar" aria-expanded="false" aria-controls="rightSidebar">Jump to Section</button>
+                                            <div id="rightSidebar" class="sticky-xl-top collapse collapse-lg">
+                                                <div class="card card-body py-0 px-xl-0 mb-3 border-0 shadow-none">
                                                     @if (Document.ContainsKey("EditLink"))
                                                     {
-                                                        <p class="font-weight-bold pt-3"><a href="@Document.GetString("EditLink")"><i class="fas fa-pencil-alt" aria-hidden="true"></i> Edit This Page</a></p>
+                                                        <p class="fw-bold pt-3"><a href="@Document.GetString("EditLink")"><i class="fas fa-pencil-alt" aria-hidden="true"></i> Edit This Page</a></p>
                                                         <hr class="m-0" />
                                                     }
-                                                    <p class="font-weight-bold pt-3">On This Page</p>
-                                                    <ul class="list-unstyled pb-xl-3">
+                                                    <p class="fw-bold pt-3 mb-2">On This Page</p>
+                                                    <ul class="nav nav-scrollspy flex-column pb-3">
                                                         @foreach (IDocument heading in headings)
                                                         {
-                                                            <li class="level-@heading.GetString(Statiq.Html.HtmlKeys.Level)"><a href="#@(heading.GetString(Statiq.Html.HtmlKeys.HeadingId))">@(await heading.GetContentStringAsync())</a></li>
+                                                            var level = "";
+                                                            switch(heading.GetString(Statiq.Html.HtmlKeys.Level))
+                                                            {
+                                                                case "1":
+                                                                    level = "d-none";
+                                                                    break;
+                                                                case "3":
+                                                                    level = "ps-4";
+                                                                    break;
+                                                                case "4":
+                                                                    level = "ps-5";
+                                                                    break;
+                                                                case "5":
+                                                                    level = "ps-c45";
+                                                                    break;
+                                                                default:
+                                                                    level = level;
+                                                                    break;                   
+                                                            }
+                                                            <li class="nav-item"><a class="nav-link @level" href="#@(heading.GetString(Statiq.Html.HtmlKeys.HeadingId))">@(await heading.GetContentStringAsync())</a></li>
                                                         }
                                                     </ul>
                                                 </div>
@@ -296,14 +315,15 @@
                 <span>© @DateTime.Today.Year Chocolatey Software, Inc.</span><br />
                 <span>Deployed from <a href="https://github.com/chocolatey/docs/commit/@VersionUtilities.GetSha()">@VersionUtilities.GetCommit()</a></span><br />
                 <span><a href="https://statiq.dev/">Generated by Statiq</a></span>
-            </div>
+            </span>
             <div id="cookieNoticeAlert" class="alert alert-primary alert-dismissible alert-dismissible-center alert-btn-center fade show d-none" role="alert">
                 <p class="mb-0"><strong>docs.chocolatey.org uses cookies to enhance the user experience of the site.</strong></p>
-                <button type="button" class="btn btn-light btn-sm d-none d-md-inline-block" data-dismiss="alert" aria-label="Close">I accept</button>
-                <button type="button" class="btn btn-light d-md-none" data-dismiss="alert" aria-label="Close">I accept</button>
+                <button type="button" class="btn btn-light btn-sm d-none d-md-inline-block" data-bs-dismiss="alert" aria-label="Close">I accept</button>
+                <button type="button" class="btn btn-light d-md-none" data-bs-dismiss="alert" aria-label="Close">I accept</button>
             </div>
         </footer>
 
+        <script type="text/javascript" src="https://polyfill.io/v3/polyfill.min.js?features=default,Array.prototype.includes,Array.prototype.find,Number.parseFloat%2CNumber.parse%2CNodeList.prototype.forEach%2CNumber.parseInt"></script>
         <script type="text/javascript" src="@Context.GetLink("/assets/js/chocolatey.bundle.min.js")"></script>
         <script>
             ((window.gitter = {}).chat = {}).options = {

--- a/input/_layout.cshtml
+++ b/input/_layout.cshtml
@@ -129,120 +129,120 @@
                     <div class="row">
                         <div class="col-md-3 col-xl-2 p-0 bg-theme-light">
                             <div id="leftSidebarNav" class="sticky-md-top collapse-y-height">
-                            @{
-                                IDocument root = OutputPages["en-us/index.html"].First();
-                            }
-                            <nav class="navbar navbar-expand-md p-0">
-                                <div id="leftSidebar" class="collapse navbar-collapse">
-                                    @Html.Partial("global-partials/_globalnavigation")
-                                    <ul class="navbar-nav">
-                                        <li class="nav-item">
-                                            @if(root.ShowLink())
+                                @{
+                                    IDocument root = OutputPages["en-us/index.html"].First();
+                                }
+                                <nav class="navbar navbar-expand-md p-0">
+                                    <div id="leftSidebar" class="collapse navbar-collapse">
+                                        @Html.Partial("global-partials/_globalnavigation")
+                                        <ul class="navbar-nav">
+                                            <li class="nav-item">
+                                                @if(root.ShowLink())
+                                                {
+                                                    <a class="nav-link ps-c2 @(Document.IdEquals(root) ? "active active-page" : null)" href="@root.GetLink()">@root.GetTitle()</a>
+                                                }
+                                                else
+                                                {
+                                                    @root.GetTitle()
+                                                }
+                                            </li>
+                                            @foreach (IDocument document in OutputPages.GetChildrenOf(root).OnlyVisible())
                                             {
-                                                <a class="nav-link ps-c2 @(Document.IdEquals(root) ? "active active-page" : null)" href="@root.GetLink()">@root.GetTitle()</a>
-                                            }
-                                            else
-                                            {
-                                                @root.GetTitle()
-                                            }
-                                        </li>
-                                        @foreach (IDocument document in OutputPages.GetChildrenOf(root).OnlyVisible())
-                                        {
-                                            DocumentList<IDocument> documentChildren = OutputPages.GetChildrenOf(document);
-                                            @if(documentChildren.Any()) {
-                                                <li class="nav-item @(Document.IdEquals(document) || OutputPages.GetDescendantsOf(document).Any(x => Document.IdEquals(x)) ? "active" : null)">
-                                                    <div class="nav-link nav-link-collapse d-flex @(Document.IdEquals(document) || OutputPages.GetDescendantsOf(document).Any(x => Document.IdEquals(x)) ? "active" : null) @(Document.IdEquals(document) ? "active-page" : null)">
-                                                        <button class="btn btn-collapse rounded-0 border-0 ps-3 @(Document.IdEquals(document) || OutputPages.GetDescendantsOf(document).Any(x => Document.IdEquals(x)) ? null : "collapsed")" type="button" data-bs-toggle="collapse" aria-expanded="@(Document.IdEquals(document) || OutputPages.GetDescendantsOf(document).Any(x => Document.IdEquals(x)) ? "true" : "false")" aria-controls="id-@document.Id" aria-label="collapse or expand navigation" href="#id-@document.Id"></button>
-                                                        <a href="@document.GetLink()">@document.GetTitle()</a>
-                                                    </div>
-                                                    <div class="collapse @(Document.IdEquals(document) || OutputPages.GetDescendantsOf(document).Any(x => Document.IdEquals(x)) ? "show" : null)" id="id-@document.Id">
-                                                        <ul class="navbar-nav">
-                                                            @foreach (IDocument child in documentChildren.OnlyVisible())
-                                                            {
-                                                                @if(OutputPages.GetChildrenOf(child).Any())
+                                                DocumentList<IDocument> documentChildren = OutputPages.GetChildrenOf(document);
+                                                @if(documentChildren.Any()) {
+                                                    <li class="nav-item @(Document.IdEquals(document) || OutputPages.GetDescendantsOf(document).Any(x => Document.IdEquals(x)) ? "active" : null)">
+                                                        <div class="nav-link nav-link-collapse d-flex @(Document.IdEquals(document) || OutputPages.GetDescendantsOf(document).Any(x => Document.IdEquals(x)) ? "active" : null) @(Document.IdEquals(document) ? "active-page" : null)">
+                                                            <button class="btn btn-collapse rounded-0 border-0 ps-3 @(Document.IdEquals(document) || OutputPages.GetDescendantsOf(document).Any(x => Document.IdEquals(x)) ? null : "collapsed")" type="button" data-bs-toggle="collapse" aria-expanded="@(Document.IdEquals(document) || OutputPages.GetDescendantsOf(document).Any(x => Document.IdEquals(x)) ? "true" : "false")" aria-controls="id-@document.Id" aria-label="collapse or expand navigation" href="#id-@document.Id"></button>
+                                                            <a href="@document.GetLink()">@document.GetTitle()</a>
+                                                        </div>
+                                                        <div class="collapse @(Document.IdEquals(document) || OutputPages.GetDescendantsOf(document).Any(x => Document.IdEquals(x)) ? "show" : null)" id="id-@document.Id">
+                                                            <ul class="navbar-nav">
+                                                                @foreach (IDocument child in documentChildren.OnlyVisible())
                                                                 {
-                                                                    <li class="nav-item">
-                                                                        <div class="nav-link nav-link-collapse d-flex @(Document.IdEquals(child) || OutputPages.GetDescendantsOf(child).Any(x => Document.IdEquals(x)) ? "active" : null) @(Document.IdEquals(child) ? "active-page" : null)">
-                                                                            <button class="btn btn-collapse rounded-0 border-0 ps-c2 @(Document.IdEquals(child) || OutputPages.GetDescendantsOf(child).Any(x => Document.IdEquals(x)) ? null : "collapsed")" type="button" data-bs-toggle="collapse" aria-expanded="@(Document.IdEquals(child) || OutputPages.GetDescendantsOf(child).Any(x => Document.IdEquals(x)) ? "true" : "false")" aria-controls="id-@child.Id" aria-label="collapse or expand navigation" href="#id-@child.Id"></button>
-                                                                            <a href="@child.GetLink()">@child.GetTitle()</a>
-                                                                        </div>
-                                                                        <div class="collapse @(Document.IdEquals(child) || OutputPages.GetDescendantsOf(child).Any(x => Document.IdEquals(x)) ? "show" : null)" id="id-@child.Id">
-                                                                            <ul class="navbar-nav">
-                                                                                @foreach (IDocument grandChild in OutputPages.GetChildrenOf(child).OnlyVisible())
-                                                                                {
-                                                                                    @if(OutputPages.GetChildrenOf(grandChild).Any())
+                                                                    @if(OutputPages.GetChildrenOf(child).Any())
+                                                                    {
+                                                                        <li class="nav-item">
+                                                                            <div class="nav-link nav-link-collapse d-flex @(Document.IdEquals(child) || OutputPages.GetDescendantsOf(child).Any(x => Document.IdEquals(x)) ? "active" : null) @(Document.IdEquals(child) ? "active-page" : null)">
+                                                                                <button class="btn btn-collapse rounded-0 border-0 ps-c2 @(Document.IdEquals(child) || OutputPages.GetDescendantsOf(child).Any(x => Document.IdEquals(x)) ? null : "collapsed")" type="button" data-bs-toggle="collapse" aria-expanded="@(Document.IdEquals(child) || OutputPages.GetDescendantsOf(child).Any(x => Document.IdEquals(x)) ? "true" : "false")" aria-controls="id-@child.Id" aria-label="collapse or expand navigation" href="#id-@child.Id"></button>
+                                                                                <a href="@child.GetLink()">@child.GetTitle()</a>
+                                                                            </div>
+                                                                            <div class="collapse @(Document.IdEquals(child) || OutputPages.GetDescendantsOf(child).Any(x => Document.IdEquals(x)) ? "show" : null)" id="id-@child.Id">
+                                                                                <ul class="navbar-nav">
+                                                                                    @foreach (IDocument grandChild in OutputPages.GetChildrenOf(child).OnlyVisible())
                                                                                     {
-                                                                                        <li class="nav-item">
-                                                                                            <div class="nav-link nav-link-collapse d-flex @(Document.IdEquals(grandChild) || OutputPages.GetDescendantsOf(grandChild).Any(x => Document.IdEquals(x)) ? "active" : null) @(Document.IdEquals(grandChild) ? "active-page" : null)">
-                                                                                                <button class="btn btn-collapse rounded-0 border-0 ps-5 @(Document.IdEquals(grandChild) || OutputPages.GetDescendantsOf(grandChild).Any(x => Document.IdEquals(x)) ? null : "collapsed")" type="button" data-bs-toggle="collapse" aria-expanded="@(Document.IdEquals(grandChild) || OutputPages.GetDescendantsOf(grandChild).Any(x => Document.IdEquals(x)) ? "true" : "false")" aria-controls="id-@grandChild.Id" aria-label="collapse or expand navigation" href="#id-@grandChild.Id"></button>
-                                                                                                <a href="@grandChild.GetLink()">@grandChild.GetTitle()</a>
-                                                                                            </div>
-                                                                                            <div class="collapse @(Document.IdEquals(grandChild) || OutputPages.GetDescendantsOf(grandChild).Any(x => Document.IdEquals(x)) ? "show" : null)" id="id-@grandChild.Id">
-                                                                                                <ul class="navbar-nav">
-                                                                                                    @foreach (IDocument greatGrandChild in OutputPages.GetChildrenOf(grandChild).OnlyVisible())
-                                                                                                    {
-                                                                                                        @if(OutputPages.GetChildrenOf(greatGrandChild).Any())
+                                                                                        @if(OutputPages.GetChildrenOf(grandChild).Any())
+                                                                                        {
+                                                                                            <li class="nav-item">
+                                                                                                <div class="nav-link nav-link-collapse d-flex @(Document.IdEquals(grandChild) || OutputPages.GetDescendantsOf(grandChild).Any(x => Document.IdEquals(x)) ? "active" : null) @(Document.IdEquals(grandChild) ? "active-page" : null)">
+                                                                                                    <button class="btn btn-collapse rounded-0 border-0 ps-5 @(Document.IdEquals(grandChild) || OutputPages.GetDescendantsOf(grandChild).Any(x => Document.IdEquals(x)) ? null : "collapsed")" type="button" data-bs-toggle="collapse" aria-expanded="@(Document.IdEquals(grandChild) || OutputPages.GetDescendantsOf(grandChild).Any(x => Document.IdEquals(x)) ? "true" : "false")" aria-controls="id-@grandChild.Id" aria-label="collapse or expand navigation" href="#id-@grandChild.Id"></button>
+                                                                                                    <a href="@grandChild.GetLink()">@grandChild.GetTitle()</a>
+                                                                                                </div>
+                                                                                                <div class="collapse @(Document.IdEquals(grandChild) || OutputPages.GetDescendantsOf(grandChild).Any(x => Document.IdEquals(x)) ? "show" : null)" id="id-@grandChild.Id">
+                                                                                                    <ul class="navbar-nav">
+                                                                                                        @foreach (IDocument greatGrandChild in OutputPages.GetChildrenOf(grandChild).OnlyVisible())
                                                                                                         {
-                                                                                                            <li class="nav-item">
-                                                                                                                <div class="nav-link nav-link-collapse d-flex @(Document.IdEquals(greatGrandChild) || OutputPages.GetDescendantsOf(greatGrandChild).Any(x => Document.IdEquals(x)) ? "active" : null) @(Document.IdEquals(greatGrandChild) ? "active-page" : null)">
-                                                                                                                    <button class="btn btn-collapse rounded-0 border-0 ps-c4 @(Document.IdEquals(greatGrandChild) || OutputPages.GetDescendantsOf(greatGrandChild).Any(x => Document.IdEquals(x)) ? null : "collapsed")" type="button" data-bs-toggle="collapse" aria-expanded="@(Document.IdEquals(greatGrandChild) || OutputPages.GetDescendantsOf(greatGrandChild).Any(x => Document.IdEquals(x)) ? "true" : "false")" aria-controls="id-@greatGrandChild.Id" aria-label="collapse or expand navigation" href="#id-@greatGrandChild.Id"></button>
-                                                                                                                    <a href="@greatGrandChild.GetLink()">@greatGrandChild.GetTitle()</a>
-                                                                                                                </div>
-                                                                                                                <div class="collapse @(Document.IdEquals(greatGrandChild) || OutputPages.GetDescendantsOf(greatGrandChild).Any(x => Document.IdEquals(x)) ? "show" : null)" id="id-@greatGrandChild.Id">
-                                                                                                                    <ul class="navbar-nav">
-                                                                                                                        @foreach (IDocument greatGreatGrandChild in OutputPages.GetChildrenOf(greatGrandChild).OnlyVisible())
-                                                                                                                        {
-                                                                                                                            <li class="nav-item">
-                                                                                                                                <a class="nav-link ps-c6 @(Document.IdEquals(greatGreatGrandChild) ? "active active-page" : null)" href="@greatGreatGrandChild.GetLink()">@greatGreatGrandChild.GetTitle()</a>
-                                                                                                                            </li>
-                                                                                                                        }
-                                                                                                                    </ul>
-                                                                                                                </div>
-                                                                                                            </li>
+                                                                                                            @if(OutputPages.GetChildrenOf(greatGrandChild).Any())
+                                                                                                            {
+                                                                                                                <li class="nav-item">
+                                                                                                                    <div class="nav-link nav-link-collapse d-flex @(Document.IdEquals(greatGrandChild) || OutputPages.GetDescendantsOf(greatGrandChild).Any(x => Document.IdEquals(x)) ? "active" : null) @(Document.IdEquals(greatGrandChild) ? "active-page" : null)">
+                                                                                                                        <button class="btn btn-collapse rounded-0 border-0 ps-c4 @(Document.IdEquals(greatGrandChild) || OutputPages.GetDescendantsOf(greatGrandChild).Any(x => Document.IdEquals(x)) ? null : "collapsed")" type="button" data-bs-toggle="collapse" aria-expanded="@(Document.IdEquals(greatGrandChild) || OutputPages.GetDescendantsOf(greatGrandChild).Any(x => Document.IdEquals(x)) ? "true" : "false")" aria-controls="id-@greatGrandChild.Id" aria-label="collapse or expand navigation" href="#id-@greatGrandChild.Id"></button>
+                                                                                                                        <a href="@greatGrandChild.GetLink()">@greatGrandChild.GetTitle()</a>
+                                                                                                                    </div>
+                                                                                                                    <div class="collapse @(Document.IdEquals(greatGrandChild) || OutputPages.GetDescendantsOf(greatGrandChild).Any(x => Document.IdEquals(x)) ? "show" : null)" id="id-@greatGrandChild.Id">
+                                                                                                                        <ul class="navbar-nav">
+                                                                                                                            @foreach (IDocument greatGreatGrandChild in OutputPages.GetChildrenOf(greatGrandChild).OnlyVisible())
+                                                                                                                            {
+                                                                                                                                <li class="nav-item">
+                                                                                                                                    <a class="nav-link ps-c6 @(Document.IdEquals(greatGreatGrandChild) ? "active active-page" : null)" href="@greatGreatGrandChild.GetLink()">@greatGreatGrandChild.GetTitle()</a>
+                                                                                                                                </li>
+                                                                                                                            }
+                                                                                                                        </ul>
+                                                                                                                    </div>
+                                                                                                                </li>
+                                                                                                            }
+                                                                                                            else
+                                                                                                            {
+                                                                                                                <li class="nav-item">
+                                                                                                                    <a class="nav-link ps-c5 @(Document.IdEquals(greatGrandChild) ? "active active-page" : null)" href="@greatGrandChild.GetLink()">@greatGrandChild.GetTitle()</a>
+                                                                                                                </li>
+                                                                                                            }
                                                                                                         }
-                                                                                                        else
-                                                                                                        {
-                                                                                                            <li class="nav-item">
-                                                                                                                <a class="nav-link ps-c5 @(Document.IdEquals(greatGrandChild) ? "active active-page" : null)" href="@greatGrandChild.GetLink()">@greatGrandChild.GetTitle()</a>
-                                                                                                            </li>
-                                                                                                        }
-                                                                                                    }
-                                                                                                </ul>
-                                                                                            </div>
-                                                                                        </li>
+                                                                                                    </ul>
+                                                                                                </div>
+                                                                                            </li>
+                                                                                        }
+                                                                                        else
+                                                                                        {
+                                                                                            <li class="nav-item">
+                                                                                                <a class="nav-link ps-c4 @(Document.IdEquals(grandChild) ? "active active-page" : null)" href="@grandChild.GetLink()">@grandChild.GetTitle()</a>
+                                                                                            </li>
+                                                                                        }
                                                                                     }
-                                                                                    else
-                                                                                    {
-                                                                                        <li class="nav-item">
-                                                                                            <a class="nav-link ps-c4 @(Document.IdEquals(grandChild) ? "active active-page" : null)" href="@grandChild.GetLink()">@grandChild.GetTitle()</a>
-                                                                                        </li>
-                                                                                    }
-                                                                                }
-                                                                            </ul>
-                                                                        </div>
-                                                                    </li>
+                                                                                </ul>
+                                                                            </div>
+                                                                        </li>
+                                                                    }
+                                                                    else
+                                                                    {
+                                                                        <li class="nav-item">
+                                                                            <a class="nav-link ps-5 @(Document.IdEquals(child) ? "active active-page" : null)" href="@child.GetLink()">@child.GetTitle()</a>
+                                                                        </li>
+                                                                    }
                                                                 }
-                                                                else
-                                                                {
-                                                                    <li class="nav-item">
-                                                                        <a class="nav-link ps-5 @(Document.IdEquals(child) ? "active active-page" : null)" href="@child.GetLink()">@child.GetTitle()</a>
-                                                                    </li>
-                                                                }
-                                                            }
-                                                        </ul>
-                                                    </div>
-                                                </li>
+                                                            </ul>
+                                                        </div>
+                                                    </li>
+                                                }
+                                                else
+                                                {
+                                                    <li class="nav-item">
+                                                        <a class="nav-link ps-c2 @(Document.IdEquals(document) ? "active active-page" : null)" href="@document.GetLink()">@document.GetTitle()</a>
+                                                    </li>
+                                                }
                                             }
-                                            else
-                                            {
-                                                <li class="nav-item">
-                                                    <a class="nav-link ps-c2 @(Document.IdEquals(document) ? "active active-page" : null)" href="@document.GetLink()">@document.GetTitle()</a>
-                                                </li>
-                                            }
-                                        }
-                                    </ul>
-                                </div>
-                            </nav>
+                                        </ul>
+                                    </div>
+                                </nav>
                             </div>
                         </div>
                         <div class="col-md-9 col-xl-10 py-3 py-md-5 mx-auto">

--- a/input/_posts.cshtml
+++ b/input/_posts.cshtml
@@ -8,7 +8,7 @@
                 <h5><a href="@Context.GetLink(post)">@post.GetString("Title")</a></h5>
                 <div class="small text-black-50">
                     @post.GetDateTime("Published").ToLongDateString() in
-                    <a href="@(topicDocument.GetLink())"><span class="badge badge-light">@topicDocument.GetTitle()</span></a>
+                    <a href="@(topicDocument.GetLink())"><span class="badge bg-primary">@topicDocument.GetTitle()</span></a>
                 </div>
                 @if (!string.IsNullOrEmpty(excerpt))
                 {

--- a/input/en-us/choco/setup.md
+++ b/input/en-us/choco/setup.md
@@ -30,7 +30,7 @@ Chocolatey installs in seconds. You are just a few steps from running choco righ
 > * If you are behind a proxy, please see <a href="#installing-behind-a-proxy">Installing behind a proxy</a>.
 > * Need completely offline solution? See <a href="#completely-offline-install">Completely Offline Install</a>.
 > * Installing the licensed edition? See [install licensed edition](xref:setup-licensed).
-> * <a class="btn-collapse-target" href="#more-install-options" data-href="#moreInstallOptions">More Options</a> / [Troubleshooting](xref:troubleshooting)
+> * <a class="btn-collapse-target" href="#more-install-options" data-collapse-target="#moreInstallOptions" role="button">More Options</a> / [Troubleshooting](xref:troubleshooting)
 
 #### Install with cmd.exe
 
@@ -74,16 +74,16 @@ The load by default is really hard to see, so you should check to ensure it is t
 
 <p><strong>Troubleshooting? Proxy? Need more options?</strong></p>
 
-<button class="btn btn-success btn-collapse collapsed" type="button" data-toggle="collapse" data-target="#moreInstallOptions" aria-expanded="false" aria-controls="moreInstallOptions">More Install Options</button>
+<button class="btn btn-success btn-collapse collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#moreInstallOptions" aria-expanded="false" aria-controls="moreInstallOptions">More Install Options</button>
 
 <div class="collapse" id="moreInstallOptions">
 
 * [Install from PowerShell v3+](#install-from-powershell-v3)
 * [Completely offline/internal install](#completely-offline-install)
 * [Install with Puppet](#install-with-puppet)
-* [Install using PowerShell from cmd.exe](#install-using-powershell-from-cmdexe)
+* [Install using PowerShell from cmd.exe](#install-using-powershell-from-cmd.exe)
 * [Install using NuGet Package Manager](#install-using-nuget-package-manager)
-* [Install using NuGet.exe from PowerShell](#install-using-nugetexe-from-powershell)
+* [Install using NuGet.exe from PowerShell](#install-using-nuget.exe-from-powershell)
 * [Install downloaded NuGet package from PowerShell](#install-downloaded-nuget-package-from-powershell)
 * [Install licensed edition](#install-licensed-edition)
 * [Installing behind a proxy](#installing-behind-a-proxy)
@@ -856,7 +856,7 @@ See [uninstall](xref:choco-uninstallation).
 
 ### I'm having trouble installing Chocolatey
 
-Make sure you've reviewed <a class="btn-collapse-target" href="#more-install-options" data-href="#moreInstallOptions">More Install Options</a> and looked over [Troubleshooting](xref:troubleshooting). If you've done those things, reach out over the mailing list or over the chat (Gitter). The links to those can be found in the open source section of https://chocolatey.org/support.
+Make sure you've reviewed <a class="btn-collapse-target" href="#more-install-options" data-collapse-target="#moreInstallOptions" role="button">More Install Options</a> and looked over [Troubleshooting](xref:troubleshooting). If you've done those things, reach out over the mailing list or over the chat (Gitter). The links to those can be found in the open source section of https://chocolatey.org/support.
 
 ### I'm getting a 403 attempting to install
 

--- a/input/en-us/choco/uninstallation.md
+++ b/input/en-us/choco/uninstallation.md
@@ -35,7 +35,7 @@ There are no warranties on this script whatsoever, but here is something you can
 > Seriously, this script may destroy your machine and require a rebuild. It may have varied results on different machines in the same environment. Think twice before running this.
 
 <p class="text-danger"><strong>Click the red button below to reveal the uninstall scripts.</strong></p>
-<button class="btn btn-danger btn-collapse collapsed" type="button" data-toggle="collapse" data-target="#uninstallScripts" aria-expanded="false" aria-controls="uninstallScripts">Yes, I understand the dangers of running these scripts</button>
+<button class="btn btn-danger btn-collapse collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#uninstallScripts" aria-expanded="false" aria-controls="uninstallScripts">Yes, I understand the dangers of running these scripts</button>
 <div id="uninstallScripts" class="collapse">
 <div class="pt-3">
 

--- a/input/en-us/chocolatey-gui/business-features/admin-only-sources.md
+++ b/input/en-us/chocolatey-gui/business-features/admin-only-sources.md
@@ -17,6 +17,6 @@ If this setting has been set to true on a source, Chocolatey GUI will no longer 
 
 Below is a short video which shows this feature in action:
 
-<div class="embed-responsive embed-responsive-700by506">
-    <iframe class="embed-responsive-item" width="700" height="506" src="https://www.youtube.com/embed/MBXnFdNMG28" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
+<div class="ratio ratio-700x506">
+    <iframe width="700" height="506" src="https://www.youtube.com/embed/MBXnFdNMG28" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
 </div>

--- a/input/en-us/chocolatey-gui/commands/feature.md
+++ b/input/en-us/chocolatey-gui/commands/feature.md
@@ -45,8 +45,8 @@ Normal:
 
 Below is a short video which shows this in action:
 
-<div class="embed-responsive embed-responsive-700by506">
-     <iframe  class="embed-responsive-item" width="700" height="506" src="https://www.youtube.com/embed/_AkDNQFoCtc" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
+<div class="ratio ratio-700x506">
+     <iframe width="700" height="506" src="https://www.youtube.com/embed/_AkDNQFoCtc" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
 </div>
 
 ## Feature Options

--- a/input/en-us/chocolatey-gui/setup/configuration/features/allow-non-admin-access-to-settings.md
+++ b/input/en-us/chocolatey-gui/setup/configuration/features/allow-non-admin-access-to-settings.md
@@ -25,8 +25,8 @@ When this setting is turned off, a non-admin user will no longer be able to acce
 
 Below is a short video which shows this feature in action:
 
-<div class="embed-responsive embed-responsive-700by506">
-    <iframe class="embed-responsive-item" width="700" height="506" src="https://www.youtube.com/embed/VCTHWo7cgW0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
+<div class="ratio ratio-700x506">
+    <iframe width="700" height="506" src="https://www.youtube.com/embed/VCTHWo7cgW0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
 </div>
 
 ## Example

--- a/input/en-us/community-repository/moderation/package-validator/rules/index.cshtml
+++ b/input/en-us/community-repository/moderation/package-validator/rules/index.cshtml
@@ -15,11 +15,11 @@ HideChildPages: true
 	<li><a href="#notes">Notes</a></li>
 </ul>
 
-<h2 class="title-child">Requirements</h2>
+<h2>Requirements</h2>
 
 <p>Requirements represent the minimum quality of a package that is acceptable. When a package version has failed requirements, the package version requires fixing and/or response by the maintainer. Provided a Requirement has flagged correctly, it must be fixed before the package version can be approved. The exact same version should be uploaded during moderation review.</p>
 
-<div class="row mt-3 mt-md-4 ml-md-n5 ml-xl-n3">
+<div class="row mt-3 mt-md-4 ms-md-n5 ms-xl-n3">
 	@foreach (IDocument child in OutputPages.GetChildrenOf(Document).OnlyRequirements())
 	{
 		object[] childTreePath = child.Get<object[]>(Keys.TreePath);
@@ -30,8 +30,8 @@ HideChildPages: true
 				<div class="circle">
 					<i class="fas fa-file" aria-hidden="true"></i>
 				</div>
-				<div class="d-flex flex-column pl-3">
-					<p class="h5 font-weight-bold card-title">@child.GetTitle()</p>
+				<div class="d-flex flex-column ps-3">
+					<p class="h5 fw-bold card-title">@child.GetTitle()</p>
 					@if (child.ContainsKey(WebKeys.Description))
 					{
 						<p class="card-content">@(child.Get(WebKeys.Description))</p>
@@ -43,11 +43,11 @@ HideChildPages: true
 	}
 </div>
 
-<h2 class="title-child">Guidelines</h2>
+<h2>Guidelines</h2>
 
 <p>Guidelines are strong suggestions that improve the quality of a package version. These are considered something to fix for next time to increase the quality of the package. Over time Guidelines can become Requirements. A package version can be approved without addressing Guideline comments but will reduce the quality of the package.</p>
 
-<div class="row mt-3 mt-md-4 ml-md-n5 ml-xl-n3">
+<div class="row mt-3 mt-md-4 ms-md-n5 ms-xl-n3">
 	@foreach (IDocument child in OutputPages.GetChildrenOf(Document).OnlyGuidelines())
 	{
 		object[] childTreePath = child.Get<object[]>(Keys.TreePath);
@@ -58,8 +58,8 @@ HideChildPages: true
 				<div class="circle">
 					<i class="fas fa-file" aria-hidden="true"></i>
 				</div>
-				<div class="d-flex flex-column pl-3">
-					<p class="h5 font-weight-bold card-title">@child.GetTitle()</p>
+				<div class="d-flex flex-column ps-3">
+					<p class="h5 fw-bold card-title">@child.GetTitle()</p>
 					@if (child.ContainsKey(WebKeys.Description))
 					{
 						<p class="card-content">@(child.Get(WebKeys.Description))</p>
@@ -71,11 +71,11 @@ HideChildPages: true
 	}
 </div>
 
-<h2 class="title-child">Suggestions</h2>
+<h2>Suggestions</h2>
 
 <p>Suggestions are either newly introduced items that will later become Guidelines or items that are don't carry enough weight to become a Guideline. Either way they should be considered. A package version can be approved without addressing Suggestion comments.</p>
 
-<div class="row mt-3 mt-md-4 ml-md-n5 ml-xl-n3">
+<div class="row mt-3 mt-md-4 ms-md-n5 ms-xl-n3">
 	@foreach (IDocument child in OutputPages.GetChildrenOf(Document).OnlySuggestions())
 	{
 		object[] childTreePath = child.Get<object[]>(Keys.TreePath);
@@ -86,8 +86,8 @@ HideChildPages: true
 				<div class="circle">
 					<i class="fas fa-file" aria-hidden="true"></i>
 				</div>
-				<div class="d-flex flex-column pl-3">
-					<p class="h5 font-weight-bold card-title">@child.GetTitle()</p>
+				<div class="d-flex flex-column ps-3">
+					<p class="h5 fw-bold card-title">@child.GetTitle()</p>
 					@if (child.ContainsKey(WebKeys.Description))
 					{
 						<p class="card-content">@(child.Get(WebKeys.Description))</p>
@@ -99,11 +99,11 @@ HideChildPages: true
 	}
 </div>
 
-<h2 class="title-child">Notes</h2>
+<h2>Notes</h2>
 
 <p>Notes typically flag things for both you and the reviewer to go over. Sometimes this is the use of things that may or may not be necessary given the constraints of what you are trying to do and/or are harder for automation to flag for other reasons. Items found in Notes might be Requirements depending on the context. A package version can be approved without addressing Note comments.</p>
 
-<div class="row mt-3 mt-md-4 ml-md-n5 ml-xl-n3">
+<div class="row mt-3 mt-md-4 ms-md-n5 ms-xl-n3">
 	@foreach (IDocument child in OutputPages.GetChildrenOf(Document).OnlyNotes())
 	{
 		object[] childTreePath = child.Get<object[]>(Keys.TreePath);
@@ -114,8 +114,8 @@ HideChildPages: true
 				<div class="circle">
 					<i class="fas fa-file" aria-hidden="true"></i>
 				</div>
-				<div class="d-flex flex-column pl-3">
-					<p class="h5 font-weight-bold card-title">@child.GetTitle()</p>
+				<div class="d-flex flex-column ps-3">
+					<p class="h5 fw-bold card-title">@child.GetTitle()</p>
 					@if (child.ContainsKey(WebKeys.Description))
 					{
 						<p class="card-content">@(child.Get(WebKeys.Description))</p>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-"@babel/code-frame@^7.10.4":
+"@babel/code-frame@^7.10.4", "@babel/code-frame@^7.12.11":
   version "7.12.11"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.12.11.tgz#f4ad435aa263db935b8f10f2c552d23fb716a63f"
   integrity sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==
@@ -35,7 +35,7 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
-"@babel/generator@^7.12.10":
+"@babel/generator@^7.12.10", "@babel/generator@^7.12.11":
   version "7.12.11"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.12.11.tgz#98a7df7b8c358c9a37ab07a24056853016aba3af"
   integrity sha512-Ggg6WPOJtSi8yYQvLVjG8F/TlpWDlKx0OpS4Kt+xMQPs5OaGYWy+v1A+1TvxI6sAMGZpKWWoAQ1DaeQbImlItA==
@@ -104,7 +104,7 @@
   dependencies:
     "@babel/types" "^7.12.1"
 
-"@babel/helper-function-name@^7.10.4":
+"@babel/helper-function-name@^7.10.4", "@babel/helper-function-name@^7.12.11":
   version "7.12.11"
   resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.12.11.tgz#1fd7738aee5dcf53c3ecff24f1da9c511ec47b42"
   integrity sha512-AtQKjtYNolKNi6nNNVLQ27CP6D9oFR6bq/HPYSizlzbp7uC1M59XJe8L+0uXjbIaZaUJF99ruHqVGiKXU/7ybA==
@@ -201,7 +201,7 @@
   dependencies:
     "@babel/types" "^7.12.1"
 
-"@babel/helper-split-export-declaration@^7.10.4", "@babel/helper-split-export-declaration@^7.11.0":
+"@babel/helper-split-export-declaration@^7.10.4", "@babel/helper-split-export-declaration@^7.11.0", "@babel/helper-split-export-declaration@^7.12.11":
   version "7.12.11"
   resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.11.tgz#1b4cc424458643c47d37022223da33d76ea4603a"
   integrity sha512-LsIVN8j48gHgwzfocYUSkO/hjYAOJqlpJEc7tGXcIm4cubjVUf8LGW6eWRyxEu7gA25q02p0rQUWoCI33HNS5g==
@@ -246,15 +246,15 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.12.10", "@babel/parser@^7.12.7":
+"@babel/parser@^7.12.10", "@babel/parser@^7.12.11", "@babel/parser@^7.12.7":
   version "7.12.11"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.12.11.tgz#9ce3595bcd74bc5c466905e86c535b8b25011e79"
   integrity sha512-N3UxG+uuF4CMYoNj8AhnbAcJF0PiuJ9KHuy1lQmkYsxTer/MAH9UBNHsBoAX/4s6NvlDD047No8mYVGGzLL4hg==
 
 "@babel/plugin-proposal-async-generator-functions@^7.12.1":
-  version "7.12.1"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.12.1.tgz#dc6c1170e27d8aca99ff65f4925bd06b1c90550e"
-  integrity sha512-d+/o30tJxFxrA1lhzJqiUcEJdI6jKlNregCv5bASeGf2Q4MXmnwH7viDo7nhx1/ohf09oaH8j1GVYG/e3Yqk6A==
+  version "7.12.12"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.12.12.tgz#04b8f24fd4532008ab4e79f788468fd5a8476566"
+  integrity sha512-nrz9y0a4xmUrRq51bYkWJIO5SBZyG2ys2qinHsN0zHDHVsUaModrkpyWWWXfGqYQmOL3x9sQIcTNN/pBGpo09A==
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
     "@babel/helper-remap-async-to-generator" "^7.12.1"
@@ -466,9 +466,9 @@
     "@babel/helper-plugin-utils" "^7.10.4"
 
 "@babel/plugin-transform-block-scoping@^7.12.11":
-  version "7.12.11"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.12.11.tgz#83ae92a104dbb93a7d6c6dd1844f351083c46b4f"
-  integrity sha512-atR1Rxc3hM+VPg/NvNvfYw0npQEAcHuJ+MGZnFn6h3bo+1U3BWXMdFMlvVRApBTWKQMX7SOwRJZA5FBF/JQbvA==
+  version "7.12.12"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.12.12.tgz#d93a567a152c22aea3b1929bb118d1d0a175cdca"
+  integrity sha512-VOEPQ/ExOVqbukuP7BYJtI5ZxxsmegTwzZ04j1aF0dkSypGo9XpDHuOrABsJu+ie+penpSJheDJ11x1BEZNiyQ==
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
 
@@ -791,24 +791,24 @@
     "@babel/types" "^7.12.7"
 
 "@babel/traverse@^7.10.4", "@babel/traverse@^7.12.1", "@babel/traverse@^7.12.10", "@babel/traverse@^7.12.5":
-  version "7.12.10"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.12.10.tgz#2d1f4041e8bf42ea099e5b2dc48d6a594c00017a"
-  integrity sha512-6aEtf0IeRgbYWzta29lePeYSk+YAFIC3kyqESeft8o5CkFlYIMX+EQDDWEiAQ9LHOA3d0oHdgrSsID/CKqXJlg==
+  version "7.12.12"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.12.12.tgz#d0cd87892704edd8da002d674bc811ce64743376"
+  integrity sha512-s88i0X0lPy45RrLM8b9mz8RPH5FqO9G9p7ti59cToE44xFm1Q+Pjh5Gq4SXBbtb88X7Uy7pexeqRIQDDMNkL0w==
   dependencies:
-    "@babel/code-frame" "^7.10.4"
-    "@babel/generator" "^7.12.10"
-    "@babel/helper-function-name" "^7.10.4"
-    "@babel/helper-split-export-declaration" "^7.11.0"
-    "@babel/parser" "^7.12.10"
-    "@babel/types" "^7.12.10"
+    "@babel/code-frame" "^7.12.11"
+    "@babel/generator" "^7.12.11"
+    "@babel/helper-function-name" "^7.12.11"
+    "@babel/helper-split-export-declaration" "^7.12.11"
+    "@babel/parser" "^7.12.11"
+    "@babel/types" "^7.12.12"
     debug "^4.1.0"
     globals "^11.1.0"
     lodash "^4.17.19"
 
-"@babel/types@^7.10.4", "@babel/types@^7.10.5", "@babel/types@^7.12.1", "@babel/types@^7.12.10", "@babel/types@^7.12.11", "@babel/types@^7.12.5", "@babel/types@^7.12.7", "@babel/types@^7.4.4":
-  version "7.12.11"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.12.11.tgz#a86e4d71e30a9b6ee102590446c98662589283ce"
-  integrity sha512-ukA9SQtKThINm++CX1CwmliMrE54J6nIYB5XTwL5f/CLFW9owfls+YSU8tVW15RQ2w+a3fSbPjC6HdQNtWZkiA==
+"@babel/types@^7.10.4", "@babel/types@^7.10.5", "@babel/types@^7.12.1", "@babel/types@^7.12.10", "@babel/types@^7.12.11", "@babel/types@^7.12.12", "@babel/types@^7.12.5", "@babel/types@^7.12.7", "@babel/types@^7.4.4":
+  version "7.12.12"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.12.12.tgz#4608a6ec313abbd87afa55004d373ad04a96c299"
+  integrity sha512-lnIX7piTxOH22xE7fDXDbSHg9MM1/6ORnafpJmov5rs0kX5g4BZxeXNJLXsMRiO0U5Rb8/FvMS6xlTnTHvxonQ==
   dependencies:
     "@babel/helper-validator-identifier" "^7.12.11"
     lodash "^4.17.19"
@@ -1191,10 +1191,10 @@ block-stream@*:
   dependencies:
     inherits "~2.0.0"
 
-bootstrap@^4.5.3:
-  version "4.5.3"
-  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.5.3.tgz#c6a72b355aaf323920be800246a6e4ef30997fe6"
-  integrity sha512-o9ppKQioXGqhw8Z7mah6KdTYpNQY//tipnkxppWhPbiSWdD+1raYsnhwEZjkTHYbGee4cVQ0Rx65EhOY/HNLcQ==
+bootstrap@^5.0.0-beta1:
+  version "5.0.0-beta1"
+  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-5.0.0-beta1.tgz#18135001a452b3ec38b344ac638a1f9549285ee7"
+  integrity sha512-UrHApw/WRmT7l2rlDdn5iXr7Jps/LlMZtJlLn9G41aGDfss48hyDeYyHtX1C6NHKVcmdUarGG+ve0LZB5iHyTQ==
 
 brace-expansion@^1.1.7:
   version "1.1.11"
@@ -1220,16 +1220,16 @@ braces@^2.3.1, braces@^2.3.2:
     split-string "^3.0.2"
     to-regex "^3.0.1"
 
-browserslist@^4.14.5, browserslist@^4.15.0:
-  version "4.16.0"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.16.0.tgz#410277627500be3cb28a1bfe037586fbedf9488b"
-  integrity sha512-/j6k8R0p3nxOC6kx5JGAxsnhc9ixaWJfYc+TNTzxg6+ARaESAvQGV7h0uNOB4t+pLQJZWzcrMxXOxjgsCj3dqQ==
+browserslist@^4.14.5, browserslist@^4.16.0:
+  version "4.16.1"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.16.1.tgz#bf757a2da376b3447b800a16f0f1c96358138766"
+  integrity sha512-UXhDrwqsNcpTYJBTZsbGATDxZbiVDsx6UjpmRUmtnP10pr8wAYr5LgFoEFw9ixriQH2mv/NX2SfGzE/o8GndLA==
   dependencies:
-    caniuse-lite "^1.0.30001165"
+    caniuse-lite "^1.0.30001173"
     colorette "^1.2.1"
-    electron-to-chromium "^1.3.621"
+    electron-to-chromium "^1.3.634"
     escalade "^3.1.1"
-    node-releases "^1.1.67"
+    node-releases "^1.1.69"
 
 buffer-equal@^1.0.0:
   version "1.0.0"
@@ -1287,10 +1287,10 @@ camelcase@^5.0.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
 
-caniuse-lite@^1.0.30001165:
-  version "1.0.30001168"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001168.tgz#6fcd098c139d003b9bd484cbb9ca26cb89907f9a"
-  integrity sha512-P2zmX7swIXKu+GMMR01TWa4csIKELTNnZKc+f1CjebmZJQtTAEXmpQSoKVJVVcvPGAA0TEYTOUp3VehavZSFPQ==
+caniuse-lite@^1.0.30001173:
+  version "1.0.30001173"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001173.tgz#3c47bbe3cd6d7a9eda7f50ac016d158005569f56"
+  integrity sha512-R3aqmjrICdGCTAnSXtNyvWYMK3YtV5jwudbq0T7nN9k4kmE4CBuwPqyJ+KBzepSTh0huivV2gLbSMEzTTmfeYw==
 
 caseless@~0.12.0:
   version "0.12.0"
@@ -1319,13 +1319,13 @@ chalk@^2.0.0, chalk@^2.3.0:
 
 "choco-theme@github:chocolatey/choco-theme":
   version "0.1.0"
-  resolved "https://codeload.github.com/chocolatey/choco-theme/tar.gz/c243e61fa3bcf190e8228d399d3588d147d92844"
+  resolved "https://codeload.github.com/chocolatey/choco-theme/tar.gz/4bc44f95242fabede9c3124121f7866f2738f3a8"
   dependencies:
     "@babel/core" "^7.12.3"
     "@babel/preset-env" "^7.12.1"
     "@fortawesome/fontawesome-free" "^5.15.1"
     anchor-js "^4.3.0"
-    bootstrap "^4.5.3"
+    bootstrap "^5.0.0-beta1"
     docsearch.js "^2.6.3"
     gulp "^4.0.2"
     gulp-babel "^8.0.0"
@@ -1539,11 +1539,11 @@ copy-props@^2.0.1:
     is-plain-object "^2.0.1"
 
 core-js-compat@^3.8.0:
-  version "3.8.1"
-  resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.8.1.tgz#8d1ddd341d660ba6194cbe0ce60f4c794c87a36e"
-  integrity sha512-a16TLmy9NVD1rkjUGbwuyWkiDoN0FDpAwrfLONvHFQx0D9k7J9y0srwMT8QP/Z6HE3MIFaVynEeYwZwPX1o5RQ==
+  version "3.8.2"
+  resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.8.2.tgz#3717f51f6c3d2ebba8cbf27619b57160029d1d4c"
+  integrity sha512-LO8uL9lOIyRRrQmZxHZFl1RV+ZbcsAkFWTktn5SmH40WgLtSNYN4m4W2v9ONT147PxBY/XrRhrWq8TlvObyUjQ==
   dependencies:
-    browserslist "^4.15.0"
+    browserslist "^4.16.0"
     semver "7.0.0"
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
@@ -1724,10 +1724,10 @@ ecc-jsbn@~0.1.1:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
 
-electron-to-chromium@^1.3.621:
-  version "1.3.628"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.628.tgz#be5a14ddf3a455de876274c84de0926439a287a7"
-  integrity sha512-fmhO4YGo/kapy+xL9Eq/cZwDASaTHZu3psIFYo4yc+RY1LzbZr84xjKlDImDrlrmWhOxsrDi98nX097U/xK/cQ==
+electron-to-chromium@^1.3.634:
+  version "1.3.634"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.634.tgz#82ea400f520f739c4f6ff00c1f7524827a917d25"
+  integrity sha512-QPrWNYeE/A0xRvl/QP3E0nkaEvYUvH3gM04ZWYtIa6QlSpEetRlRI1xvQ7hiMIySHHEV+mwDSX8Kj4YZY6ZQAw==
 
 emoji-regex@^7.0.1:
   version "7.0.3"
@@ -2145,9 +2145,9 @@ get-caller-file@^2.0.1:
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
 get-intrinsic@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.0.1.tgz#94a9768fcbdd0595a1c9273aacf4c89d075631be"
-  integrity sha512-ZnWP+AmS1VUaLgTRy47+zKtjTxz+0xMpx3I52i+aalBK1QP19ggLF3Db89KJX7kjfOfP2eoa01qc++GwPgufPg==
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.0.2.tgz#6820da226e50b24894e08859469dc68361545d49"
+  integrity sha512-aeX0vrFm21ILl3+JpFFRNe9aUvp6VFZb2/CTbgLb8j75kOhvoNYjt9d8KA/tJG4gSo8nzEDedRl0h7vDmBYRVg==
   dependencies:
     function-bind "^1.1.1"
     has "^1.0.3"
@@ -3045,17 +3045,17 @@ micromatch@^3.0.4, micromatch@^3.1.10, micromatch@^3.1.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.2"
 
-mime-db@1.44.0:
-  version "1.44.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.44.0.tgz#fa11c5eb0aca1334b4233cb4d52f10c5a6272f92"
-  integrity sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==
+mime-db@1.45.0:
+  version "1.45.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.45.0.tgz#cceeda21ccd7c3a745eba2decd55d4b73e7879ea"
+  integrity sha512-CkqLUxUk15hofLoLyljJSrukZi8mAtgd+yE5uO4tqRZsdsAJKv0O+rFMhVDRJgozy+yG6md5KwuXhD4ocIoP+w==
 
 mime-types@^2.1.12, mime-types@~2.1.19:
-  version "2.1.27"
-  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.27.tgz#47949f98e279ea53119f5722e0f34e529bec009f"
-  integrity sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==
+  version "2.1.28"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.28.tgz#1160c4757eab2c5363888e005273ecf79d2a0ecd"
+  integrity sha512-0TO2yJ5YHYr7M2zzT7gDU1tbwHxEUWBCLt0lscSNpcdAfFyJOVEpRYNS7EXVcTLNj/25QO8gulHC5JtTzSE2UQ==
   dependencies:
-    mime-db "1.44.0"
+    mime-db "1.45.0"
 
 min-document@^2.19.0:
   version "2.19.0"
@@ -3202,10 +3202,10 @@ node-gyp@^7.1.0:
     tar "^6.0.2"
     which "^2.0.2"
 
-node-releases@^1.1.67:
-  version "1.1.67"
-  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.67.tgz#28ebfcccd0baa6aad8e8d4d8fe4cbc49ae239c12"
-  integrity sha512-V5QF9noGFl3EymEwUYzO+3NTDpGfQB4ve6Qfnzf3UNydMhjQRVPR1DZTuvWiLzaFJYw2fmDwAfnRNEVb64hSIg==
+node-releases@^1.1.69:
+  version "1.1.69"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.69.tgz#3149dbde53b781610cd8b486d62d86e26c3725f6"
+  integrity sha512-DGIjo79VDEyAnRlfSqYTsy+yoHd2IOjJiKUozD2MV2D85Vso6Bug56mb9tT/fY5Urt0iqk01H7x+llAruDR2zA==
 
 node-sass@^4.8.3:
   version "4.14.1"
@@ -3604,9 +3604,9 @@ postcss-selector-parser@^6.0.2:
     util-deprecate "^1.0.2"
 
 postcss@^8.2.1:
-  version "8.2.1"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.2.1.tgz#eabc5557c4558059b9d9e5b15bce7ffa9089c2a8"
-  integrity sha512-RhsqOOAQzTgh1UB/IZdca7F9WDb7SUCR2Vnv1x7DbvuuggQIpoDwjK+q0rzoPffhYvWNKX5JSwS4so4K3UC6vA==
+  version "8.2.2"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.2.2.tgz#60613b62297005084fd21024a68637798864fe26"
+  integrity sha512-HM1NDNWLgglJPQQMNwvLxgH2KcrKZklKLi/xXYIOaqQB57p/pDWEJNS83PVICYsn1Dg/9C26TiejNr422/ePaQ==
   dependencies:
     colorette "^1.2.1"
     nanoid "^3.1.20"
@@ -4739,9 +4739,9 @@ xtend@~4.0.0, xtend@~4.0.1:
   integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
 
 y18n@^3.2.1:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/y18n/-/y18n-3.2.1.tgz#6d15fba884c08679c0d77e88e7759e811e07fa41"
-  integrity sha1-bRX7qITAhnnA136I53WegR4H+kE=
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-3.2.2.tgz#85c901bd6470ce71fc4bb723ad209b70f7f28696"
+  integrity sha512-uGZHXkHnhF0XeeAPgnKfPv1bgKAYyVvmNL1xlKsPYZPaIHxGti2hHqvOCQv71XMsLxu1QjergkqogUnms5D3YQ==
 
 y18n@^4.0.0:
   version "4.0.1"


### PR DESCRIPTION
> ### ⚠️ Choco-theme must be updated and pulled in for this to work. See https://github.com/chocolatey/choco-theme/pull/27.

The choco-theme has been updated to Bootstrap v5. As a result, many of
the classes used have been updated. Find more information on this
update in the choco-theme repository and the Bootstrap documentation.

Bootstrap 5 Migration:
https://getbootstrap.com/docs/5.0/migration/