### PR TITLE
(#149) Update Organizational Documentation for trials

### DIFF
--- a/input/en-us/guides/organizations/organizational-deployment-guide.md
+++ b/input/en-us/guides/organizations/organizational-deployment-guide.md
@@ -101,7 +101,7 @@ For Chocolatey clients, you will need the following:
 
 ### Chocolatey Repository Servers
 
-Unforunately it's harder to make recommendations here as it is really dependent on the repository that you choose and what requirements they have. It varies from a Windows deployment to Linux deployed repositories, from Java-based, to .NET-based, to PHP, and Rust-based repositories. The requirements vary wildly, plus you may use those repositories that address multiple types of packages and would need to figure out the space available for that.
+Unfortunately it's harder to make recommendations here as it is really dependent on the repository that you choose and what requirements they have. It varies from a Windows deployment to Linux deployed repositories, from Java-based, to .NET-based, to PHP, and Rust-based repositories. The requirements vary wildly, plus you may use those repositories that address multiple types of packages and would need to figure out the space available for that.
 
 **SPACE RECOMMENDATION**: Have enough space for 10x the size of the installers and other software you will store. This will allow for some default growth. We would recommend 100 GB at a minimum.
 
@@ -124,26 +124,20 @@ From the machine with internet access:
 1. NONADMIN (**only**): We'll need to redirect Chocolatey not to install to the default location. Run `$env:ChocolateyInstall="$env:ProgramData\chocoportable"` and press enter.
 1. Now run `Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))` (this will get Chocolatey installed and it is what you see at https://chocolatey.org/install). It also makes choco available in that current shell. If you run into proxy issues here, please see [installing Chocolatey behind a proxy server](xref:proxy-settings).
 1. C4B / MSP / C4BTRIAL: Obtain the `chocolatey.license.xml` from the email sent from the Chocolatey team and save the license file to `c:\choco-setup\files` so we can use it here and on the offline machines.
-1. C4BTRIAL: grab a copy of the two nupkgs from the email. If you don't have that email with the download links, request it from whoever provided you the trial license. Save those two packages to `c:\choco-setup\packages`.
 1. C4B / MSP / C4BTRIAL: Run this command `New-Item $env:ChocolateyInstall\license -ItemType Directory -Force` - this creates the license directory.
 1. C4B / MSP / C4BTRIAL: Copy the license file ("chocolatey.license.xml") into that folder that was just created. Run `Copy-Item "$env:SystemDrive\choco-setup\files\chocolatey.license.xml" $env:ChocolateyInstall\license\chocolatey.license.xml -Force`.
 1. C4B / MSP / C4BTRIAL: Verify the license is recognized - run `choco`. You should see something like "Chocolatey v0.10.8 Business". You will see what looks like an error message about not having chocolatey.extension installed. That's a warning and we can ignore that for now.
    > :warning: **WARNING**
    >
    > It is normal to see an error at this point, the next steps which install the extension resolve this.
-1. C4B / MSP: Run `choco upgrade chocolatey.extension -y`. You will see what looks like an error message about not having chocolatey.extension installed. That's a warning and should clear up when this command completes.
-   > :warning: **WARNING**
-   >
-   > If you have a C4BTRIAL, you do **NOT** run this step as it doesn't start with "C4BTRIAL". See the next step.
-1. C4BTRIAL: Run `choco upgrade chocolatey.extension -y --pre --source c:\choco-setup\packages` (this is where you saved the nupkgs earlier).
+1. C4B / MSP / C4BTRIAL: Run `choco upgrade chocolatey.extension -y`. You will see what looks like an error message about not having chocolatey.extension installed. That's a warning and should clear up when this command completes.
 1. Run `choco` - you should no longer see the error about not having chocolatey.extension installed. If you do, please circle back and use copy/paste for instructions as you may have mistyped something.
 1. Run `choco config set cacheLocation $env:ALLUSERSPROFILE\choco-cache`. This moves the TEMP location in scripts to use this and makes clean up more deterministic.
 1. Run `choco config set commandExecutionTimeoutSeconds 14400`. This increases the timeout more than the default 45 minutes, you may wish to set it higher.
 1. C4B / MSP / C4BTRIAL: Run `choco feature enable --name="'internalizeAppendUseOriginalLocation'"`. This sets Package Internalizer to append `-UseOriginalLocation` to the end of `Install-ChocolateyPackage` to make it behave more like `Install-ChocolateyInstallPackage`. Since the files are local, we won't need it copying them to temp prior to running it.
 1. C4B / MSP / C4BTRIAL: Run `choco feature enable --name="'reduceInstalledPackageSpaceUsage'"` to ensure Package Reducer is turned on.
 1. Set proxy configuration, virus scan configuration, or other configuration as described at [Chocolatey configuration](xref:configuration).
-1. C4B: Are we installing the [optional Chocolatey Agent Service as well](xref:setup-agent)? If so, run `choco upgrade chocolatey-agent -y --pre` and then follow the link in the first sentence for other settings you will need to configure.
-1. C4BTRIAL: Are we installing the [optional Chocolatey Agent Service as well](xref:setup-agent)? If so, run `choco upgrade chocolatey-agent -y --pre --source c:\choco-setup\packages` (this is where you saved the nupkgs earlier). Then follow the link in the first sentence for other settings you will need to configure.
+1. C4B / C4BTRIAL: Are we installing the [optional Chocolatey Agent Service as well](xref:setup-agent)? If so, run `choco upgrade chocolatey-agent -y --pre` and then follow the link in the first sentence for other settings you will need to configure.
 1. Download packages (choose one):
     * C4B / MSP / C4BTRIAL: - Run the following: `choco download chocolatey chocolatey.server dotnet4.6.1 chocolateygui --internalize`. This is going to take quite awhile.
     * FOSS only - download the following packages:
@@ -155,8 +149,8 @@ From the machine with internet access:
         * [dotnet4.6.1](https://chocolatey.org/api/v2/package/DotNet4.6.1) - [internalize manually](xref:recompile-packages)
         * [KB2919355](https://chocolatey.org/api/v2/package/KB2919355) - [internalize manually](xref:recompile-packages)
         * [KB2919442](https://chocolatey.org/api/v2/package/KB2919442) - [internalize manually](xref:recompile-packages)
-1. C4B - Run the following additionally: `choco download chocolatey.extension chocolatey-agent --internalize`. C4BTRIAL - you should already have placed these nupkgs in the folder earlier.
-1. MSP - Run the following additionally: `choco download chocolatey.extension --internalize`. C4BTRIAL - you should already have placed these nupkgs in the folder earlier.
+1. C4B / C4BTRIAL - Run the following additionally: `choco download chocolatey.extension chocolatey-agent --internalize`.
+1. MSP - Run the following additionally: `choco download chocolatey.extension --internalize`.
 1. Now we should have several packages in `c:\choco-setup\packages`. If not, type `start .` and go copy the files here to that location.
 1. Obtain the PowerShell script from the [complete offline install setup section](xref:setup-choco#completely-offline-install) and copy it to `c:\choco-setup\files` as "ChocolateyLocalInstall.ps1". We will need this to install Chocolatey on the airgapped box.
 1. Open `c:\choco-setup\files\ChocolateyLocalInstall.ps1` in an editor like Notepad++ or Visual Studio Code (do not use Notepad.exe!!).
@@ -191,9 +185,7 @@ Copy-Item $env:SystemDrive\choco-setup\files\chocolatey.license.xml $env:Chocola
 
 # Install Chocolatey Licensed Extension
 choco upgrade chocolatey.extension -y --pre
-Write-Host "If you see what looks like an error about a missing extension, that is what this step does so it will clear up on next command."
-# C4BTRIAL: Place nupkgs into the "$env:SystemDrive\choco-setup\packages" directory (add a script here to do so)
-# C4BTRIAL: Run this instead: choco upgrade chocolatey.extension --pre --source c:\choco-setup\packages
+Write-Host "If you see what looks like an error about a missing extension, that is what this step does so it will clear up on the next command."
 
 # Set Configuration
 choco config set cacheLocation $env:ALLUSERSPROFILE\choco-cache
@@ -218,11 +210,10 @@ choco feature enable --name="'reduceInstalledPackageSpaceUsage'"
 
 # Download and internalize packages.
 choco download chocolatey chocolatey.server dotnet4.6.1 chocolateygui --internalize --output-directory="$env:SystemDrive\choco-setup\packages" --source="'https://chocolatey.org/api/v2/'"
-# C4BTRIAL: skip this next step
-# C4B - use this
-choco download chocolatey.extension chocolatey-agent --internalize --output-directory="$env:SystemDrive\choco-setup\packages" --source="'https://licensedpackages.chocolatey.org/api/v2/'" # will fail on trial
+# C4B / C4BTRIAL - use this
+choco download chocolatey.extension chocolatey-agent --internalize --output-directory="$env:SystemDrive\choco-setup\packages" --source="'https://licensedpackages.chocolatey.org/api/v2/'"
 # MSP - use this
-#choco download chocolatey.extension --internalize --output-directory="$env:SystemDrive\choco-setup\packages" --source="'https://licensedpackages.chocolatey.org/api/v2/'" # will fail on trial
+#choco download chocolatey.extension --internalize --output-directory="$env:SystemDrive\choco-setup\packages" --source="'https://licensedpackages.chocolatey.org/api/v2/'"
 
 # Download local install script - need at least PowerShell v3
 $installScript = iwr -UseBasicParsing -Uri https://gist.githubusercontent.com/ferventcoder/d0aa1703a7d302fce79e7a4cc13797c0/raw/b1f7bad2441fa6c371b48b8475ef91cecb4d6370/ChocolateyLocalInstall.ps1 -UseDefaultCredentials

--- a/input/en-us/licensed-extension/setup.md
+++ b/input/en-us/licensed-extension/setup.md
@@ -45,14 +45,16 @@ Here's the whole process for installing your license and installing the licensed
 
 ## How Do I Install The Licensed Edition?
 
-> :memo: **NOTE** Prior to install, see if there are any parameters (like turning off context menus) that you may want to set. See [install options](#install-options).
+> :memo: **NOTE**
+>
+> Prior to install, see if there are any parameters (like turning off context menus) that you may want to set. See [install options](#install-options).
 
 
 > :warning: **WARNING**
 >
 > Order is **VERY** important here. You need license file placed, then `chocolatey.extension`, then any other licensed components. Expect issues if you don't follow this order exactly.
 
- 1. Install a recent version of Chocolatey (0.10.8+) - `choco upgrade chocolatey` (due to a tight integration, `chocolatey.extension` may need a newer version than what is listed here). TRIAL? You need to do more as your license key will not be known by the server. See [Install the Trial Edition](#how-do-i-install-the-trial-edition).
+ 1. Install a recent version of Chocolatey (0.10.8+) - `choco upgrade chocolatey` (due to a tight integration, `chocolatey.extension` may need a newer version than what is listed here).
  1. You received a license file in email.
  1. Open PowerShell.exe as an administrative shell. You can type Windows Key + X + A (Windows 8+ - when that comes up if it is cmd.exe, simply type `powershell` to get into it).
  1. In PowerShell, run `New-Item $env:ChocolateyInstall\license -Type Directory -Force` - this creates the license directory. Alternatively, you can put the license in your user profile directory, e.g. `"C:\Users\YourUserName\chocolatey.license.xml"`, however we only recommend you do this for Professional licenses as for other licensing you may need it to be recognized by multiple users.
@@ -81,27 +83,8 @@ See the next section - the logic is quite similar.
 
 ### How Do I Install The Trial Edition?
 
-If you've received a trial license, you will also receive a link to download a recent version of the `chocolatey.extension` package. **You will not be able to install or upgrade the licensed edition through regular means. Chocolatey may add the licensed source, but your license will not be recognized on the server.**
-
-> :memo: **NOTE** Prior to install, see if there are any parameters (like turning off context menus) that you may want to set. See [install options](#install-options).
-
-> :warning: **WARNING**
->
-> Order is **VERY** important here. You need license file placed, then `chocolatey.extension`, then any other licensed components. Expect issues if you don't follow this order exactly.
-
- 1. Install a recent version of Chocolatey (0.10.8+) - `choco upgrade chocolatey` (due to a tight integration, `chocolatey.extension` may need a newer version than what is listed here).
- 1. You received a license file in email. **That email also contains links to download licensed nupkgs.** If you received the license file from another party but not the email, please ask them to forward it over to you as you will need it.
- 1. Obtain the `chocolatey.license.xml` and download the licensed nupkgs from the locations noted in the trial license email to a local folder. Note this location, you will need it later.
- 1. Open PowerShell.exe as an administrative shell. You can type Windows Key + X + A (Windows 8+ - when that comes up if it is cmd.exe, simply type `powershell` to get into it).
- 1. In PowerShell, run `New-Item $env:ChocolateyInstall\license -Type Directory -Force` - this creates the license directory. Alternatively, you can put the license in your user profile directory, e.g. `"C:\Users\YourUserName\chocolatey.license.xml"`, however we only recommend you do this for Professional licenses as for other licensing you may need it to be recognized by multiple users.
- 1. Now place that license file in that license folder. You can do this manually, or you can adapt this PowerShell command - `Copy-Item <c:\path\>chocolatey.license.xml $env:ChocolateyInstall\license\chocolatey.license.xml -Force`. (See image below)
- 1. Verify the license file is set properly. In PowerShell, run `type $env:ChocolateyInstall\license\chocolatey.license.xml.` If that returns something, it means you are good to go. If not, something is misspelled or misplaced somewhere.
- 1. Run this command: `choco upgrade chocolatey.extension --pre --source c:\folder\where\downloaded\nupkg\resides` (or you can use `install` instead of `upgrade`).
-     > :memo: **NOTE** Source location is not `--source c:\downloads\chocolatey.extension.1.8.1.nupkg`, it is `--source c:\downloads`. You will see an error you can safely ignore.
- 1. Run this command: `choco`. You should not see any error message logged anymore (like you saw in the previous run asking you to install the licensed extension). If you do see an error message still, you may need to revisit these steps and determine what might have been missed or mistyped.
- 1. That's it! You are good to go.
-
-See the difference between the trial install here and [a fully licensed edition](#how-do-i-install-the-licensed-edition) (also see the pictures above).
+Trial licenses can be installed in the same way as full Business or Professional licenses.
+See [How do I install the Licensed Edition?](#how-do-i-install-the-licensed-edition) above.
 
 #### Notes on the Trial Version
 
@@ -561,7 +544,7 @@ If neither of these have resolved the issue, the following steps should remedy t
 * Run `choco uninstall chocolatey.extension`.
 * Add the license file again - rename the `licensed` folder back to `license`.
 * Run `choco upgrade chocolatey.extension`.
-* Compare the current `chocolatey.config to your backed up `chocolatey.config` and set anything that was reset in this process.
+* Compare the current `chocolatey.config` to your backed up `chocolatey.config` and set anything that was reset in this process.
 
 ### Error when registering components
 


### PR DESCRIPTION
Remove mentions of trials needing to manually download packages from their trial emails; we will no longer need those steps to differ from fully licensed customers when the licensed package feed is updated.

Included a few small formatting / minor spelling fixes that I happened to catch as I was looking through.

Fixes #149