### PR TITLE
(#163) Adjust wording around VMware tools for esxi

### DIFF
--- a/input/en-us/quick-deployment/setup/index.md
+++ b/input/en-us/quick-deployment/setup/index.md
@@ -223,7 +223,8 @@ Steps to create a QDE virtual machine in Azure:
 
 > :memo: **NOTE**
 >
-> Upon first booting the environment in ESXi 6.7 the mouse will not be available to the VM when using the HTML modal console control. You will need to use rather RDP or VMRC (VMWare Remote Console) to access the VM and install VMWare Tools.
+> Upon first booting the environment in ESXi with the HTML modal console control, the mouse will not be available to the VM.
+> We recommend you use either RDP or VMRC (VMWare Remote Console) to access the VM initially and install VMWare Tools.
 > Once VMWare Tools is installed, the mouse and other advanced VM functionality will be made available to the VM.
 
 ### Platform: VMware (VMDK file)


### PR DESCRIPTION
Wording here was version-specific, which may lead to folks getting the wrong impression about past and/or future versions of ESXi.

Instead, reworded it to be more focused around the type of VM remote access used, and recommend installing VMware Tools via one of the other known working VM remote access methods.