### PR TITLE
Mention .skipAutoInstall in docs

### DIFF
--- a/input/en-us/create/functions/uninstall-chocolateypackage.md
+++ b/input/en-us/create/functions/uninstall-chocolateypackage.md
@@ -50,6 +50,10 @@ auto uninstaller.
 May not be required. Starting in 0.9.10+, the Automatic Uninstaller
 (AutoUninstaller) is turned on by default.
 
+If your script performs full uninstallation by itself and would like
+to avoid warnings by auto installer, you can disable it for the
+package by creating a special file named `tools/.skipAutoUninstall`.
+
 ## Aliases
 
 None


### PR DESCRIPTION
Inspired by this StackOverflow question: https://stackoverflow.com/questions/45871385/is-there-a-way-to-disable-autouninstaller-from-uninstaller-file

I personally think it's better to have such behavior described somewhere in the official documents.

My case in point (pending moderator review, so may not be correct at all, actually): https://community.chocolatey.org/packages/logitech-camera-settings , the uninstaller is NSIS, but is not auto-detected by the Auto Uninstaller for some reason, so I called it manually