### PR TITLE
Add Cloudsmith to host-packages.md

### DIFF
--- a/input/en-us/features/host-packages.md
+++ b/input/en-us/features/host-packages.md
@@ -220,6 +220,7 @@ These are simple servers that have more advanced options and authentication scen
 
 #### Commercial Options
 
+* [Cloudsmith](https://cloudsmith.com/nuget-feed/) ([NuGet Documentation](https://help.cloudsmith.io/docs/nuget-feed))
 * Sonatype Nexus - [Nexus2](https://books.sonatype.com/nexus-book/reference/nuget-nuget_hosted_repositories.html) / [Nexus3](https://books.sonatype.com/nexus-book/3.0/reference/nuget.html#nuget-hosted)
 * [ProGet](http://inedo.com/support/documentation/proget/installation/installation-guide)
 * [Artifactory Pro](http://www.jfrog.com/confluence/display/RTF/NuGet+Repositories)


### PR DESCRIPTION
Hello! <3 Chocolatey.

This PR proposes to add [Cloudsmith](https://cloudsmith.com) to the list of SaaS package management services that support Chocolatey (NuGet v2). Cloudsmith is a fully managed platform for package management, and supports Chocolatey/NuGet, plus 22+ other formats.

We have conversations with our customers often about Chocolatey and support for it, especially when they ask about best practices for Windows packaging. So it made sense to list here as well, and to show our support with a reciprocal link. :-)

If you've got any questions, please let us know!