### PR TITLE
(#186) Fixes link to installChocolatey.cmd

### DIFF
--- a/input/en-us/choco/setup.md
+++ b/input/en-us/choco/setup.md
@@ -609,7 +609,7 @@ SET DIR=%~dp0%
 %systemroot%\System32\WindowsPowerShell\v1.0\powershell.exe -NoProfile -ExecutionPolicy Bypass -Command "& '%DIR%install.ps1' %*"
 ~~~
 
-You can also get to this file by going to [https://chocolatey.org/installchocolatey.cmd](https://chocolatey.org/installchocolatey.cmd).
+You can also get to this file by going to [https://chocolatey.org/installChocolatey.cmd](https://chocolatey.org/installChocolatey.cmd).
 
 If you prefer to have the install.ps1 file already, comment out the download line in the batch file and download the [`install.ps1`](https://chocolatey.org/install.ps1) from [chocolatey.org](https://chocolatey.org/install.ps1) and save it as `install.ps1` next to the `installChocolatey.cmd` file.
 


### PR DESCRIPTION
Our current link was mis-cased, and our configuration currently requires a correctly cased link. 

This fixes the link in the Setup documentation.