### PR TITLE
(#188) Add example configuration for Windows Defender to VirusScanner docs

### DIFF
--- a/input/en-us/features/virus-check.md
+++ b/input/en-us/features/virus-check.md
@@ -61,11 +61,11 @@ In `genericVirusScannerValidExitCodes`, these are exit codes that indicate that 
 #### Windows Defender Example Configuration
 
 ```powershell
-choco config set virusScannerType Generic
-choco config set genericVirusScannerPath "C:\Program Files\Windows Defender\MpCmdRun.exe"
-choco config set genericVirusScannerArgs "-Scan -ScanType 3 -File [[FILE]]"
-choco config set genericVirusScannerValidExitCodes "0"
-choco feature enable -n virusCheck
+choco config set --name="'virusScannerType'" --value="'Generic'"
+choco config set --name="'genericVirusScannerPath'" --value="'C:\Program Files\Windows Defender\MpCmdRun.exe'"
+choco config set --name="'genericVirusScannerArgs'" --value="'-Scan -ScanType 3 -File [[FILE]]'"
+choco config set --name="'genericVirusScannerValidExitCodes'" --value="'0'"
+choco feature enable --name="'virusCheck'"
 ```
 
 ## See It In Action

--- a/input/en-us/features/virus-check.md
+++ b/input/en-us/features/virus-check.md
@@ -58,6 +58,16 @@ In `genericVirusScannerArgs`, these are the arguments that Chocolatey will pass 
 
 In `genericVirusScannerValidExitCodes`, these are exit codes that indicate that a binary is okay. This defaults to `0`, but you can configure this with as many exit codes as necessary by adding them to the configuration as comma separated values.
 
+#### Windows Defender Example Configuration
+
+```powershell
+choco config set virusScannerType Generic
+choco config set genericVirusScannerPath "C:\Program Files\Windows Defender\MpCmdRun.exe"
+choco config set genericVirusScannerArgs "-Scan -ScanType 3 -File [[FILE]]"
+choco config set genericVirusScannerValidExitCodes "0"
+choco feature enable -n virusCheck
+```
+
 ## See It In Action
 
 ![Pro install in action](/assets/images/gifs/chocopro_install_stopped.gif)


### PR DESCRIPTION
Adds a complete configuration for using Windows Defender with Virus Scanner to the docs.