### PR TITLE
(#200) Corrects QDE v1 Links to v2 Documents

### DIFF
--- a/input/en-us/quick-deployment/v1/client-setup.md
+++ b/input/en-us/quick-deployment/v1/client-setup.md
@@ -9,7 +9,7 @@ RedirectFrom: docs/quick-deployment-client-setup-v1
 > :memo: **NOTE**
 >
 > This document is for **Version 1** of the Quick Deployment Environment.
-> If you're using a newer version of QDE, please refer to the [newer QDE Client Setup page](xref:v1-client-setup).
+> If you're using a newer version of QDE, please refer to the [newer QDE Client Setup page](xref:v2-client-setup).
 
 ## Summary
 

--- a/input/en-us/quick-deployment/v1/desktop-readme.md
+++ b/input/en-us/quick-deployment/v1/desktop-readme.md
@@ -9,7 +9,7 @@ RedirectFrom: docs/quick-deployment-desktop-readme-v1
 > :memo: **NOTE**
 >
 > This document is for **Version 1** of the Quick Deployment Environment.
-> If you're using a newer version of QDE, please refer to the [newer QDE Desktop Readme page](xref:v1-desktop-readme).
+> If you're using a newer version of QDE, please refer to the [newer QDE Desktop Readme page](xref:v2-desktop-readme).
 
 This system has been pre-configured as a fully functioning C4B environment.
 

--- a/input/en-us/quick-deployment/v1/firewall-changes.md
+++ b/input/en-us/quick-deployment/v1/firewall-changes.md
@@ -9,7 +9,7 @@ RedirectFrom: docs/quick-deployment-firewall-changes-v1
 > :memo: **NOTE**
 >
 > This document is for **Version 1** of the Quick Deployment Environment.
-> If you're using a newer version of QDE, please refer to the [newer QDE Firewall Changes page](xref:v1-firewall-changes).
+> If you're using a newer version of QDE, please refer to the [newer QDE Firewall Changes page](xref:v2-firewall-changes).
 
 ## External Ports
 

--- a/input/en-us/quick-deployment/v1/index.md
+++ b/input/en-us/quick-deployment/v1/index.md
@@ -2,5 +2,5 @@
 Order: 30
 xref: v1-qde
 Title: QDE v1
-Description: Information about the initial release of the Chocolatey Quick Depolyment Environment
+Description: Information about the initial release of the Chocolatey Quick Deployment Environment
 ---

--- a/input/en-us/quick-deployment/v1/ssl-setup.md
+++ b/input/en-us/quick-deployment/v1/ssl-setup.md
@@ -11,7 +11,7 @@ RedirectFrom: docs/quick-deployment-ssl-setup-v1
 > :memo: **NOTE**
 >
 > This document is for **Version 1** of the Quick Deployment Environment.
-> If you're using a newer version of QDE, please refer to the [newer QDE SSL Setup page](xref:v1-ssl-setup).
+> If you're using a newer version of QDE, please refer to the [newer QDE SSL Setup page](xref:v2-ssl-setup).
 
 All services have been protected with Self-Signed SSL certificates and are placed in the appropriate stores.
 Under the following situations you would want to run the script that follows:


### PR DESCRIPTION
Some links were incorrectly pointing to the document they were in. This commit fixes that, and a single typo.