### PR TITLE
(fix) Fixes Preview.ps1 running from PWDs other than repository root

### DIFF
--- a/preview.ps1
+++ b/preview.ps1
@@ -1,2 +1,7 @@
-dotnet tool restore
-dotnet cake
+try {
+    Push-Location $PSScriptRoot
+    dotnet tool restore
+    dotnet cake
+} finally {
+    Pop-Location
+}


### PR DESCRIPTION
Previously, this would fail if you weren't in the repository. After some discussion, this was judged to be a reasonable way to fix it.