### PR TITLE
WIP: Provide Tab Shell for UI

### DIFF
--- a/input/en-us/central-management/setup/database.md
+++ b/input/en-us/central-management/setup/database.md
@@ -170,6 +170,32 @@ The CCM database package will add or update a database to an existing SQL Server
 
 ### Scenarios
 
+<ul class="nav nav-tabs" role="tablist">
+    <li class="nav-item">
+        <a class="nav-link active" id="scenario-one-tab" data-bs-toggle="tab" href="#scenario-one" role="tab" aria-controls="scenario-one" aria-selected="true">Scenario 1</a>
+    </li>
+    <li class="nav-item">
+        <a class="nav-link" id="scenario-two-tab" data-bs-toggle="tab" href="#scenario-two" role="tab" aria-controls="scenario-two" aria-selected="false">Scenario 2</a>
+    </li>
+    <li class="nav-item">
+        <a class="nav-link" id="scenario-three-tab" data-bs-toggle="tab" href="#scenario-three" role="tab" aria-controls="scenario-three" aria-selected="false">Scenario 3</a>
+    </li>
+</ul>
+
+::::{.tab-content .text-bg-theme-elevation-1 .p-3 .mb-3 .border-start .border-end .border-bottom .rounded-bottom}
+:::{.tab-pane .fade .show .active #scenario-one role=tabpanel aria-labelledby=scenario-one-tab}
+## Scenario 1
+
+Markdown can be added here!
+:::
+:::{.tab-pane .fade #scenario-two role=tabpanel aria-labelledby=scenario-two-tab}
+## Scenario 2
+:::
+:::{.tab-pane .fade #scenario-three role=tabpanel aria-labelledby=scenario-three-tab}
+## Scenario 3
+:::
+::::
+
 #### SQL Server Windows Authentication
 
 ##### Use Windows Authentication to Local SQL Server


### PR DESCRIPTION
While providing a tabbed interface completely in markdown isn't
possibly with the current set up, the tab pane content area is. This
provides a shell tab area for content to be added in as necessary.

Currently, there is a known issue where any headers inside the tabbed
area are added into the right hand navigation, but are not navigatable
unless the selected tab pane is already open.

This will render as below:
<img width="815" alt="Screen Shot 2021-08-17 at 1 24 13 PM" src="https://user-images.githubusercontent.com/42750725/129780382-ff7b5a90-aa9e-458d-a249-a75e681d259c.png">
