### PR TITLE
Update uninstall script for fix PATH clean failure

### DIFF
--- a/input/en-us/choco/uninstallation.md
+++ b/input/en-us/choco/uninstallation.md
@@ -74,7 +74,7 @@ if (-not (Test-Path $env:ChocolateyInstall)) {
 $userKey = [Microsoft.Win32.Registry]::CurrentUser.OpenSubKey('Environment')
 $userPath = $userKey.GetValue('PATH', [string]::Empty, 'DoNotExpandEnvironmentNames').ToString()
 
-$machineKey = [Microsoft.Win32.Registry]::LocalMachine.OpenSubKey('SYSTEM\ControlSet001\Control\Session Manager\Environment\')
+$machineKey = [Microsoft.Win32.Registry]::LocalMachine.OpenSubKey('SYSTEM\ControlSet001\Control\Session Manager\Environment\', $true)
 $machinePath = $machineKey.GetValue('PATH', [string]::Empty, 'DoNotExpandEnvironmentNames').ToString()
 
 $backupPATHs = @(


### PR DESCRIPTION
Faced an error when execute uninstall script which documented.
See below (note to I use windows 10 in Japanese locale):

```
PS C:\Users\kimiaki\Desktop> .\uninstall.ps1
詳細: Chocolatey Install location found in Machine Path. Removing...
警告:     This could cause issues after reboot where nothing is found if something goes wrong.
    In that case, look at the backup file for the original PATH values in 'C:\PATH_backups_ChocolateyUninstall.txt'.
"3" 個の引数を指定して "SetValue" を呼び出し中に例外が発生しました: "レジストリ キーに書き込めません。"
発生場所 C:\Users\kimiaki\Desktop\uninstall.ps1:71 文字:5
+     $machineKey.SetValue('PATH', $newMachinePATH, 'ExpandString')
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [], MethodInvocationException
    + FullyQualifiedErrorId : UnauthorizedAccessException
```

This caused by SetValue needs write permission but $machineKey haven't the permisson.
To solve, add writable option when use OpenSubKey.
See: https://docs.microsoft.com/ja-jp/dotnet/api/microsoft.win32.registrykey.opensubkey?view=net-5.0#Microsoft_Win32_RegistryKey_OpenSubKey_System_String_System_Boolean_