### PR TITLE
(#264) Correct casing for Win Defender example

### DIFF
--- a/input/en-us/features/virus-check.md
+++ b/input/en-us/features/virus-check.md
@@ -63,7 +63,7 @@ In `genericVirusScannerValidExitCodes`, these are exit codes that indicate that 
 ```powershell
 choco config set --name="'virusScannerType'" --value="'Generic'"
 choco config set --name="'genericVirusScannerPath'" --value="'C:\Program Files\Windows Defender\MpCmdRun.exe'"
-choco config set --name="'genericVirusScannerArgs'" --value="'-Scan -ScanType 3 -File [[FILE]]'"
+choco config set --name="'genericVirusScannerArgs'" --value="-Scan -ScanType 3 -File '[[File]]'"
 choco config set --name="'genericVirusScannerValidExitCodes'" --value="'0'"
 choco feature enable --name="'virusCheck'"
 ```


### PR DESCRIPTION
Thpull request updates the example for Windows Defender when configuring
a generic virus scanner, to use the same case as in other parts of the documentation.
Additionally, the quoting of the value have been updated to ensure that
passed to the generic virus scanner will work when the path contains spaces.

This change is necessary to be consistent with the documentation,
as well as only using upper case letters currently do not work for the
replacement variable.

fixes #264
