### PR TITLE
(doc) Update default for webRequestTimeoutSeconds

### DIFF
--- a/input/en-us/configuration.md
+++ b/input/en-us/configuration.md
@@ -28,7 +28,7 @@ Config settings are adjusted using `choco config set --name="'<nameFromBelow>'" 
 ### Timeouts
 
 * `commandExecutionTimeoutSeconds` = **'2700'** - Default timeout for command execution. '0' for infinite (starting in 0.10.4). It is recommended that organizations bump this up to at least 4 hours (14400).
-* `webRequestTimeoutSeconds` = **'45'** - Default timeout for web requests. Available in 0.9.10+.
+* `webRequestTimeoutSeconds` = **'30'** - Default timeout for web requests. Available in 0.9.10+.
 
 ### Other
 


### PR DESCRIPTION
When constructing the ConfigurationBuilder, the default is 30,
not 45, as shown here:

https://github.com/chocolatey/choco/blob/develop/src/chocolatey/infrastructure.app/ApplicationParameters.cs#L133