### PR TITLE
Update proxy-settings-for-chocolatey.md

### DIFF
--- a/input/en-us/guides/usage/proxy-settings-for-chocolatey.md
+++ b/input/en-us/guides/usage/proxy-settings-for-chocolatey.md
@@ -8,6 +8,17 @@ RedirectFrom: docs/proxy-settings-for-chocolatey
 
 ## Installing Chocolatey behind a proxy server
 
+>Try this option first to use your default proxy server to install Chocolatey
+>Or you have this error , "The remote server returned an error: (407) Proxy Authentication Required."
+
+Steps to help address this:
+1. Open a Command Prompt, run as an Administrator.
+2. Copy this piece of code from Duane Newman
+  `@powershell -NoProfile -ExecutionPolicy Unrestricted -Command "[Net.WebRequest]::DefaultWebProxy.Credentials = [Net.CredentialCache]::DefaultCredentials; iex ((New-Object Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))" && SET PATH=%PATH%;%systemdrive%\chocolatey\bin`
+3. Run it and this will resolve the issue.
+4. This solution completely resolves the issue around installing chocolatey behind proxy using the command to force the WebRequest to use the Default Credentials for the proxy setting.
+For more information, kindly refer to this link https://duanenewman.net/blog/post/installing-chocolatey-behind-a-corporate-proxy/ or https://stackoverflow.com/questions/30897204/how-do-i-install-chocolatey-packages-behind-a-proxy-on-windows-2012-r2-core
+
 When trying to install Chocolatey behind a proxy server, you may be faced with errors like
 
 > Get Response returned: (407) Proxy Authentication Required
@@ -107,3 +118,6 @@ Starting in 0.10.4, you can pass proxy information at runtime with each command.
 ## What to do if my proxy is socks?
 
 It may just work. It hasn't been validated yet.
+
+
+

--- a/input/en-us/guides/usage/proxy-settings-for-chocolatey.md
+++ b/input/en-us/guides/usage/proxy-settings-for-chocolatey.md
@@ -6,20 +6,9 @@ Description: Settings up Chocolatey to use locally configured proxy server
 RedirectFrom: docs/proxy-settings-for-chocolatey
 ---
 
-## Installing Chocolatey behind a proxy server
+## Installing Chocolatey from behind a proxy server
 
->Try this option first to use your default proxy server to install Chocolatey
->Or you have this error , "The remote server returned an error: (407) Proxy Authentication Required."
-
-Steps to help address this:
-1. Open a Command Prompt, run as an Administrator.
-2. Copy this piece of code from Duane Newman
-  `@powershell -NoProfile -ExecutionPolicy Unrestricted -Command "[Net.WebRequest]::DefaultWebProxy.Credentials = [Net.CredentialCache]::DefaultCredentials; iex ((New-Object Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))" && SET PATH=%PATH%;%systemdrive%\chocolatey\bin`
-3. Run it and this will resolve the issue.
-4. This solution completely resolves the issue around installing chocolatey behind proxy using the command to force the WebRequest to use the Default Credentials for the proxy setting.
-For more information, kindly refer to this link https://duanenewman.net/blog/post/installing-chocolatey-behind-a-corporate-proxy/ or https://stackoverflow.com/questions/30897204/how-do-i-install-chocolatey-packages-behind-a-proxy-on-windows-2012-r2-core
-
-When trying to install Chocolatey behind a proxy server, you may be faced with errors like
+When trying to install Chocolatey behind a proxy server, you may be faced with one of the following errors:
 
 > Get Response returned: (407) Proxy Authentication Required
 
@@ -30,18 +19,29 @@ or
 Steps to help address this:
 
 1. Copy the [install.ps1](https://community.chocolatey.org/install.ps1) file locally.
-2. Open a PowerShell command line.
-3. Set the following environment variables - `$env:chocolateyProxyLocation` (with proxyserver:proxyport), `$env:chocolateyProxyUser` (if it is a domain account, ensure you have the appropriate domain prefix for the account, e.g. `AD\UserName` or `UserName`), and `$env:chocolateyProxyPassword` with your password.
-4. With that same shell open where the environment variables are set, run the downloaded script to install Chocolatey.
+1. Open a PowerShell command line as administrator.
+1. If _not_ using a proxy with authentication, set the default proxy credentials with `[Net.WebRequest]::DefaultWebProxy.Credentials = [Net.CredentialCache]::DefaultCredentials`
+1. Set the following environment variables:
+   1. `$env:chocolateyProxyLocation` (in the format `proxyserver:proxyport`, see below for an example)
+1. If your proxy requires authentication, set the following variables:
+   1. `$env:chocolateyProxyUser` (if using a domain account, ensure you have the appropriate domain prefix for the account, e.g. `AD\UserName` or `UserName`)
+   1. `$env:chocolateyProxyPassword`
+1. With that same shell open where the environment variables are set, run the downloaded script to install Chocolatey.
 
 In PowerShell, it looks like this:
 
-~~~powershell
-$env:chocolateyProxyLocation = 'https://local/proxy/server'
+```powershell
+[Net.WebRequest]::DefaultWebProxy.Credentials = [Net.CredentialCache]::DefaultCredentials
+$env:chocolateyProxyLocation = 'https://local.proxy.address:8001'
+
+# Un-comment the following lines if your proxy server requires explicit authentication and
+# substitute your username and password.
 #$env:chocolateyProxyUser = 'username'
 #$env:chocolateyProxyPassword = 'password'
-# install script
-~~~
+
+# Run the downloaded install script
+& "C:\Path\to\script\install.ps1"
+```
 
 > :choco-info: **NOTE**
 >
@@ -49,16 +49,18 @@ $env:chocolateyProxyLocation = 'https://local/proxy/server'
 
 ### Troubleshooting Installation
 
-You've tried everything and Chocolatey still won't install from https://community.chocolatey.org -
+You've tried everything and Chocolatey still won't install from <https://community.chocolatey.org> -
 
 > The underlying connection was closed: Could not establish trust relationship for the SSL / TLS secure channel.
 
 It could also be that your trusted root certificates are missing or not up to date (Windows 2012 does not install root certificates by default). You will need to download and install the following certificates into your LocalMachine's *Trusted Root Certification Authorities* certificate store.
 
 To access [community.chocolatey.org](https://community.chocolatey.org):
+
 * [Go Daddy Secure Certificate Authority - G2](https://certs.godaddy.com/repository) (File: `gdroot-g2.crt`; Thumbprint: `47BEABC922EAE80E78783462A79F45C254FDE68B`). (On the download page, this certificate is named *GoDaddy Class 2 Certification Authority Root Certificate - G2* and its listed thumbprint (`45140B3247EB9CC8C5B4F0D7B53091F73292089E6E5A63E2749DD3ACA9198EDA`) is wrong.
 
 To access [packages.chocolatey.org](https://packages.chocolatey.org):
+
 * [AddTrust External CA Root](https://support.comodo.com/index.php?/Default/Knowledgebase/Article/View/917/91/) (File: `addtrustexternalcaroot.crt`; Thumbprint: `02FAF3E291435468607857694DF5E45B68851868`)
 
 ## System Proxy Settings
@@ -118,6 +120,3 @@ Starting in 0.10.4, you can pass proxy information at runtime with each command.
 ## What to do if my proxy is socks?
 
 It may just work. It hasn't been validated yet.
-
-
-


### PR DESCRIPTION
This solution completely resolves the issue around installing chocolatey behind proxy using the command to force the WebRequest to use the Default Credentials for the proxy setting.