### PR TITLE
(doc) Clarify process for Verifier exemption

### DIFF
--- a/input/en-us/community-repository/moderation/package-verifier.md
+++ b/input/en-us/community-repository/moderation/package-verifier.md
@@ -29,7 +29,7 @@ The systems we run against:
 
 ## How can I bypass the verifier?
 
-If your package needs to be exempted, please contact the site admins on the package page of the package that needs the bypass and/or reach out on Gitter.
+If your package needs to be exempted, please contact the site admins on the package page of the package that needs the bypass.
 
 ## How does the verifier work?
 


### PR DESCRIPTION
Update to clarify the Package Verifier exemption process. Whenever anybody reaches out on Gitter we ask them to add it to the package review / moderation comments so it seems redundant to ask them to do so.