### PR TITLE
(doc) Add documentation for Commercial Validation Rule

### DIFF
--- a/input/en-us/community-repository/moderation/package-validator/rules/cpmr0071.md
+++ b/input/en-us/community-repository/moderation/package-validator/rules/cpmr0071.md
@@ -1,0 +1,22 @@
+---
+Order: 0071
+xref: cpmr0071
+Title: CPMR0071 - Script uses commercial cmdlets (script)
+Description: Information on how to remediate the Chocolatey Package Moderation Rule 0071.
+RuleType: Requirement
+---
+
+<?! Include "../../../../../shared/package-validator-rule-requirement.txt" /?>
+
+## Issue
+
+In an automation script (`.ps1`/`.psm1`), one or more calls to a licensed function that is only available in licensed editions of Chocolatey, is being used.
+
+## Recommended Solution
+
+Please do not use licensed features when creating packages that you will submit to the Chocolatey Community Repository. Update all automation scripts to use functions that are available in open-source Chocolatey.
+
+## Reasoning
+
+Packages created with licensed features should not be made available in the Chocolatey Community Repository and are intended for use by organizations hosting their own internal package repository.
+All packages submitted to the Chocolatey Community Repository are for the community and should work on all editions of Chocolatey.


### PR DESCRIPTION
This is basic documentation for the upcoming rule that validates if packages make use of commercial cmdlets in their automation scripts or not.
The cmdlets is not called out specifically as these can change between versions.

ref: https://github.com/chocolatey/home/issues/76