### PR TITLE
Remove mention of future version

### DIFF
--- a/input/shared/intune-note.txt
+++ b/input/shared/intune-note.txt
@@ -1,6 +1,6 @@
-> :warning: **WARNING**
+> :memo: **NOTE**
 >
-> The Chocolatey Intune integration is planned for an upcoming release of Chocolatey Licensed Extension and may not yet be available..
+> The Chocolatey Intune integration shipped as part of v3.0.0 of the Chocolatey Licensed Extension.
 
 > :memo: **NOTE**
 >


### PR DESCRIPTION
Support for Intune shipped as part of v3.0.0 so we should call that out
specifically.