### PR TITLE
Changed wording for chococlatey.server support

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,4 +1,5 @@
 {
   "MD026": false,
-  "MD013": false
+  "MD013": false,
+  "MD024": false
 }

--- a/input/en-us/features/host-packages.md
+++ b/input/en-us/features/host-packages.md
@@ -29,7 +29,6 @@ Some of these options also work from a non-Windows hosting perspective. See [Non
 
 * File Share\UNC share (below)
 * SCCM Distribution Points (when used as a file share)
-* [Chocolatey.Server](xref:set-up-chocolatey-server) (supported by Chocolatey Software with your Chocolatey for Business subscription)
 * Sonatype Nexus - [Nexus2](https://books.sonatype.com/nexus-book/reference/nuget-nuget_hosted_repositories.html) / [Nexus3](https://books.sonatype.com/nexus-book/3.0/reference/nuget.html#nuget-hosted)- Sonatype Nexus has a built-in simple server
 * [ProGet](http://inedo.com/proget/overview) - ProGet gives you a ready to go On-Premise option. Enterprise has replication
 * [Artifactory Pro](https://www.jfrog.com/artifactory/) - see [Artifactory NuGet Repositories](http://www.jfrog.com/confluence/display/RTF/NuGet+Repositories)
@@ -120,7 +119,6 @@ There is where the bulk of NuGet OData compatible servers fall (NuGet.Server, Ch
 
 ### Known Simple Server Options
 
-* [Chocolatey.Server](xref:set-up-chocolatey-server) (recommended)
 * NuGet.Server
 * [TeamCity](https://www.jetbrains.com/teamcity/) has built-in Simple Server
 * [Visual Studio Team Services (NuGet v2 endpoints)](https://docs.microsoft.com/en-us/vsts/package/overview) - [Setup](https://docs.microsoft.com/en-us/vsts/package/get-started-nuget) (Remove the part of the url that is /v3/index.json and use /v2 instead) - you may also need to [setup a personal access token](https://docs.microsoft.com/en-us/vsts/accounts/use-personal-access-tokens-to-authenticate).

--- a/input/en-us/features/host-packages.md
+++ b/input/en-us/features/host-packages.md
@@ -371,7 +371,3 @@ If you don't want to host on Windows you have only the following options (from l
 * [Cloudsmith](https://cloudsmith.com) - see [Cloudsmith NuGet Repositories](https://help.cloudsmith.io/docs/nuget-feed)
 * [Artifactory Pro](https://www.jfrog.com/artifactory/) - see [Artifactory NuGet Repositories](http://www.jfrog.com/confluence/display/RTF/NuGet+Repositories)
 * [Sonatype Nexus](https://books.sonatype.com/nexus-book/reference/nuget-nuget_hosted_repositories.html)
-
-> :memo: **NOTE** NuGet.Java.Server, TeamCity and JNuGet are about the same in terms of sophistication (they are ordered alphabetically).
-
-> :memo: **NOTE** Artifactory Pro and Nexus are about the same in terms of sophistication (they are also ordered alphabetically).

--- a/input/en-us/features/host-packages.md
+++ b/input/en-us/features/host-packages.md
@@ -139,8 +139,8 @@ If the option you've chosen is not listed, take a look at [known hosting options
 * Windows is not required - there are at least two pure Java versions (see [Non-Windows Hosting](#non-windows-hosting)).
 * Push over HTTP / HTTPS/TLS.
 * Authentication / Authorization:
-   * API key for pushing packages.
-   * Basic Authentication with IIS.
+  * API key for pushing packages.
+  * Basic Authentication with IIS.
 * No direct access to packages so security can be locked down to just modify through push.
 * Package store is file system.
 * Can manage PowerShell gallery type packages.
@@ -175,11 +175,10 @@ Setting up NuGet.Server is very much a hands on approach for a packaging server 
 Many google searches will throw out good ways to set up your own feed (hint: search for "host your own NuGet server feed")
 Some notable references:
 
- * Nuget Docs [Host Your Own Remote Feed](https://docs.nuget.org/Create/Hosting-Your-Own-NuGet-Feeds#creating-remote-feeds)
- * itToby - [Setup Your Own Chocolatey/NuGet Repository](http://blog.ittoby.com/2014/07/setup-your-own-chocoloateynuget.html)
- * Rich Hopkins - [Bake your own Chocolatey NuGet repository](https://souladin.wordpress.com/2014/12/05/bake-your-own-chocolatey-nuget-repository/)
- * Brandon - [Host NuGet Server in Azure](http://netitude.bc3tech.net/2015/01/07/create-your-own-hosted-nuget-server-in-azure/)
-
+* Nuget Docs [Host Your Own Remote Feed](https://docs.nuget.org/Create/Hosting-Your-Own-NuGet-Feeds#creating-remote-feeds)
+* itToby - [Setup Your Own Chocolatey/NuGet Repository](http://blog.ittoby.com/2014/07/setup-your-own-chocoloateynuget.html)
+* Rich Hopkins - [Bake your own Chocolatey NuGet repository](https://souladin.wordpress.com/2014/12/05/bake-your-own-chocolatey-nuget-repository/)
+* Brandon - [Host NuGet Server in Azure](http://netitude.bc3tech.net/2015/01/07/create-your-own-hosted-nuget-server-in-azure/)
 
 ## Package Gallery
 
@@ -219,7 +218,7 @@ At this time we don't have setup instructions and are not keen to answer questio
 
 These are simple servers that have more advanced options and authentication scenarios, plus multiple repository types. This section accounts for the following types.
 
-#### Commercial Options
+### Commercial Options
 
 * [Artifactory Pro](http://www.jfrog.com/confluence/display/RTF/NuGet+Repositories)
 * [Cloudsmith](https://cloudsmith.com/nuget-feed/) ([Chocolatey Documentation](https://help.cloudsmith.io/docs/chocolatey-repository), [NuGet Documentation](https://help.cloudsmith.io/docs/nuget-feed))
@@ -239,13 +238,13 @@ If the option you've chosen is not listed, take a look at [known hosting options
 * API key for pushing packages.
 * No direct access to packages so security can be locked down to just modify through push or upload.
 * Authentication / Authorization:
-   * Multiple api keys.
-   * Basic Authentication through IIS.
-   * RBAC (role-based access control) available in some options.
-   * LDAP authentication in some options (although Nuget/Chocolatey may not support this for package operations).
+  * Multiple api keys.
+  * Basic Authentication through IIS.
+  * RBAC (role-based access control) available in some options.
+  * LDAP authentication in some options (although Nuget/Chocolatey may not support this for package operations).
 * Package stores can be file system, database, Azure blobs, and AWS S3 depending on the product.
 * Website interface.
-   * Uploading packages can also be done through website.
+  * Uploading packages can also be done through website.
 * Multiple repositories in an instance.
 * Multiple repository types (not limited to just NuGet/Chocolatey types).
 * HA (High Availability) available in some options.

--- a/input/en-us/guides/organizations/set-up-chocolatey-server.md
+++ b/input/en-us/guides/organizations/set-up-chocolatey-server.md
@@ -223,4 +223,4 @@ Turn on customErrors under system.web `<customErrors mode="Off" />` see this gui
 
 Then browse to the site to see if you can gather any more information.
 
-If so, and you are a commercial edition customer, please open a support ticket. If you are using open source Chocolatey, please open a ticket at https://github.com/chocolatey-community/simple-server/issues.
+If so, and you are a commercial edition customer or open source Chocolatey user, please open a ticket at https://github.com/chocolatey-community/simple-server/issues.

--- a/input/en-us/guides/organizations/set-up-chocolatey-server.md
+++ b/input/en-us/guides/organizations/set-up-chocolatey-server.md
@@ -62,35 +62,35 @@ If you are using the Puppet module [chocolatey/chocolatey_server](https://forge.
 The module works with Windows Server 2008/2012.
 For a simple `include chocolatey_server` it does the following automatically:
 
- * Ensures IIS is installed
- * Ensures ASP.NET is installed
- * Ensures the chocolatey.server package is installed
- * Ensures an app pool for the chocolatey.server site
- * Ensures the IIS website is setup for chocolatey.server
- * Ensures permissions for the site are set correctly.
+* Ensures IIS is installed
+* Ensures ASP.NET is installed
+* Ensures the chocolatey.server package is installed
+* Ensures an app pool for the chocolatey.server site
+* Ensures the IIS website is setup for chocolatey.server
+* Ensures permissions for the site are set correctly.
 
 ### Setup Manually
 
- * If your Windows updates are not up to date, there are two required Windows updates you are going to need (heads up they take awhile)
-    * Install KB2919355 - `choco install KB2919355 -y` - this one or the other Windows update takes a **very** long time to install, just be patient
-    * Restart your machine.
-    * Install KB2919442 - `choco install KB2919442 -y` (IIRC this is the one that takes forever...) -
-    * Reboot that machine again
- * You need at least .NET Framework 4.6. If you don't have that or newer, then run `choco install dotnet4.6.1 -y`
-    * Reboot one more time, thanks Windows!!
- * Install or upgrade the package - `choco upgrade chocolatey.server -y`
- * Ensure IIS is installed. You can try `choco install IIS-WebServer --source windowsfeatures`
- * Ensure that ASP.NET is installed. Try `choco install IIS-ASPNET45 --source windowsfeatures` (Windows Server 2012). Use `IIS-ASPNET` for Windows Server 2008, possibly `IIS-ASPNET46` for Windows Server 2016.
- * Disable or remove the Default website
- * Set up an app pool for Chocolatey.Server. Ensure 32-bit is enabled and the managed runtime version is `v4.0` (or some version of 4). Ensure it is "Integrated" and not "Classic".
- * Set up an IIS website pointed to the install location and set it to use the app pool.
- * Go to explorer and right click on `c:\tools\chocolatey.server` and add the following permissions:
-   * `IIS_IUSRS` - Read
-   * `IUSR` - Read
-   * `IIS APPPOOL\<app pool name>` - Read
- * Right click on the `App_Data` subfolder and add the following permissions:
-   * `IIS_IUSRS` - Modify
-   * `IIS APPPOOL\<app pool name>` - Modify
+* If your Windows updates are not up to date, there are two required Windows updates you are going to need (heads up they take awhile)
+  * Install KB2919355 - `choco install KB2919355 -y` - this one or the other Windows update takes a **very** long time to install, just be patient
+  * Restart your machine.
+  * Install KB2919442 - `choco install KB2919442 -y` (IIRC this is the one that takes forever...) -
+  * Reboot that machine again
+* You need at least .NET Framework 4.6. If you don't have that or newer, then run `choco install dotnet4.6.1 -y`
+  * Reboot one more time, thanks Windows!!
+* Install or upgrade the package - `choco upgrade chocolatey.server -y`
+* Ensure IIS is installed. You can try `choco install IIS-WebServer --source windowsfeatures`
+* Ensure that ASP.NET is installed. Try `choco install IIS-ASPNET45 --source windowsfeatures` (Windows Server 2012). Use `IIS-ASPNET` for Windows Server 2008, possibly `IIS-ASPNET46` for Windows Server 2016.
+* Disable or remove the Default website
+* Set up an app pool for Chocolatey.Server. Ensure 32-bit is enabled and the managed runtime version is `v4.0` (or some version of 4). Ensure it is "Integrated" and not "Classic".
+* Set up an IIS website pointed to the install location and set it to use the app pool.
+* Go to explorer and right click on `c:\tools\chocolatey.server` and add the following permissions:
+  * `IIS_IUSRS` - Read
+  * `IUSR` - Read
+  * `IIS APPPOOL\<app pool name>` - Read
+* Right click on the `App_Data` subfolder and add the following permissions:
+  * `IIS_IUSRS` - Modify
+  * `IIS APPPOOL\<app pool name>` - Modify
 
 ### Setup with PowerShell Script
 
@@ -189,11 +189,9 @@ To configure for performance, you will want to do the following:
   * Under the Site's Advanced Settings:
     * Preload Enabled -> True
 
-
 #### Future
 
 We are looking to add support for the package source to automatically handle this aspect - http://blog.nuget.org/20150922/Accelerate-Package-Source.html
-
 
 ### Configure Simple Server alongside WSUS admin-site
 
@@ -221,7 +219,7 @@ This can mean a couple of things:
 
 ### Other error
 
-Turn on customErrors under system.web - <customErrors mode="Off" /> - see this guide to set it - https://stackify.com/web-config-customerrors-asp-net/
+Turn on customErrors under system.web `<customErrors mode="Off" />` see this guide to set it - https://stackify.com/web-config-customerrors-asp-net/
 
 Then browse to the site to see if you can gather any more information.
 


### PR DESCRIPTION
## Description Of Changes
Went through and changed wording regarding chococlatey.server package to coincide with current support structure. Also added to the markdown lint rules for the repo.

Specifically adding 

* MD024 - set to false to allow the same heading to be used more than once in a single page without causing linting errors.
* MD034 - Set to false to allow for full URL listings in docs without causing linting errors. 

## Motivation and Context
Changes in documentation are being made to better communicate not advocating for chocolatey.server as an organizations first choice for a repository solution. 

Changes to the markdown lint document seemed a no brainer as we continue to redefine the linter rules we are using on this GitHub repo.

## Testing

1. Did a local Statiq build with changes while editing.

## Change Types Made

* [ ] Bug fix (non-breaking change)
* [ ] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [ ] PowerShell code changes.
* [X] Documentation change

## Related Issue
#183

Fixes #183
 
## Change Checklist

* [X] Requires a change to the documentation
* [X] Documentation has been updated
