### PR TITLE
(doc) Fix typo in troubleshooting doc

### DIFF
--- a/input/en-us/troubleshooting.md
+++ b/input/en-us/troubleshooting.md
@@ -569,7 +569,7 @@ A corrupt .registry file exists at C:\ProgramData\chocolatey\.chocolatey\$applic
 
             else {
 
-                Write-Warning -Message "No .bad file exists in $($folder.DirectoryName), renaming file"
+                Write-Warning -Message "No .registry file exists in $($folder.DirectoryName), renaming file"
 
                 Move-Item "$($Folder.DirectoryName)\.registry.bad" "$($Folder.DirectoryName)\.registry"
 


### PR DESCRIPTION
## Description Of Changes

There's a typo in the script for dealing with .registry.bad files.

## Motivation and Context

The script indicates that there's no .bad file found, when in fact it checked for .registry files.

## Testing

I'm not able to test this as I noticed the typo after running the script and noticing that it said .bad instead of .registry. There shouldn't be much need to actually test as the change is only in the warning that is displayed.

## Change Types Made

* [x] Bug fix (non-breaking change)
* [ ] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [ ] PowerShell code changes.

## Related Issue

I didn't raise an issue as I just clicked the edit button on the Docs page. Can create one if we want it.

## Change Checklist

* [x] Requires a change to the documentation
* [x] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [ ] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.
