### PR TITLE
Removed jenkins is pinned to a specific version

### DIFF
--- a/input/en-us/guides/organizations/chocolatey-for-business-quick-start-guide.md
+++ b/input/en-us/guides/organizations/chocolatey-for-business-quick-start-guide.md
@@ -200,7 +200,7 @@ Below are the minimum requirements for setting up your C4B server via this guide
     > <details>
     > <summary><strong>What does this script do? (click to expand)</strong></summary>
     > <ul class="list-style-type-disc">
-    > <li>Installs Jenkins package (pinned to a specific version)</li>
+    > <li>Installs Jenkins package</li>
     > <li>Updates Jenkins plugins</li>
     > <li>Configures pre-downloaded Jenkins scripts for Package Internalizer automation</li>
     > <li>Sets up pre-defined Jenkins jobs for the scripts above</li>


### PR DESCRIPTION
## Description Of Changes
Removed explanation that jenkins is pinned to a specific version

## Motivation and Context
Did this as documentation step for [QSG Issue](https://github.com/chocolatey/choco-quickstart-scripts/issues/94)

## Testing
Previews change locally in Statiq build

## Change Types Made

Docs update

## Related Issue
[QSG Issue](https://github.com/chocolatey/choco-quickstart-scripts/issues/94)

Fixes #315 

## Change Checklist

* [X] Requires a change to the documentation
* [X] Documentation has been updated
* [X] All new and existing tests passed.