### PR TITLE
(doc) Add information about defaultTemplateName

### DIFF
--- a/input/en-us/configuration.md
+++ b/input/en-us/configuration.md
@@ -16,6 +16,7 @@ Config settings are adjusted using `choco config set --name="'<nameFromBelow>'" 
 
 * `cacheLocation` = **' '** - Cache location if not TEMP folder. Replaces `$env:TEMP` value.  It is highly recommended this be set to make Chocolatey more deterministic in cleanup.
 * `upgradeAllExceptions` = **' '** - A comma-separated list of package names that should not be upgraded when running `choco upgrade all'. Defaults to empty. Available in 0.10.14+.
+* `defaultTemplateName` = **' '** - Default template name used when running [`choco new` command](xref:choco-command-new). Available in 0.12.0+.
 
 ### Proxy
 


### PR DESCRIPTION
## Description Of Changes

Add information about defaultTemplateName configuration option.

This was added in 0.12.0, and allowing the setting of the
defaultTemplateName configuration parameter when running the choco new
command.  So rather than having to type choco new --template bob, you
can simply do choco config set --name defaultTemplateName --value bob
and then run choco new, and it will use the template named bob.

## Motivation and Context

This information is not added automatically from the `GenerateDocs.ps1` file, and needs to be 
updated manually.

## Testing
1. Executed `./preview.ps1` locally, and ensured that it appeared correctly.

## Change Types Made

* [ ] Bug fix (non-breaking change)
* [ ] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [ ] PowerShell code changes.
* [x] Markdown documentation update

## Related Issue

Relates to https://github.com/chocolatey/choco/issues/2391

## Change Checklist

* [x] Requires a change to the documentation
* [x] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [ ] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.