### PR TITLE
(#326) Add Code Comment in SQL Permission Script and General Markdown Edits

### DIFF
--- a/input/en-us/central-management/setup/database.md
+++ b/input/en-us/central-management/setup/database.md
@@ -384,6 +384,8 @@ ALTER ROLE [$DatabaseRole] ADD MEMBER [$Username]
     $Connection.Close()
 }
 
+# Please choose from one of the three listed account types below. The commands will grant database permissions to a user account of your choice. This account will be used in your Connection String for the CCM Service and Web package installs ahead.
+
 # Add Sql Server Login / User:
 Add-DatabaseUserAndRoles -DatabaseName 'ChocolateyManagement' -Username 'ChocoUser' -SqlUserPassword '<SUPER HARD PASSWORD>' -CreateSqlUser  -DatabaseRoles @('db_datareader', 'db_datawriter')
 

--- a/input/en-us/central-management/setup/database.md
+++ b/input/en-us/central-management/setup/database.md
@@ -305,13 +305,13 @@ Once we have the database, we can create logins and map those logins to users in
 
 The difference between a login and a user when it comes to SQL Server accounts has long confused folks. Simply put:
 
-- Login (Authentication) - A login is at instance level (the credentials or Windows-based accounts) - [https://docs.microsoft.com/en-us/sql/relational-databases/security/authentication-access/create-a-login](https://docs.microsoft.com/en-us/sql/relational-databases/security/authentication-access/create-a-login)
-- User (Authorization) - A user is that login being mapped to a database and given roles/privileges (an instance can contain multiple databases) - [https://docs.microsoft.com/en-us/sql/relational-databases/security/authentication-access/create-a-database-user](https://docs.microsoft.com/en-us/sql/relational-databases/security/authentication-access/create-a-database-user)
+* Login (Authentication) - A login is at instance level (the credentials or Windows-based accounts) - [https://docs.microsoft.com/en-us/sql/relational-databases/security/authentication-access/create-a-login](https://docs.microsoft.com/en-us/sql/relational-databases/security/authentication-access/create-a-login)
+* User (Authorization) - A user is that login being mapped to a database and given roles/privileges (an instance can contain multiple databases) - [https://docs.microsoft.com/en-us/sql/relational-databases/security/authentication-access/create-a-database-user](https://docs.microsoft.com/en-us/sql/relational-databases/security/authentication-access/create-a-database-user)
 
 Notes:
 
-- Grant `db_datareader` and `db_datawriter` to the accounts you create for the web and service.
-- You can share the same login for the two accounts, unless your internal best practices dictate using different passwords.
+* Grant `db_datareader` and `db_datawriter` to the accounts you create for the web and service.
+* You can share the same login for the two accounts, unless your internal best practices dictate using different passwords.
 
 ```powershell
 function Add-DatabaseUserAndRoles {


### PR DESCRIPTION
## Description Of Changes
- Added code comment in SQL permissions script to better explain that only one of the three options listed needs to be run. As well as explaining based on the choice will be your connection string method for the next 2 package installs.
- Also made some minor markdown changes that the linter wanted.

## Motivation and Context
I've seen users just copy and paste this script thinking you need to run all 2 account provisioning scripts at the end of it. Hopefully the code comment added will cut down on this happening. 

## Testing
Built locally to verify layout changes. 

## Change Types Made
* [ ] Bug fix (non-breaking change)
* [ ] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [X] PowerShell code changes.

## Related Issue

Fixes #326 

## Change Checklist

* [X] Requires a change to the documentation
* [X] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [X] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.
