### PR TITLE
Add information around deprecations

### DIFF
--- a/input/en-us/configuration.md
+++ b/input/en-us/configuration.md
@@ -8,6 +8,11 @@ RedirectFrom: docs/chocolatey-configuration
 
 There are settings and features that can customize the way that Chocolatey works for you. The following is a list of config settings and features and their default values.
 
+> :information_source: **INFORMATION**
+>
+> When a Chocolatey configuration or feature is removed (for example, it becomes deprecated and no longer required), it will not be removed from the chocolatey.config file automatically when you upgrade Chocolatey.
+> This is in order to preserve backwards compatibility, should the user decide to go back to a previous version of Chocolatey.
+
 ## Config Settings
 
 Config settings are adjusted using `choco config set --name="'<nameFromBelow>'" --value="'<value>'"` and set back to default with `choco config unset --name="'<nameFromBelow>'"`. For more information see [`choco config` command](xref:choco-command-config) or run `choco config -?`.


### PR DESCRIPTION
## Description Of Changes

It is possible, when a config/feature is deprecated and removed between
package versions of Chocolatey, that the config/feature values remain
in the chocolatey.config file.

This is by design, as it means that the configuration file is backwards
compatible, especially when going between Chocolatey Licensed and back
to OSS.

This is not immediately obvious though, so we have to call it out.

## Motivation and Context

To make it clearer to folks who notice this happening.

## Testing

Ran the website locally, and all looks good

![image](https://user-images.githubusercontent.com/1271146/150110992-e85a2e16-a94a-48ac-823a-aebb638c12a3.png)

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [ ] Bug fix (non-breaking change)
* [ ] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [ ] PowerShell code changes.

## Related Issue

N/A

## Change Checklist

* [x] Requires a change to the documentation
* [x] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [ ] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.