### PR TITLE
(#358) Update step 1 of Quickstart Guide for new method of installation

### DIFF
--- a/input/en-us/guides/organizations/chocolatey-for-business-quick-start-guide.md
+++ b/input/en-us/guides/organizations/chocolatey-for-business-quick-start-guide.md
@@ -76,7 +76,9 @@ Below are the minimum requirements for setting up your C4B server via this guide
     Set-ExecutionPolicy Bypass -Scope Process -Force
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::tls12
     $QuickStart = 'https://raw.githubusercontent.com/chocolatey/choco-quickstart-scripts/main/Start-C4bSetup.ps1'
-    Invoke-Expression -Command ((New-Object System.Net.WebClient).DownloadString($QuickStart))
+    $Script = [System.Net.Webclient]::new().DownloadString($QuickStart)
+    $sb = [ScriptBlock]::Create($Script)
+    & $sb
     ```
 
     > <details>


### PR DESCRIPTION
## Description Of Changes

Update method of execution for step 1 of the Quickstart guide

## Motivation and Context

We introduced a begin {} block in all of the scripts for the Guide to prevent the execution of the scripts from being able to occur within the PowerShell ISE as it causes problems with native command output.

This commit updates the first step of the Guide to use a different mechanism of execution as Invoke-Expression will not work with the script containing a begin block, so we switch to using a Scriptblock instead, and then
executing it

## Testing

1. Local preview was validated
2. Code changes validated on a blank system

## Change Types Made

* [x] Bug fix (non-breaking change)
* [ ] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [x] PowerShell code changes.

## Related Issue

Fixes #358 

## Change Checklist

* [ ] Requires a change to the documentation
* [x] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [ ] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.

