### PR TITLE
Quick typo change and Markdown linting addition

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,5 +1,8 @@
 {
   "MD026": false,
   "MD013": false,
-  "MD024": false
+  "MD024": false,
+  "MD033": {
+    "allowed_elements": ["details", "strong", "summary"]
+  }
 }

--- a/input/en-us/quick-deployment/setup/internet-setup.md
+++ b/input/en-us/quick-deployment/setup/internet-setup.md
@@ -323,7 +323,7 @@ These are both configuration items that can be set using the `choco config` comm
 
 ```powershell
 choco config set centralManagementClientCommunicationSaltAdditivePassword 'YourSuperSecureSalt1'
-choco config set centralManagementServerCommunicationSaltAdditivePassword 'YourSuperSecureSalt2'
+choco config set centralManagementServiceCommunicationSaltAdditivePassword 'YourSuperSecureSalt2'
 ```
 
 Further details on configuring CCM, and all available settings, can be found in the [Central Management Client Setup](xref:ccm-client#config-settings) documentation.


### PR DESCRIPTION
## Description Of Changes
- Changed type in doc to reference correct name of config setting name. 
- Added markdown linting rule to allow summary, details, and strong HTML elements as to my knowledge this isn't possible through markdown itself. 
## Motivation and Context
- Fix wrong info on doc
- Add rules since we use HTML details, strong, and summary in a few places in the docs.

## Testing
Build locally using Statiq

## Change Types Made

* [ ] Bug fix (non-breaking change)
* [ ] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [X] PowerShell code changes.

## Related Issue
Quick fix so no issue created ):

## Change Checklist

* [X] Requires a change to the documentation
* [X] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [ ] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.
