### PR TITLE
Update Chocolatey release videos

### DIFF
--- a/input/en-us/agent/release-notes.md
+++ b/input/en-us/agent/release-notes.md
@@ -37,7 +37,7 @@ A short video explaining what is included in this release can be found here:
 
 <p>
 <div class="ratio ratio-16x9">
-    <iframe src="https://www.youtube.com/embed/EoliKrC_MBA?list=PL84yg23i9GBhOSL0YVuJV2bG5fTOijsD4" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen>
+    <iframe src="https://www.youtube.com/embed/EoliKrC_MBA?list=PLGvGJzqY88snXVlfxr8pt9WxQ4nCjB9Uj" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen>
     </iframe>
 </div>
 <br>
@@ -63,7 +63,7 @@ A short video explaining what is included in this release can be found here:
 
 <p>
 <div class="ratio ratio-16x9">
-    <iframe src="https://www.youtube.com/embed/Uv59msxXzeg?list=PL84yg23i9GBhOSL0YVuJV2bG5fTOijsD4" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen>
+    <iframe src="https://www.youtube.com/embed/Uv59msxXzeg?list=PLGvGJzqY88snXVlfxr8pt9WxQ4nCjB9Uj" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen>
     </iframe>
 </div>
 <br>

--- a/input/en-us/central-management/release-notes.md
+++ b/input/en-us/central-management/release-notes.md
@@ -51,7 +51,7 @@ A short video explaining what is included in this release can be found here:
 
 <p>
 <div class="ratio ratio-16x9">
-    <iframe src="https://www.youtube.com/embed/WH9ecBP-1zY?list=PL84yg23i9GBilzTYltuVSvxuqPg56cCCe" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen>
+    <iframe src="https://www.youtube.com/embed/WH9ecBP-1zY?list=PLGvGJzqY88snxQwtZJ-OMUiMVuKHjg-br" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen>
     </iframe>
 </div>
 <br>
@@ -72,7 +72,7 @@ A short video explaining what is included in this release can be found here:
 
 <p>
 <div class="ratio ratio-16x9">
-    <iframe src="https://www.youtube.com/embed/D3z4w3O6w8Q?list=PL84yg23i9GBilzTYltuVSvxuqPg56cCCe" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen>
+    <iframe src="https://www.youtube.com/embed/D3z4w3O6w8Q?list=PLGvGJzqY88snxQwtZJ-OMUiMVuKHjg-br" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen>
     </iframe>
 </div>
 <br>
@@ -97,7 +97,7 @@ A short video explaining what is included in this release can be found here:
 
 <p>
 <div class="ratio ratio-16x9">
-    <iframe src="https://www.youtube.com/embed/UF3Z9PVh2K0?list=PL84yg23i9GBilzTYltuVSvxuqPg56cCCe" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen>
+    <iframe src="https://www.youtube.com/embed/UF3Z9PVh2K0?list=PLGvGJzqY88snxQwtZJ-OMUiMVuKHjg-br" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen>
     </iframe>
 </div>
 <br>
@@ -113,7 +113,7 @@ A short video explaining what is included in this release can be found here:
 
 <p>
 <div class="ratio ratio-16x9">
-    <iframe src="https://www.youtube.com/embed/pbgpxeRQ-V4?list=PL84yg23i9GBilzTYltuVSvxuqPg56cCCe" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen>
+    <iframe src="https://www.youtube.com/embed/pbgpxeRQ-V4?list=PLGvGJzqY88snxQwtZJ-OMUiMVuKHjg-br" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen>
     </iframe>
 </div>
 <br>
@@ -136,7 +136,7 @@ A short video explaining what is included in this release can be found here:
 
 <p>
 <div class="ratio ratio-16x9">
-    <iframe src="https://www.youtube.com/embed/i5_42euUABY?list=PL84yg23i9GBilzTYltuVSvxuqPg56cCCe" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen>
+    <iframe src="https://www.youtube.com/embed/i5_42euUABY?list=PLGvGJzqY88snxQwtZJ-OMUiMVuKHjg-br" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen>
     </iframe>
 </div>
 <br>
@@ -152,7 +152,7 @@ A short video explaining what is included in this release can be found here:
 
 <p>
 <div class="ratio ratio-16x9">
-    <iframe src="https://www.youtube.com/embed/ED6vAz6_AHk?list=PL84yg23i9GBilzTYltuVSvxuqPg56cCCe" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen>
+    <iframe src="https://www.youtube.com/embed/ED6vAz6_AHk?list=PLGvGJzqY88snxQwtZJ-OMUiMVuKHjg-br" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen>
     </iframe>
 </div>
 <br>
@@ -176,7 +176,7 @@ A short video explaining what is included in this release can be found here:
 
 <p>
 <div class="ratio ratio-16x9">
-    <iframe src="https://www.youtube.com/embed/ZeT4NxNRFwg?list=PL84yg23i9GBilzTYltuVSvxuqPg56cCCe" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen>
+    <iframe src="https://www.youtube.com/embed/ZeT4NxNRFwg?list=PLGvGJzqY88snxQwtZJ-OMUiMVuKHjg-br" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen>
     </iframe>
 </div>
 <br>

--- a/input/en-us/choco/release-notes.md
+++ b/input/en-us/choco/release-notes.md
@@ -17,6 +17,18 @@ This covers changes for the "chocolatey" and "chocolatey.lib" packages, which ar
  * Fix - Installation of Chocolatey fails when running under "AllSigned" execution policy - see [#2539](https://github.com/chocolatey/choco/issues/2539)
  * Fix - Output from "choco template -h" references wrong subcommand in usage statement - see [#2546](https://github.com/chocolatey/choco/issues/2546)
 
+ ### Release Video
+
+A short video explaining what is included in this release can be found here:
+
+<p>
+<div class="ratio ratio-16x9">
+    <iframe src="https://www.youtube.com/embed/2yKiCi5m9Jw?list=PLGvGJzqY88sm2CQ1Bf5ZGCgtJbTlgw1xK" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen>
+    </iframe>
+</div>
+<br>
+</p>
+
 
 ## [0.12.0](https://github.com/chocolatey/choco/issues?q=is%3Aclosed+milestone%3A0.12.0) (January 18th, 2022)
 
@@ -68,6 +80,8 @@ This covers changes for the "chocolatey" and "chocolatey.lib" packages, which ar
 ### Release Video
 
 A short video explaining what is included in this release can be found here:
+
+https://www.youtube.com/watch?v=2yKiCi5m9Jw&
 
 <p>
 <div class="ratio ratio-16x9">

--- a/input/en-us/choco/release-notes.md
+++ b/input/en-us/choco/release-notes.md
@@ -81,11 +81,9 @@ A short video explaining what is included in this release can be found here:
 
 A short video explaining what is included in this release can be found here:
 
-https://www.youtube.com/watch?v=2yKiCi5m9Jw&
-
 <p>
 <div class="ratio ratio-16x9">
-    <iframe src="https://www.youtube.com/embed/py-3BJIPebk?list=PL84yg23i9GBh4-KNBaQrTnwGlHsWFY6tc" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen>
+    <iframe src="https://www.youtube.com/embed/py-3BJIPebk?list=PLGvGJzqY88sm2CQ1Bf5ZGCgtJbTlgw1xK" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen>
     </iframe>
 </div>
 <br>
@@ -101,7 +99,7 @@ A short video explaining what is included in this release can be found here:
 
 <p>
 <div class="ratio ratio-16x9">
-    <iframe src="https://www.youtube.com/embed/YMLpILkkoGc?list=PL84yg23i9GBh4-KNBaQrTnwGlHsWFY6tc" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen>
+    <iframe src="https://www.youtube.com/embed/YMLpILkkoGc?list=PLGvGJzqY88sm2CQ1Bf5ZGCgtJbTlgw1xK" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen>
     </iframe>
 </div>
 <br>
@@ -117,7 +115,7 @@ A short video explaining what is included in this release can be found here:
 
 <p>
 <div class="ratio ratio-16x9">
-    <iframe src="https://www.youtube.com/embed/hSCh9o37qb8?list=PL84yg23i9GBh4-KNBaQrTnwGlHsWFY6tc" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen>
+    <iframe src="https://www.youtube.com/embed/hSCh9o37qb8?list=PLGvGJzqY88sm2CQ1Bf5ZGCgtJbTlgw1xK" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen>
     </iframe>
 </div>
 <br>
@@ -178,7 +176,7 @@ A short video explaining what is included in this release can be found here:
 
 <p>
 <div class="ratio ratio-16x9">
-    <iframe src="https://www.youtube.com/embed/hMzbedfEl8w?list=PL84yg23i9GBh4-KNBaQrTnwGlHsWFY6tc" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen>
+    <iframe src="https://www.youtube.com/embed/hMzbedfEl8w?list=PLGvGJzqY88sm2CQ1Bf5ZGCgtJbTlgw1xK" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen>
     </iframe>
 </div>
 <br>

--- a/input/en-us/chocolatey-gui-licensed-extension/release-notes.md
+++ b/input/en-us/chocolatey-gui-licensed-extension/release-notes.md
@@ -45,7 +45,7 @@ A short video explaining what is included in this release can be found here:
 
 <p>
 <div class="ratio ratio-16x9">
-    <iframe src="https://www.youtube.com/embed/O0fyUHe2pb8?list=PL84yg23i9GBjSzAEmtCqSLf2us_LLIDwZ" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen>
+    <iframe src="https://www.youtube.com/embed/O0fyUHe2pb8?list=PLGvGJzqY88slXNljm_qph3jnD2Z4bH6nx" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen>
     </iframe>
 </div>
 <br>
@@ -62,7 +62,7 @@ A short video explaining what is included in this release can be found here:
 
 <p>
 <div class="ratio ratio-16x9">
-    <iframe src="https://www.youtube.com/embed/t4h3Y9GMIrc?list=PL84yg23i9GBjSzAEmtCqSLf2us_LLIDwZ" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen>
+    <iframe src="https://www.youtube.com/embed/t4h3Y9GMIrc?list=PLGvGJzqY88slXNljm_qph3jnD2Z4bH6nx" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen>
     </iframe>
 </div>
 <br>
@@ -85,7 +85,7 @@ A short video explaining what is included in this release can be found here:
 
 <p>
 <div class="ratio ratio-16x9">
-    <iframe src="https://www.youtube.com/embed/tug8P1wxXmY?list=PL84yg23i9GBjSzAEmtCqSLf2us_LLIDwZ" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen>
+    <iframe src="https://www.youtube.com/embed/tug8P1wxXmY?list=PLGvGJzqY88slXNljm_qph3jnD2Z4bH6nx" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen>
     </iframe>
 </div>
 <br>
@@ -107,7 +107,7 @@ A short video explaining what is included in this release can be found here:
 
 <p>
 <div class="ratio ratio-16x9">
-    <iframe src="https://www.youtube.com/embed/kypWt1UyVwg?list=PL84yg23i9GBjSzAEmtCqSLf2us_LLIDwZ" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen>
+    <iframe src="https://www.youtube.com/embed/kypWt1UyVwg?list=PLGvGJzqY88slXNljm_qph3jnD2Z4bH6nx" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen>
     </iframe>
 </div>
 <br>

--- a/input/en-us/chocolatey-gui/release-notes.md
+++ b/input/en-us/chocolatey-gui/release-notes.md
@@ -74,7 +74,7 @@ A short video explaining what is included in this release can be found here:
 
 <p>
 <div class="ratio ratio-16x9">
-    <iframe src="https://www.youtube.com/embed/6EJKPy4cCKI?list=PL84yg23i9GBggcdl08xpJxOdikIvd3-3V" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen>
+    <iframe src="https://www.youtube.com/embed/6EJKPy4cCKI?list=PLGvGJzqY88slZbIf7_6QVAVmrZHujDW44" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen>
     </iframe>
 </div>
 <br>
@@ -92,7 +92,7 @@ A short video explaining what is included in this release can be found here:
 
 <p>
 <div class="ratio ratio-16x9">
-    <iframe src="https://www.youtube.com/embed/PC00qA4rlkY?list=PL84yg23i9GBggcdl08xpJxOdikIvd3-3V" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen>
+    <iframe src="https://www.youtube.com/embed/PC00qA4rlkY?list=PLGvGJzqY88slZbIf7_6QVAVmrZHujDW44" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen>
     </iframe>
 </div>
 <br>
@@ -116,7 +116,7 @@ A short video explaining what is included in this release can be found here:
 
 <p>
 <div class="ratio ratio-16x9">
-    <iframe src="https://www.youtube.com/embed/LzMKMZX_ja4?list=PL84yg23i9GBggcdl08xpJxOdikIvd3-3V" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen>
+    <iframe src="https://www.youtube.com/embed/LzMKMZX_ja4?list=PLGvGJzqY88slZbIf7_6QVAVmrZHujDW44" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen>
     </iframe>
 </div>
 <br>
@@ -171,7 +171,7 @@ A short video explaining what is included in this release can be found here:
 
 <p>
 <div class="ratio ratio-16x9">
-    <iframe src="https://www.youtube.com/embed/eKXPDmqO-hs?list=PL84yg23i9GBggcdl08xpJxOdikIvd3-3V" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen>
+    <iframe src="https://www.youtube.com/embed/eKXPDmqO-hs?list=PLGvGJzqY88slZbIf7_6QVAVmrZHujDW44" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen>
     </iframe>
 </div>
 <br>
@@ -189,7 +189,7 @@ A short video explaining what is included in this release can be found here:
 
 <p>
 <div class="ratio ratio-16x9">
-    <iframe src="https://www.youtube.com/embed/SAob-HgTf2Q?list=PL84yg23i9GBggcdl08xpJxOdikIvd3-3V" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen>
+    <iframe src="https://www.youtube.com/embed/SAob-HgTf2Q?list=PLGvGJzqY88slZbIf7_6QVAVmrZHujDW44" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen>
     </iframe>
 </div>
 <br>
@@ -207,7 +207,7 @@ A short video explaining what is included in this release can be found here:
 
 <p>
 <div class="ratio ratio-16x9">
-    <iframe src="https://www.youtube.com/embed/DGpdtcby9N4?list=PL84yg23i9GBggcdl08xpJxOdikIvd3-3V" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen>
+    <iframe src="https://www.youtube.com/embed/DGpdtcby9N4?list=PLGvGJzqY88slZbIf7_6QVAVmrZHujDW44" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen>
     </iframe>
 </div>
 <br>
@@ -226,7 +226,7 @@ A short video explaining what is included in this release can be found here:
 
 <p>
 <div class="ratio ratio-16x9">
-    <iframe src="https://www.youtube.com/embed/1wSwRMbds1k?list=PL84yg23i9GBggcdl08xpJxOdikIvd3-3V" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen>
+    <iframe src="https://www.youtube.com/embed/1wSwRMbds1k?list=PLGvGJzqY88slZbIf7_6QVAVmrZHujDW44" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen>
     </iframe>
 </div>
 <br>

--- a/input/en-us/licensed-extension/release-notes.md
+++ b/input/en-us/licensed-extension/release-notes.md
@@ -78,7 +78,7 @@ A short video explaining what is included in this release can be found here:
 
 <p>
 <div class="ratio ratio-16x9">
-    <iframe src="https://www.youtube.com/embed/p8m2nnSO7bw?list=PL84yg23i9GBgflAg7JGRLWh7tqTX7F5-z" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen>
+    <iframe src="https://www.youtube.com/embed/p8m2nnSO7bw?list=PLGvGJzqY88smUhr6TiAwpSs5W25-Z4RZ5" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen>
     </iframe>
 </div>
 <br>
@@ -108,7 +108,7 @@ A short video explaining what is included in this release can be found here:
 
 <p>
 <div class="ratio ratio-16x9">
-    <iframe src="https://www.youtube.com/embed/yohhvgtwxiM?list=PL84yg23i9GBgflAg7JGRLWh7tqTX7F5-z" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen>
+    <iframe src="https://www.youtube.com/embed/yohhvgtwxiM?list=PLGvGJzqY88smUhr6TiAwpSs5W25-Z4RZ5" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen>
     </iframe>
 </div>
 <br>


### PR DESCRIPTION
## Description Of Changes
Updated the Chocolatey release videos to point to Chocolatey YouTube.

## Motivation and Context
The videos in the Chocolatey release notes all point to videos on Gary's YouTube page. The last CLI release notes video we did was a Chocolatey Twitch Stream, so we would start to have mixed videos between Gary's and Chocolatey YouTube, possible causing confusion.

On YouTube, I've created a [playlist of Gary's release notes videos and added the latest Twitch stream one in there too](https://www.youtube.com/c/ChocolateySoftware/playlists?view=50&sort=dd&shelf_id=3). We need to update the docs to point to the Chocolatey YouTube playlist.

## Testing
Viewed through the Docker container.

## Change Types Made

* [ ] Bug fix (non-breaking change)
* [ ] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [ ] PowerShell code changes.

## Related Issue

Fixes #381.

## Change Checklist

* [x] Requires a change to the documentation
* [x] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [ ] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.
