### PR TITLE
(#386) Remove a blank line

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -90,7 +90,6 @@ Task("Run-Gulp")
     Gulp.Local.Execute();
 });
 
-
 Task("Statiq-Preview")
     .IsDependentOn("Run-Gulp")
     .Does<BuildData>((context, buildData) =>


### PR DESCRIPTION
## Description Of Changes

Add desktop.ini to gitignore, and remove an extraneous blank line from build.cake.

## Motivation and Context

I was blatantly stealing the build.cake for use on my statiq project, and I noticed an extra blank line. I also noticed that we had .DS_Store in gitignore, but not the Windows counterpart desktop.ini.

## Testing

Built site in dev container, confirmed that it built properly.

## Change Types Made

* [ ] Bug fix (non-breaking change)
* [x] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [ ] PowerShell code changes.

## Related Issue
<!-- Make sure you have raised an issue for this pull request before
continuing. -->

Fixes #386 

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [ ] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.
