### PR TITLE
(#388) Add .github templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Ask A Question
+    url: https://github.com/chocolatey/docs/discussions
+    about: Please ask and answer questions here.
+  - name: Security Issues or Concerns?
+    url: https://docs.chocolatey.org/en-us/information/security
+    about: Please see this for security vulnerabilities or concerns, including how to responsibly disclose to us.

--- a/.github/ISSUE_TEMPLATE/zFeatureRequest.md
+++ b/.github/ISSUE_TEMPLATE/zFeatureRequest.md
@@ -1,0 +1,28 @@
+---
+name: Documentation Enhancement / Addition
+about: Would you like to see new or updated documentation?
+---
+
+<!--
+Ensure you have read over [Submitting Issues](https://github.com/chocolatey/.github/blob/main/SUBMITTING_ISSUES.md)
+Please check to see if your issue already exists with a quick search of the issues. Start with one relevant term and then add if you get too many results.
+NOTE: Keep in mind we have a [Code Of Conduct](https://github.com/chocolatey/.github/blob/main/CODE_OF_CONDUCT.md) that we expect folks to observe when they are looking for support in the Chocolatey community.
+Name your issue appropriately: give it a sentence that reads well enough for anyone seeing this in the release notes to what it is.
+When writing out the issue details please ensure you are writing it as if you were explaining it to somebody else.
+Even if you will be working on and resolving the issue yourself. This helps others to understand the reasons for the issue and for it to be searchable in future.
+Please do not remove any of the headings.
+If a heading is not applicable then enter N/A: Why it's not applicable
+Please remove all comments before submitting.
+-->
+
+## What New Or Updated Would You Like To See?
+
+<!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
+
+## Why Is It Needed?
+
+<!-- A clear and concise description of what you want to happen. -->
+
+## Additional Context?
+
+<!-- Add any other context or screenshots about the feature request here. -->

--- a/.github/ISSUE_TEMPLATE/zReportIssue.md
+++ b/.github/ISSUE_TEMPLATE/zReportIssue.md
@@ -1,0 +1,29 @@
+---
+name: Report Issue
+about: Did you find issues in our documentation?
+---
+
+<!--
+Ensure you have read over [Submitting Issues](https://github.com/chocolatey/.github/blob/main/SUBMITTING_ISSUES.md)
+
+Please check to see if your issue already exists with a quick search of the issues. Start with one relevant term and then add if you get too many results.
+
+NOTE: Keep in mind we have a [Code Of Conduct](https://github.com/chocolatey/.github/blob/main/CODE_OF_CONDUCT.md) that we expect folks to observe when they are looking for support in the Chocolatey community.
+
+Name your issue appropriately: give it a sentence that reads well enough for anyone seeing this in the release notes to what it is.
+
+When writing out the issue details please ensure you are writing it as if you were explaining it to somebody else.
+Even if you will be working on and resolving the issue yourself. This helps others to understand the reasons for the issue and for it to be searchable in future.
+-->
+
+### What You Are Seeing?
+
+
+### What is Expected?
+
+
+### How Did You Get This To Happen? (Steps to Reproduce)
+
+<!--
+This section is not intended to be used for suggesting documentation changes.
+-->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,55 @@
+<!--
+BEFORE YOU CREATE A PULL REQUEST:
+
+Ensure you have read over [CONTRIBUTING.md](./CONTRIBUTING.md). We provide VERY defined guidance (as such, we strongly adhere to it).
+
+A summary of our expectations:
+ - You are not submitting a pull request from your MASTER / MAIN branch.
+ - YOUR GIT COMMIT MESSAGE FORMAT IS EXTREMELY IMPORTANT. We have a very defined expectation for this format and are sticklers about it. Really, READ the entire Contributing document. It will save you and us pain.
+ - Do not reformat code, it makes it hard to see what has changed. Leave the formatting to us.
+
+THANKS! We appreciate you reading the entire Contributing document and not just scanning through it.
+
+Name your issue appropriately: give it a sentence that reads well enough for anyone seeing this in release notes to know what the issue is.
+
+When writing out the pull request details please ensure you are writing it as
+if you were explaining it to somebody else.
+Even if you will be working on and resolving the issue yourself.
+This helps others to understand the reasons for the pull request and for it to be searchable in future.
+
+Please do not remove any of the headings.
+If a heading is not applicable then enter N/A: Why it's not applicable
+
+Make sure you have raised an issue for this pull request before continuing.
+
+Please remove all comments before submitting.
+-->
+
+## Description Of Changes
+<!-- Enter a description of the pull request changes -->
+
+## Motivation and Context
+<!-- Why is this change necessary and under what context is it being done -->
+
+## Testing
+
+* [ ] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.
+
+## Change Types Made
+<!-- Tick the boxes for the type of changes that have been made -->
+
+* [ ] Minor documentation fix (typos etc.).
+* [ ] Major documentation change (refactoring, reformatting or adding documentation to existing page).
+* [ ] New documentation page added.
+
+## Change Checklist
+
+* [ ] Requires a change to menu structure (top or left hand side)/
+* [ ] Menu structure has been updated
+
+## Related Issue
+<!-- Make sure you have raised an issue for this pull request before continuing. -->
+
+Fixes #
+
+<!-- PLEASE REMOVE ALL COMMENTS BEFORE SUBMITTING -->


### PR DESCRIPTION
## Description Of Changes
Added relevant .github templates.

## Motivation and Context
The [standard templates for the Chocolatey organization](https://github.com/chocolatey/.github) has information not relevant to this repository.

## Testing
No testing was done.

## Change Types Made

* [ ] Bug fix (non-breaking change)
* [x] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [ ] PowerShell code changes.

## Related Issue
<!-- Make sure you have raised an issue for this pull request before
continuing. -->

Fixes #388 

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [ ] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.

[Clickup Task](https://app.clickup.com/t/20540031/ENGTASKS-577)