### PR TITLE
(#396) Adds WinSysBlog Archive Links

### DIFF
--- a/input/en-us/features/package-internalizer.md
+++ b/input/en-us/features/package-internalizer.md
@@ -88,8 +88,8 @@ See [download command](xref:choco-command-download) for more information.
 Community posts that include Package Internalizer:
 
 * [Getting Started With Chocolatey 4 Business & Jenkins CI](https://blog.pauby.com/post/getting-started-with-chocolatey-and-jenkins/)
-* [Automating Chocolatey package internalizing with PowerShell](https://winsysblog.com/2017/10/automating-chocolatey-package-internalizing-with-powershell.html)
-* [Recompiling Chocolatey packages](https://winsysblog.com/2017/08/recompiling-chocolatey-packages.html)
+* [Automating Chocolatey package internalizing with PowerShell](https://winsysblog.com/2017/10/automating-chocolatey-package-internalizing-with-powershell.html) ([archive.org](https://web.archive.org/web/20201025112142/https://winsysblog.com/2017/10/automating-chocolatey-package-internalizing-with-powershell.html))
+* [Recompiling Chocolatey packages](https://winsysblog.com/2017/08/recompiling-chocolatey-packages.html) ([archive.org](https://web.archive.org/web/20210815015512/https://winsysblog.com/2017/08/recompiling-chocolatey-packages.html))
 
 ## FAQ
 

--- a/input/en-us/information/learning-resources/resources.md
+++ b/input/en-us/information/learning-resources/resources.md
@@ -55,7 +55,7 @@ See [Infrastructure automation](xref:integrations)
 #### July
 
 * https://techielass.com/automating-azure-vm-with-chef
-* https://winsysblog.com/2019/07/introducing-the-chocolatey-remote-management-powershell-gui.html
+* https://winsysblog.com/2019/07/introducing-the-chocolatey-remote-management-powershell-gui.html ([archive.org](https://web.archive.org/web/20210814063003/https://winsysblog.com/2019/07/introducing-the-chocolatey-remote-management-powershell-gui.html))
 
 #### June
 
@@ -80,11 +80,11 @@ See [Infrastructure automation](xref:integrations)
 
 #### December
 
-* https://winsysblog.com/2018/12/using-multiple-package-repositories-with-chocolatey.html
+* https://winsysblog.com/2018/12/using-multiple-package-repositories-with-chocolatey.html ([archive.org](https://web.archive.org/web/20210813110818/https://winsysblog.com/2018/12/using-multiple-package-repositories-with-chocolatey.html))
 
 #### September
 
-* https://winsysblog.com/2018/09/anatomy-of-a-chocolatey-package.html
+* https://winsysblog.com/2018/09/anatomy-of-a-chocolatey-package.html ([archive.org](https://web.archive.org/web/20210817161935/https://winsysblog.com/2018/09/anatomy-of-a-chocolatey-package.html))
 
 #### October
 
@@ -92,16 +92,16 @@ See [Infrastructure automation](xref:integrations)
 
 #### August
 
-* https://winsysblog.com/2018/08/installing-chocolatey-packages-remotely-with-powershell.html
+* https://winsysblog.com/2018/08/installing-chocolatey-packages-remotely-with-powershell.html ([archive.org](https://web.archive.org/web/20210814141429/https://winsysblog.com/2018/08/installing-chocolatey-packages-remotely-with-powershell.html))
 
 #### July
 
 * https://www.gep13.co.uk/blog/problem-running-chocolatey-test-environment
-* https://winsysblog.com/2018/07/auditing-software-with-chocolatey.html
+* https://winsysblog.com/2018/07/auditing-software-with-chocolatey.html ([archive.org](https://web.archive.org/web/20210813115006/https://winsysblog.com/2018/07/auditing-software-with-chocolatey.html))
 
 #### June
 
-* https://winsysblog.com/2018/06/install-internalized-chocolatey-packages-from-your-offline-repository.html
+* https://winsysblog.com/2018/06/install-internalized-chocolatey-packages-from-your-offline-repository.html ([archive.org](https://web.archive.org/web/20210815153256/https://winsysblog.com/2018/06/install-internalized-chocolatey-packages-from-your-offline-repository.html))
 
 #### April
 
@@ -134,11 +134,11 @@ See [Infrastructure automation](xref:integrations)
 #### October
 
 * http://jkarger.de/2017/10/29/tile-banner-for-chocolateygui/
-* https://winsysblog.com/2017/10/automating-chocolatey-package-internalizing-with-powershell.html (C4B)
+* https://winsysblog.com/2017/10/automating-chocolatey-package-internalizing-with-powershell.html (C4B) ([archive.org](https://web.archive.org/web/20210814170920/https://winsysblog.com/2017/10/automating-chocolatey-package-internalizing-with-powershell.html))
 
 #### August
 
-* http://www.winsysblog.com/2017/08/recompiling-chocolatey-packages.html (C4B)
+* http://www.winsysblog.com/2017/08/recompiling-chocolatey-packages.html (C4B) ([archive.org](https://web.archive.org/web/20210815015512/https://winsysblog.com/2017/08/recompiling-chocolatey-packages.html))
 * https://controlaltfail.wordpress.com/2017/08/03/salt-chocolatey-install-totally-offline/
 
 #### July
@@ -161,12 +161,12 @@ See [Infrastructure automation](xref:integrations)
 
 #### April
 
-* http://www.winsysblog.com/2017/04/importing-hosted-nuget-packages-into.html (MDT)
+* http://www.winsysblog.com/2017/04/importing-hosted-nuget-packages-into.html (MDT) ([archive.org](https://web.archive.org/web/20201201143740/https://winsysblog.com/2017/04/importing-hosted-nuget-packages-into.html))
 * http://www.laurierhodes.info/?q=node/129
 
 #### March
 
-* https://winsysblog.com/2017/03/creating-software-packages-wi.html
+* https://winsysblog.com/2017/03/creating-software-packages-wi.html ([archive.org](https://web.archive.org/web/20210813091644/https://winsysblog.com/2017/03/creating-software-packages-wi.html))
 * https://brian.teeman.net/joomla/885-install-amp-on-windows-with-chocolatey
 
 #### February


### PR DESCRIPTION
## Description Of Changes
The commit adds web archive links to the various blogposts to ensure folk can easily access the data.

## Motivation and Context
WinSysBlog.com has been broken for some time, leaving broken links in our docs.

## Testing

1. Built and previewed the changes on my local machine
    ![image](https://user-images.githubusercontent.com/1975761/156359785-fef8f69c-e884-4a47-bf5d-5a77a34429e0.png)
    ![image](https://user-images.githubusercontent.com/1975761/156359863-14010269-1d9a-4524-8f8a-9d0acba3c16b.png)

## Change Types Made

* [x] Bug fix (non-breaking change)
* [ ] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [ ] PowerShell code changes.

## Related Issue

Fixes #396

## Change Checklist

* [ ] Requires a change to the documentation
* [x] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [x] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.
