### PR TITLE
(#345) Update documentation mention Get-BinRoot deprecation

### DIFF
--- a/input/en-us/community-repository/moderation/package-validator/rules/cpmr0035.md
+++ b/input/en-us/community-repository/moderation/package-validator/rules/cpmr0035.md
@@ -16,6 +16,10 @@ In an automation script (`.ps1`/`.psm1`),
 
 ## Recommended Solution
 
-Please update _ so that _
+Replace all uses of the cmdlet `Get-BinRoot` to use `Get-ToolsLocation` instead.
 
 ## Reasoning
+
+The PowerShell cmdlet is badly named, and was replaced with a new cmdlet called `Get-ToolsLocation` instead.
+The cmdlet is also deprecated in version 1.0.0 of Chocolatey and will be removed in version 2.0.0 so any calls
+to the cmdlet should no longer be made.

--- a/input/en-us/create/create-packages.md
+++ b/input/en-us/create/create-packages.md
@@ -177,13 +177,15 @@ If you think, the user should be able to customize this path and you, the packag
 
 You can extract the application within the package directory itself (or even ship an extracted version with the package). This allows Chocolatey to automatically find executables and put those on `%path%`.
 
-### 3. Path provided by the `Get-BinRoot` helper - will be deprecated later (closer to v1) but okay to use for now
+### 3 Path provided by the `Get-ToolsLocation` helper
 
-The path returned by the helper `Get-BinRoot` can be used as the parent directory for the installation. `Get-BinRoot` will return the value of the  environment variable `%ChocolateyBinRoot%`. If the value does not contain a drive reference, the system drive will be prepended. If the environment variable is not set, the default path (~~`C:\Tools`~~ `C:\Chocolatey\bin`) will be returned.
+> :warning: **WARNING** It was previously possible to use the helper `Get-BinRoot` for backwards compatibility. This is still possible in v1.0.0, however its use is not recommended as the function is now deprecated, and will be removed in v2.0.0.
 
-As an example, [MinGW](https://github.com/ferventcoder/chocolatey-packages/blob/master/manual/mingw/tools/chocolateyInstall.ps1) uses `%ChocolateyBinRoot%`. If the environment variable is not set, it will be set to `c:\tools` and MinGW will install to `C:\Tools\MinGW` by default. If `%ChocolateyBinRoot%` is set to "C:\Common\bin", MinGW installs to `C:\Common\bin\MinGW`.
+The path returned by the helper `Get-ToolsLocation` can be used as the parent directory for the installation. `Get-ToolsLocation` will return the value of the  environment variable `%ChocolateyToolsLocation%`. If the value does not contain a drive reference, the system drive will be prepended. If the environment variable is not set, the default path (`C:\tools`) will be returned.
 
-`%ChocolateyBinRoot%` gives the Chocolatey user a way of controlling where packages are installed. If you want to allow customizing the installation path, then this is currently the way to go.
+As an example, [GeoServer](https://github.com/AdmiringWorm/chocolatey-packages/blob/0f3b93ab7b067b265a06349a68297d07b1598e64/automatic/geoserver/tools/chocolateyuninstall.ps1#L8) uses `%ChocolateyToolsLocation%`. If the environment variable is not set, it will be set to `c:\tools` and GeoServer will install to `C:\tools\GeoServer` by default. If `%ChocolateyToolsLocation%` is set to "C:\Common\bin", GeoServer installs to `C:\Common\bin\GeoServer`.
+
+`%ChocolateyToolsLocation%` gives the Chocolatey user a way of controlling where packages are installed. If you want to allow customizing the installation path, then this is currently the way to go.
 
 ### Make it clear in the package description
 

--- a/input/en-us/getting-started.md
+++ b/input/en-us/getting-started.md
@@ -170,7 +170,7 @@ How the heck does this all work?
 1. Starting in 0.9.10, Chocolatey will look for and run a chocolateyBeforeModify.ps1 file in the existing package prior to upgrading or uninstalling a package. This is your opportunity to shut down services and/or processes. This is run from the existing package, not the new version of the package. If it fails, it just passes a warning and continues on.
 2. Similar to install, except choco will make a backup of the package folder (and only the package folder) prior to attempting upgrade.
 3. The files snapshot is used to determine what files can be removed from the package folder. If those files have not changed, they will be removed.
-4. If the upgrade fails, choco will ask if you want to rollback the package folder to the previous version. If you choose to move roll back, it will put the backed up package directory back in place. This does not fix any folders you may have been using outside of the package directory, such as where the native installer may have installed a program to nor the location of `Get-ToolsLocation`/`Get-BinRoot` (e.g. `c:\tools`). You will need to handle those fixes on your own. Chocolatey also doesn't rerun any install scripts on rollback.
+4. If the upgrade fails, choco will ask if you want to rollback the package folder to the previous version. If you choose to move roll back, it will put the backed up package directory back in place. This does not fix any folders you may have been using outside of the package directory, such as where the native installer may have installed a program to nor the location of `Get-ToolsLocation` (e.g. `c:\tools`). You will need to handle those fixes on your own. Chocolatey also doesn't rerun any install scripts on rollback.
 
 ### Uninstall
 


### PR DESCRIPTION
## Description Of Changes

﻿Thpull request updates the mentions about Get-BinRoot to
say that this cmdlet is deprecated, and to instead use
the cmdlet Get-ToolsLocation instead.

## Motivation and Context

This is necessary as the Get-BinRoot will be deprecated, and eventually removed in a future major release.

## Testing

N/A

## Change Types Made

* [ ] Bug fix (non-breaking change)
* [ ] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [ ] PowerShell code changes.
* [x] Documentation.

## Related Issue

Fixes #345

## Change Checklist

* [ ] Requires a change to the documentation
* [x] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [ ] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.
