### PR TITLE
(maint) Remove GitHub template security question

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,6 +3,3 @@ contact_links:
   - name: Ask A Question
     url: https://github.com/chocolatey/docs/discussions
     about: Please ask and answer questions here.
-  - name: Security Issues or Concerns?
-    url: https://docs.chocolatey.org/en-us/information/security
-    about: Please see this for security vulnerabilities or concerns, including how to responsibly disclose to us.


### PR DESCRIPTION
## Description Of Changes
Remove the Security question from the issue template options. This was noticed [here](https://github.com/chocolatey/docs/pull/389).

Note that this can't be tested so no testing has been done.

## Motivation and Context
The security question is added automatically from the [organizational template Security policy](https://github.com/chocolatey/.github/blob/main/.github/SECURITY.md).

## Testing

* [ ] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made

* [ ] Minor documentation fix (typos etc.).
* [ ] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.

## Change Checklist

* [ ] Requires a change to menu structure (top or left hand side)/
* [ ] Menu structure has been updated

## Related Issue

N/A