### PR TITLE
(#415) Update tab completion code block with correct code

### DIFF
--- a/input/en-us/troubleshooting.md
+++ b/input/en-us/troubleshooting.md
@@ -170,7 +170,11 @@ Once you've looked at your log to determine what it said, here are some followup
 - If that is fine, then we need to look at your "$profile". Run `type $profile`. Examine the output. You should have something like this in the file:
 
 ~~~powershell
-# Chocolatey profile
+# Import the Chocolatey Profile that contains the necessary code to enable
+# tab-completions to function for `choco`.
+# Be aware that if you are missing these lines from your profile, tab completion
+# for `choco` will not function.
+# See https://ch0.co/tab-completion for details.
 $ChocolateyProfile = "$env:ChocolateyInstall\helpers\chocolateyProfile.psm1"
 if (Test-Path($ChocolateyProfile)) {
   Import-Module "$ChocolateyProfile"


### PR DESCRIPTION
## Description Of Changes

This pr updates the example used when tab completions do not work on our documentation site to be the same code that is actually added by Chocolatey CLI v1.0.0.

## Motivation and Context

To have the documentation example accurately reflect what will be added by Chocolatey CLI (at least the latest version).

## Testing

* [x] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made

* [x] Minor documentation fix (typos etc.).
* [ ] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.

## Change Checklist

* [ ] Requires a change to menu structure (top or left hand side)/
* [ ] Menu structure has been updated

## Related Issue

Fixes #415
