### PR TITLE
(#367) Navigate to nested items on hash change

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -1336,9 +1336,9 @@ __metadata:
   linkType: hard
 
 "@types/marked@npm:^4.0.1":
-  version: 4.0.2
-  resolution: "@types/marked@npm:4.0.2"
-  checksum: 61d7f47b2b9924a63600f975ae0417894d0b5e009d8d75d165ace563ec3b0e56205e66df08bc68017a530315289b491f2626e3e0b8e33ac08aec474b1944f0e8
+  version: 4.0.3
+  resolution: "@types/marked@npm:4.0.3"
+  checksum: 2fc409a6291cb770688731a444f54e7eab6257c9b565dea4e9d2f3b6654b606e9dd8ea4a924e306b2d2f581dedcb7a27f10f2ca7aed828b11642ab85955341f1
   languageName: node
   linkType: hard
 
@@ -2136,7 +2136,7 @@ __metadata:
 
 "choco-theme@git+https://github.com/chocolatey/choco-theme.git":
   version: 0.1.0
-  resolution: "choco-theme@https://github.com/chocolatey/choco-theme.git#commit=d485202397a02c3bc6c262412f3a0d5b906f254d"
+  resolution: "choco-theme@https://github.com/chocolatey/choco-theme.git#commit=610e9aa1ac52e7e860ce9483491a8202fdf4baee"
   dependencies:
     "@babel/core": ^7.12.3
     "@babel/preset-env": ^7.12.1
@@ -2173,7 +2173,7 @@ __metadata:
     mousetrap: ^1.6.5
     node-sass: ^7.0.1
     nouislider: ^15.5.1
-  checksum: f12332455ff57040ef809721c685dead362f36924fa883953b6a3adb2d554bfa32cd791d7adfd8fed047e2e05d93464820c588a6397183c18793ac700db04163
+  checksum: 1209bf03b258be0620b6a9cb101da44b765fd21bfa4361740da14178ac17b225a4b0c48f429d3ad134181127c5e77075ef9afd35846dbb5aec0193b534d8a131
   languageName: node
   linkType: hard
 
@@ -4377,13 +4377,11 @@ __metadata:
   linkType: hard
 
 "json5@npm:^2.1.2":
-  version: 2.2.0
-  resolution: "json5@npm:2.2.0"
-  dependencies:
-    minimist: ^1.2.5
+  version: 2.2.1
+  resolution: "json5@npm:2.2.1"
   bin:
     json5: lib/cli.js
-  checksum: e88fc5274bb58fc99547baa777886b069d2dd96d9cfc4490b305fd16d711dabd5979e35a4f90873cefbeb552e216b041a304fe56702bedba76e19bc7845f208d
+  checksum: 74b8a23b102a6f2bf2d224797ae553a75488b5adbaee9c9b6e5ab8b510a2fc6e38f876d4c77dea672d4014a44b2399e15f2051ac2b37b87f74c0c7602003543b
   languageName: node
   linkType: hard
 
@@ -4806,13 +4804,6 @@ __metadata:
     is-plain-obj: ^1.1.0
     kind-of: ^6.0.3
   checksum: 8c040b3068811e79de1140ca2b708d3e203c8003eb9a414c1ab3cd467fc5f17c9ca02a5aef23bedc51a7f8bfbe77f87e9a7e31ec81fba304cda675b019496f4e
-  languageName: node
-  linkType: hard
-
-"minimist@npm:^1.2.5":
-  version: 1.2.5
-  resolution: "minimist@npm:1.2.5"
-  checksum: 86706ce5b36c16bfc35c5fe3dbb01d5acdc9a22f2b6cc810b6680656a1d2c0e44a0159c9a3ba51fb072bb5c203e49e10b51dcd0eec39c481f4c42086719bae52
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description Of Changes
This updates how anchors are navigated to when they are located
inside a collapsed element. The previous implementation stopped working,
and this is a long term solution to fix the bug for good. This is
mostly used on the docs site on the setup Chocolatey CLI page, and on
the pricing page, however it can be used anywhere needed.

Changes done via choco-theme:
https://github.com/chocolatey/choco-theme/commit/b9572ff012c7bc3dd6024dddb70bc92f30a86f31

## Motivation and Context
Links should always navigate to where they are pointing to.

## Testing
1. Linked choco-theme to both docs and chocolatey.org
2. On the docs site, went to `/en-us/choco/setup`
3. In the right hand nav, clicked on "Completely Offline Install" (2nd option under "More Install Options")
4. Clicking opened up the collapsed element and navigated me to the correct spot.

## Change Types Made
* [ ] Minor documentation fix (typos etc.).
* [ ] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.

## Change Checklist
* [ ] Requires a change to menu structure (top or left hand side)/
* [ ] Menu structure has been updated

## Related Issue
* https://github.com/chocolatey/choco-theme/issues/142
* https://github.com/chocolatey/docs/issues/367
* https://github.com/chocolatey/chocolatey.org/issues/126
