### PR TITLE
(maint) Make titles consistent

### DIFF
--- a/input/en-us/central-management/release-notes.md
+++ b/input/en-us/central-management/release-notes.md
@@ -43,7 +43,7 @@ This covers the release notes for the Chocolatey Central Management (`chocolatey
 - Disable updating of related group information when it is not needed as computers are reporting in.
 
 
-## 0.7.0 (November 17th, 2021)
+## 0.7.0 (November 17, 2021)
 ### BREAKING CHANGES
  * Additional steps required to change LDAP and SMTP passwords.
    * The LDAP and SMTP password is no longer present on the page so cannot be inspected.
@@ -75,7 +75,7 @@ A short video explaining what is included in this release can be found here:
 <br>
 </p>
 
-## 0.6.3 (September 23rd, 2021)
+## 0.6.3 (September 23, 2021)
 ### BUG FIXES
  * Fix - Processing of message queue does not complete when an invalid XML file is located - see [Licensed #266](https://github.com/chocolatey/chocolatey-licensed-issues/issues/266)
  * Fix - When the "Only one concurrent login per user" setting is enabled, users are locked out of CCM Web UI - see [Licensed #260](https://github.com/chocolatey/chocolatey-licensed-issues/issues/260)
@@ -96,7 +96,7 @@ A short video explaining what is included in this release can be found here:
 <br>
 </p>
 
-## 0.6.2 (August 26th, 2021)
+## 0.6.2 (August 26, 2021)
 ### BUG FIXES
  * Fix - Service - Method to determine correct SSL certificate to use between CCM Service installation script and execution is inconsistent
  * Fix - Service - Exceptions thrown during CCM Service startup do not halt internal service tasks
@@ -121,7 +121,7 @@ A short video explaining what is included in this release can be found here:
 <br>
 </p>
 
-## 0.6.1 (August 5th, 2021)
+## 0.6.1 (August 5, 2021)
 ### BUG FIXES
  * Fix - Service - Unable to install chocolatey-management-service package under certain conditions - see [Licensed #242](https://github.com/chocolatey/chocolatey-licensed-issues/issues/242)
 
@@ -137,7 +137,7 @@ A short video explaining what is included in this release can be found here:
 <br>
 </p>
 
-## 0.6.0 (August 3rd, 2021)
+## 0.6.0 (August 3, 2021)
 ### BREAKING CHANGES
  * Audit Retention
    * By default, Audit Logs generated within CCM will now be kept for 30 days, after which they will be removed
@@ -160,7 +160,7 @@ A short video explaining what is included in this release can be found here:
 <br>
 </p>
 
-## 0.5.1 (April 12th, 2021)
+## 0.5.1 (April 12, 2021)
 ### BUG FIXES
  * Fix - Service - Unable to process deployment report messages that contain invalid XML characters - see [Licensed #216](https://github.com/chocolatey/chocolatey-licensed-issues/issues/216)
 

--- a/input/en-us/choco/release-notes.md
+++ b/input/en-us/choco/release-notes.md
@@ -38,7 +38,7 @@ This covers changes for the "chocolatey" and "chocolatey.lib" packages, which ar
 - Document the fact that the Source switch doesn't do anything when running the command choco list --lo - see [#2545](https://github.com/chocolatey/choco/issues/2545)
 - Update warning that is shown regarding using a trial license of Chocolatey - see [#2407](https://github.com/chocolatey/choco/issues/2407)
 
-## [0.12.1](https://github.com/chocolatey/choco/issues?q=is%3Aclosed+milestone%3A0.12.1) (January 25th, 2022)
+## [0.12.1](https://github.com/chocolatey/choco/issues?q=is%3Aclosed+milestone%3A0.12.1) (January 25, 2022)
 
 ### Bug Fixes
 
@@ -57,7 +57,7 @@ A short video explaining what is included in this release can be found here:
 <br>
 </p>
 
-## [0.12.0](https://github.com/chocolatey/choco/issues?q=is%3Aclosed+milestone%3A0.12.0) (January 18th, 2022)
+## [0.12.0](https://github.com/chocolatey/choco/issues?q=is%3Aclosed+milestone%3A0.12.0) (January 18, 2022)
 
 > :warning: **WARNING**
 >
@@ -100,7 +100,7 @@ A short video explaining what is included in this release can be found here:
 - Update default template regarding building Chocolatey package on non-Windows systems - see [#2384](https://github.com/chocolatey/choco/issues/2384)
 - Fix version number used in default template - see [#2381](https://github.com/chocolatey/choco/pull/2381)
 
-## [0.11.3](https://github.com/chocolatey/choco/issues?q=is%3Aclosed+milestone%3A0.11.3) (October 27th, 2021)
+## [0.11.3](https://github.com/chocolatey/choco/issues?q=is%3Aclosed+milestone%3A0.11.3) (October 27, 2021)
 
 ### Bug Fixes
 
@@ -122,7 +122,7 @@ A short video explaining what is included in this release can be found here:
 <br>
 </p>
 
-## [0.11.2](https://github.com/chocolatey/choco/issues?q=is%3Aclosed+milestone%3A0.11.2) (September 23rd, 2021)
+## [0.11.2](https://github.com/chocolatey/choco/issues?q=is%3Aclosed+milestone%3A0.11.2) (September 23, 2021)
 
 ### Bug Fix
 

--- a/input/en-us/information/learning-resources/presentations.md
+++ b/input/en-us/information/learning-resources/presentations.md
@@ -18,9 +18,9 @@ RedirectFrom: docs/presentations
 
 ### 2019
 
-* [Automating the Software Deployment Lifecycle in Azure with Chocolatey, Jenkins and PowerShell](https://blog.pauby.com/presentation/20190702-neaug/) - [North East Azure User Group](https://www.meetup.com/North-East-Azure-User-Group/) - [Paul Broadwith](https://pauby.com), [June 6th, 2019](https://www.meetup.com/North-East-Azure-User-Group/events/261825832/)
-* [Click Free Application Deployment with the Magic of PowerShell and Chocolatey](https://blog.pauby.com/presentation/20190607-psconfeu/) - [PowerShell Conference Europe](https://psconf.eu/2019/) - [Paul Broadwith](https://pauby.com), June 7th, 2019 - [Video](https://www.youtube.com/watch?v=HAWRkWMnAus&list=PLfpfxDPYyd6KBiKwl2oopwG8ogAUtQ9nP)
-* [Automating the Software Deployment Lifecycle with Chocolatey, Jenkins and PowerShell](https://blog.pauby.com/presentation/20190606-psconfeu/) - [PowerShell Conference Europe](https://psconf.eu/2019/) - [Paul Broadwith](https://pauby.com), June 6th, 2019 - [Video](https://www.youtube.com/watch?v=TvWl2VzGo5U&list=PLfpfxDPYyd6KBiKwl2oopwG8ogAUtQ9nP)
+* [Automating the Software Deployment Lifecycle in Azure with Chocolatey, Jenkins and PowerShell](https://blog.pauby.com/presentation/20190702-neaug/) - [North East Azure User Group](https://www.meetup.com/North-East-Azure-User-Group/) - [Paul Broadwith](https://pauby.com), [June 6, 2019](https://www.meetup.com/North-East-Azure-User-Group/events/261825832/)
+* [Click Free Application Deployment with the Magic of PowerShell and Chocolatey](https://blog.pauby.com/presentation/20190607-psconfeu/) - [PowerShell Conference Europe](https://psconf.eu/2019/) - [Paul Broadwith](https://pauby.com), June 7, 2019 - [Video](https://www.youtube.com/watch?v=HAWRkWMnAus&list=PLfpfxDPYyd6KBiKwl2oopwG8ogAUtQ9nP)
+* [Automating the Software Deployment Lifecycle with Chocolatey, Jenkins and PowerShell](https://blog.pauby.com/presentation/20190606-psconfeu/) - [PowerShell Conference Europe](https://psconf.eu/2019/) - [Paul Broadwith](https://pauby.com), June 6, 2019 - [Video](https://www.youtube.com/watch?v=TvWl2VzGo5U&list=PLfpfxDPYyd6KBiKwl2oopwG8ogAUtQ9nP)
 
 ### 2017
 


### PR DESCRIPTION
## Description Of Changes

When expressing a date, we should use (for example) March 21, 2022,
without any sort of suffix, i.e. th, st, or rd.

## Motivation and Context

Consistency with the remainder of the document.

## Testing

* [x] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made

* [x] Minor documentation fix (typos etc.).
* [ ] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.

## Change Checklist

* [ ] Requires a change to menu structure (top or left hand side)/
* [ ] Menu structure has been updated

## Related Issue

N/A