### PR TITLE
(maint) Add warning about Licensed requirement

### DIFF
--- a/input/en-us/choco/release-notes.md
+++ b/input/en-us/choco/release-notes.md
@@ -16,6 +16,10 @@ This covers changes for the "chocolatey" and "chocolatey.lib" packages, which ar
 
 ## [1.0.0](https://github.com/chocolatey/choco/milestone/50?closed=1) (March 21, 2022)
 
+> :warning: **WARNING**
+>
+> If you are using a commercial version of Chocolatey (i.e. you have the chocolatey.extension package installed), you will need to **_first_** upgrade to version v4.0.0 of the [Chocolatey Licensed Extension](xref:licensed-extension-release-notes#march-21-2022).
+
 ### Breaking Changes
 
 - Remove deprecated Chocolatey commands and shims - see [#2468](https://github.com/chocolatey/choco/issues/2468)


### PR DESCRIPTION
## Description Of Changes

This was pointed out in Discord that we should have a note in the CLI
release notes that you _need_ to have at least v4.0.0 of the Licensed
Extension in order to use v1.0.0 of CLI.


## Motivation and Context

To try to make it clearer to folks exactly what is required.

## Testing

* [x] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made

* [x] Minor documentation fix (typos etc.).
* [ ] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.

## Change Checklist

* [ ] Requires a change to menu structure (top or left hand side)/
* [ ] Menu structure has been updated

## Related Issue

N/A