### PR TITLE
(#427) Add CLE Compatibility page

### DIFF
--- a/input/en-us/licensed-extension/compatibility.md
+++ b/input/en-us/licensed-extension/compatibility.md
@@ -1,0 +1,58 @@
+---
+Order: 30
+xref: licensed-extension-compatibility
+Title: Compatibility
+Description: Compatibility Information for Chocolatey Licensed Extension
+RedirectFrom:
+---
+
+## Summary
+
+This covers the compatibility information for the Chocolatey Licensed Extension and associated Chocolatey and other product versions.
+The Chocolatey Licensed Extension is designed to work with a certain corresponding version range of the Chocolatey CLI package.
+Using incompatible versions of Chocolatey CLI with the Chocolatey Licensed Extension may result in undesirable behaviour.
+
+This page serves as a reference for troubleshooting and resolving issues that may arise from having incompatible versions of the Chocolatey Licensed Extension installed.
+
+<?! Include "../../shared/chocolatey-component-dependencies.txt" /?>
+
+## Troubleshooting
+
+The above table lists the compatible product versions with the most recent version of the Chocolatey Licensed Extension.
+If you are working with an earlier version of Chocolatey Licensed Extension, please consult the [Chocolatey Licensed Extension](xref:licensed-extension-release-notes) release notes to determine the recommended version(s) of Chocolatey CLI for your version of the Chocolatey Licensed Extension.
+
+> :warning: **WARNING**
+>
+> Chocolatey CLI v1.0.1 and up may continue to work for versions of the Chocolatey Licensed Extension older than v4.0.0, but these configurations are not supported for use in a production environment.
+> We recommend all customers update to new product versions as they are able to do so in order to get the latest features and fixes.
+
+In Chocolatey CLI versions v1.0.1 and newer, you may receive error messages from the licensed extension, but these will not prevent Chocolatey from functioning.
+In order to resolve these messages, simply use `choco install` or `choco upgrade` to install, upgrade, or downgrade the Chocolatey CLI or Chocolatey Licensed Extension packages as appropriate to ensure you are using compatible versions of Chocolatey CLI and the Chocolatey Licensed Extension.
+
+In Chocolatey CLI versions prior to v1.0.1, you may receive error messages similar to the following if there are incompatible versions of the Chocolatey Licensed Extension installed:
+
+```error
+The registered delegate for type IEnumerable<ICommand> threw an exception.
+```
+
+To resolve these errors, you will need to rename or move the Chocolatey Licensed Extension folder on your system in order to restore Chocolatey functionality.
+From a PowerShell console, you can run the following command to back up your Chocolatey Licensed Extension and get basic Chocolatey CLI functionality back:
+
+```powershell
+Rename-Item -Path "$env:ChocolateyInstall\extensions\chocolatey" -NewName "chocolatey.old"
+```
+
+Once that's done, use `choco install` or `choco upgrade` to install, upgrade, or downgrade the Chocolatey CLI or Chocolatey Licensed Extension packages as appropriate to ensure you are using compatible versions of Chocolatey CLI and the Chocolatey Licensed Extension.
+For example, the following command can be used to upgrade the Chocolatey Licensed Extension package to the latest version:
+
+```powershell
+choco upgrade chocolatey.extension -y
+```
+
+Add the `--version` parameter with the appropriate version if you need to install a specific version of the extension, possibly with the `--allow-downgrade` parameter if you are rolling back to an earlier version.
+
+If you needed to back-up the existing Chocolatey Licensed Extension version in order to install the newer version, the following command can be used to remove the backed-up files after you have confirmed that the above steps have resolved the issue:
+
+```powershell
+Remove-Item -Path "C:\ProgramData\chocolatey\extensions\chocolatey.old" -Recurse -Force
+```

--- a/input/en-us/licensed-extension/compatibility.md
+++ b/input/en-us/licensed-extension/compatibility.md
@@ -3,12 +3,11 @@ Order: 30
 xref: licensed-extension-compatibility
 Title: Compatibility
 Description: Compatibility Information for Chocolatey Licensed Extension
-RedirectFrom:
 ---
 
 ## Summary
 
-This covers the compatibility information for the Chocolatey Licensed Extension and associated Chocolatey and other product versions.
+This covers the compatibility information for the Chocolatey Licensed Extension and associated Chocolatey CLI and other product versions.
 The Chocolatey Licensed Extension is designed to work with a certain corresponding version range of the Chocolatey CLI package.
 Using incompatible versions of Chocolatey CLI with the Chocolatey Licensed Extension may result in undesirable behaviour.
 
@@ -24,9 +23,9 @@ If you are working with an earlier version of Chocolatey Licensed Extension, ple
 > :warning: **WARNING**
 >
 > Chocolatey CLI v1.0.1 and up may continue to work for versions of the Chocolatey Licensed Extension older than v4.0.0, but these configurations are not supported for use in a production environment.
-> We recommend all customers update to new product versions as they are able to do so in order to get the latest features and fixes.
+> We recommend all customers update to new product versions, if/when they are able to do so, in order to get the latest features and fixes.
 
-In Chocolatey CLI versions v1.0.1 and newer, you may receive error messages from the licensed extension, but these will not prevent Chocolatey from functioning.
+In Chocolatey CLI versions v1.0.1 and newer, you may receive error messages regarding the currently installed Chocolatey Licensed Extension, but these will not prevent Chocolatey from functioning.
 In order to resolve these messages, simply use `choco install` or `choco upgrade` to install, upgrade, or downgrade the Chocolatey CLI or Chocolatey Licensed Extension packages as appropriate to ensure you are using compatible versions of Chocolatey CLI and the Chocolatey Licensed Extension.
 
 In Chocolatey CLI versions prior to v1.0.1, you may receive error messages similar to the following if there are incompatible versions of the Chocolatey Licensed Extension installed:
@@ -54,5 +53,44 @@ Add the `--version` parameter with the appropriate version if you need to instal
 If you needed to back-up the existing Chocolatey Licensed Extension version in order to install the newer version, the following command can be used to remove the backed-up files after you have confirmed that the above steps have resolved the issue:
 
 ```powershell
-Remove-Item -Path "C:\ProgramData\chocolatey\extensions\chocolatey.old" -Recurse -Force
+Remove-Item -Path "$env:ChocolateyInstall\extensions\chocolatey.old" -Recurse -Force
+```
+
+## Compatibility Warnings
+
+As of Chocolatey CLI v1.1.0, Chocolatey will notify you with a warning if it detects that the version of the Chocolatey Licensed Extension is not supported by the current version of Chocolatey CLI.
+At runtime, with a potentially incompatible version of Chocolatey Licensed Extension installed, you will see a warning that looks like this:
+
+```code
+WARNING!
+
+You are running a version of Chocolatey that may not be compatible with
+the currently installed version of the chocolatey.extension package.
+Running Chocolatey with the current version of the chocolatey.extension
+package is an unsupported configuration.
+
+See https://ch0.co/compatibility for more information.
+If you are in the process of modifying the chocolatey.extension package,
+you can ignore this warning.
+
+Additionally, you can ignore these warnings by either setting the
+DisableCompatibilityChecks feature:
+
+choco feature enable --name=""'disableCompatibilityChecks'""
+
+Or by passing the --skip-compatibility-checks option when executing a
+command.
+```
+
+As the warning text notes, this feature can be disabled in one of two ways.
+When running each Chocolatey CLI command, you can append the `--skip-compatibility-checks` flag, for example:
+
+```powershell
+choco list --local-only --skip-compatibility-checks
+```
+
+Alternatively, the compatibility checks can be persistently disabled by enabling the `disableCompatibilityChecks` feature:
+
+```powershell
+choco feature enable --name=""'disableCompatibilityChecks'""
 ```

--- a/input/en-us/licensed-extension/intune/index.md
+++ b/input/en-us/licensed-extension/intune/index.md
@@ -1,5 +1,5 @@
 ---
-Order: 30
+Order: 40
 xref: intune
 Title: Intune
 Description: Intune documentation

--- a/input/shared/chocolatey-component-dependencies.txt
+++ b/input/shared/chocolatey-component-dependencies.txt
@@ -5,16 +5,17 @@ The following table aims to illustrate those dependencies, based on the latest s
 
 | Package Name / Dependency      | chocolatey  | chocolatey.extension | chocolateygui |
 |------------------------------- |-------------|----------------------|---------------|
-| chocolatey v1.0.0              |             |                      |               |
-| chocolatey.extension v4.0.0    | v1.0.0      |                      |               |
+| chocolatey v1.1.0              |             |                      |               |
+| chocolatey.extension v4.1.0    | v1.0.0      |                      |               |
 | chocolatey-agent v1.0.0        |             | v4.0.0               |               |
 | chocolateygui v1.0.0           | v1.0.0      |                      |               |
 | chocolateygui.extension v1.0.0 |             | v4.0.0               | v1.0.0        |
 
 > :warning: **WARNING**
 >
-> Due the nature of how Chocolatey package dependencies work, we can ensure that all the required package versions are installed.
-For example, if you were to install chocolateygui.extension then it would make sure that the following tree of packages are installed:
+> Due the nature of how Chocolatey package dependencies work, we can ensure that all the required package versions are
+> installed. For example, if you were to install chocolateygui.extension then it would make sure that the following tree
+> of packages, with as a minimum these package versions, are installed:
 >
 > | Package Name            | Version |
 > | ----------------------- | ------- |
@@ -22,6 +23,9 @@ For example, if you were to install chocolateygui.extension then it would make s
 > | chocolateygui           | v1.0.0  |
 > | chocolatey.extension    | v4.0.0  |
 > | chocolatey              | v1.0.0  |
+>
+> **NOTE:** Newer package versions may be available at the time of installation, and Chocolatey will pick the highest
+> available that matches the defined dependency range.
 >
 > However, there is nothing that can be done to ensure that indirect dependencies are satisfied.
 > For example, if you currently have chocolateygui v0.18.1 installed along with chocolateygui.extension


### PR DESCRIPTION
## Description Of Changes

Added a page for CLE compatibility with Choco CLI, with some instructions for troubleshooting for folks on older Chocolatey CLI versions to get them out of sticky situations.

## Motivation and Context

Some versions of Choco and the licensed extension can result in a broken installation until the licensed extension is removed from the equation. This should hopefully get customers up and running again, able to make the necessary changes to their installations in a pinch.

## Testing

* [x] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [ ] Minor documentation fix (typos etc.).
* [ ] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [x] New documentation page added.

## Change Checklist

* [x] Requires a change to menu structure (top or left hand side)/
* [x] Menu structure has been updated

## Related Issue

Fixes #427
