### PR TITLE
Remove QDE Link on CCM Setup Doc

### DIFF
--- a/input/en-us/central-management/setup/index.md
+++ b/input/en-us/central-management/setup/index.md
@@ -21,7 +21,7 @@ When setting up Central Management, currently, the CCM packages do not provision
 
 > :memo: **NOTE**
 >
-> If this seems like a lot to set up, you have the ability to get access to the [Quick Deployment Environment (QDE)](xref:qde). It comes preloaded with Central Management and other Chocolatey recommended infrastructure. Please see [Quick Deployment Environment (QDE)](xref:qde).
+> If this seems like a lot to set up, you have access to the [Quick Start Guide](xref:c4b-quick-start-guide). Making setup of Central Management just running one powershell script. We also offer our [Chocolatey For Business Azure Environment](xref:qdeazure). It comes preloaded with Central Management and other Chocolatey recommended infrastructure.
 
 > :warning: **WARNING**
 >

--- a/input/en-us/central-management/setup/index.md
+++ b/input/en-us/central-management/setup/index.md
@@ -11,23 +11,19 @@ While it is envisioned that CCM will be installed across multiple servers (split
 
 When setting up Central Management, currently, the CCM packages do not provision the SQL Server Database Permissions that are required for the CCM components to function.  It is assumed that the necessary permissions have already been provided (see the [FAQ](#how-can-i-add-sql-server-permissions-through-powershell) for one method of doing it).
 
-> :memo: **NOTE**
+> :warning: **WARNINGS**
 >
-> Please read through all of this prior to running installation as you could run into issues that require support to help you correct later.
-
-> :warning: **WARNING**
+> * Unless otherwise noted, please follow these steps in **exact** order. These steps build on each other and need to be completed in order.
 >
-> Unless otherwise noted, please follow these steps in **exact** order. These steps build on each other and need to be completed in order.
-
-> :memo: **NOTE**
+> * All deployed components of the CCM packages should **always** be the **SAME VERSION**. The only time you should not have this is when you are in a state of upgrading and that transition time should be quite short.
 >
-> If this seems like a lot to set up, you have access to the [Quick Start Guide](xref:c4b-quick-start-guide). Making setup of Central Management just running one powershell script. We also offer our [Chocolatey For Business Azure Environment](xref:qdeazure). It comes preloaded with Central Management and other Chocolatey recommended infrastructure.
 
-> :warning: **WARNING**
+> :memo: **NOTES**
 >
-> All deployed components of the CCM packages should **always** be the **SAME VERSION**. The only time you should not have this is when you are in a state of upgrading and that transition time should be quite short.
-
-> :memo: **NOTE** Looking for upgrade instructions? See [Central Management Upgrade](xref:ccm-upgrade).
+> * Please read through all of this prior to running installation as you could run into issues that require support to help you correct later.
+>
+> * If this seems like a lot to set up, you have access to the [Quick Start Guide](xref:c4b-quick-start-guide). Making setup of Central Management just running one powershell script. We also offer our [Chocolatey For Business Azure Environment](xref:qdeazure). It comes preloaded with Central Management and other Chocolatey recommended infrastructure.
+>
 
 ## High Level Requirements
 
@@ -120,7 +116,7 @@ Looking for upgrade instructions? See [Central Management Upgrade](xref:ccm-upgr
 
 ### Executable script code found in signature block
 
-When attempting to install some components of Chocolatey, you may have seen this error. This was a bug due to how the script at [Step 1: Internalize Packages](#step-1-internalize-packages) was exasperating a known issue at https://github.com/chocolatey/chocolatey-licensed-issues/issues/155.
+When attempting to install some components of Chocolatey, you may have seen this error. This was a bug due to how the script at [Step 1: Internalize Packages](#step-1-internalize-packages) was exasperating a known issue at <https://github.com/chocolatey/chocolatey-licensed-issues/issues/155>.
 
 Please go back through Step 1 and re-internalize those packages. You may need to overwrite any you would have pushed up (many if it won't let you do a push). In Nexus, you can remove the existing items and then upload through there. In other repositories you may need to remove the existing package versions you deployed first.
 

--- a/input/en-us/central-management/setup/index.md
+++ b/input/en-us/central-management/setup/index.md
@@ -22,7 +22,7 @@ When setting up Central Management, currently, the CCM packages do not provision
 >
 > * Please read through all of this prior to running installation as you could run into issues that require support to help you correct later.
 >
-> * If this seems like a lot to set up, you have access to the [Quick Start Guide](xref:c4b-quick-start-guide). Making setup of Central Management just running one powershell script. We also offer our [Chocolatey For Business Azure Environment](xref:qdeazure). It comes preloaded with Central Management and other Chocolatey recommended infrastructure.
+> * If this seems like a lot to set up, you have access to the [Quick Start Guide](xref:c4b-quick-start-guide) which makes setup of Chocolatey Central Management just running one Powershell script. We also offer our [Chocolatey For Business Azure Environment](xref:qdeazure). It comes preloaded with Chocolatey Central Management and other Chocolatey recommended infrastructure.
 >
 
 ## High Level Requirements
@@ -116,7 +116,7 @@ Looking for upgrade instructions? See [Central Management Upgrade](xref:ccm-upgr
 
 ### Executable script code found in signature block
 
-When attempting to install some components of Chocolatey, you may have seen this error. This was a bug due to how the script at [Step 1: Internalize Packages](#step-1-internalize-packages) was exasperating a known issue at <https://github.com/chocolatey/chocolatey-licensed-issues/issues/155>.
+When attempting to install some components of Chocolatey, you may have seen this error. This was a bug due to how the script at [Step 1: Internalize Packages](#step-1-internalize-packages) was [internalizing packages](https://github.com/chocolatey/chocolatey-licensed-issues/issues/155).
 
 Please go back through Step 1 and re-internalize those packages. You may need to overwrite any you would have pushed up (many if it won't let you do a push). In Nexus, you can remove the existing items and then upload through there. In other repositories you may need to remove the existing package versions you deployed first.
 


### PR DESCRIPTION
## Description Of Changes
Get rid of deprecated QDE solution and link to QSG and Azure enviornment instead. Also some minor linting and styling changes.

## Motivation and Context
Update to not link to QDE and make look prettier.

## Testing

* [X] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made

* [X] Minor documentation fix (typos etc.).
* [ ] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.

## Change Checklist

* [ ] Requires a change to menu structure (top or left hand side)/
* [ ] Menu structure has been updated

## Related Issue

Fixes #434 
