### PR TITLE
(#444) Take out Read-Host in Client Setup

### DIFF
--- a/input/en-us/c4b-environments/azure/client-setup.md
+++ b/input/en-us/c4b-environments/azure/client-setup.md
@@ -66,17 +66,17 @@ See [Accessing Services](xref:c4b-azure#accessing-services) for more information
 When you're ready, run the following on the client from an elevated (Run as Administrator) PowerShell console:
 
 ```powershell
-# Prompt for input
-$fqdn = Read-Host 'Enter the FQDN for your Chocolatey for Business Azure Environment'
-$clientCommunicationSalt = Read-Host 'Enter the "ccmClientCommunicationSalt", you can find this in your Azure Key Vault'
-$serverCommunicationSalt = Read-Host 'Enter the "ccmServiceCommunicationSalt", you can find this in your Azure Key Vault'
-$password = Read-Host 'Enter the "ChocoUserPassword", you can find this in your Azure Key Vault' -AsSecureString
+# Please fill in the following values
+$fqdn = 'Replace with FQDN for your Chocolatey for Business QDE Azure Environment' 
+$clientCommunicationSalt = 'Your ccmClientCommunicationSalt'  #This value is stored within your Azure Key Vault
+$serverCommunicationSalt = 'Your ccmServiceCommunicationSalt' #This value is stored within your Azure Key Vault
+$password = 'Your ChocoUserPassword' #This value is stored within your Azure Key Vault
 
 # Touch NOTHING below this line
 $user = 'chocouser'
 
-$credential = [pscredential]::new($user, $password)
-
+$securePassword = $password | ConvertTo-SecureString -AsPlainTest -Force
+$credential = [pscredential]::new($user, $securePassword)
 $downloader = [System.Net.WebClient]::new()
 $downloader.Credentials = $credential
 


### PR DESCRIPTION
## Description Of Changes
Remove Read-Host from Client Setup script and correct handling of pscredential object as a result.

## Motivation and Context
Make this Client Setup script more closely match the format used by QSG and make it easier to define one and plop into an RRM/Code Deployment tool to run on endpoint machines.

## Testing

* [X] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made

* [ ] Minor documentation fix (typos etc.).
* [X] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.

## Change Checklist

* [ ] Requires a change to menu structure (top or left hand side)/
* [ ] Menu structure has been updated

## Related Issue

Fixes #444 
