### PR TITLE
(doc) Add info about Maintenance and Support

### DIFF
--- a/input/en-us/choco/release-notes.md
+++ b/input/en-us/choco/release-notes.md
@@ -14,7 +14,9 @@ This covers changes for the "chocolatey" and "chocolatey.lib" packages, which ar
 >
 > For commercial editions, please also refer to [Licensed Release Notes](xref:setup-licensed).
 
-<?! Include "../../shared/chocolatey-component-dependencies.txt" /?>
+<?! Include "../../shared/maintenance-and-support-link.txt" /?>
+
+<?! Include "../../shared/chocolatey-component-dependencies-link.txt" /?>
 
 ## [1.2.0](https://github.com/chocolatey/choco/milestone/54?closed=1) (October 19, 2022)
 

--- a/input/en-us/chocolatey-components-dependencies-and-support-lifecycle.md
+++ b/input/en-us/chocolatey-components-dependencies-and-support-lifecycle.md
@@ -1,0 +1,10 @@
+---
+Order: 75
+xref: chocolatey-components-dependencies-and-support-lifecycle
+Title: Chocolatey Components Dependencies and Support Lifecycle
+Description: Provides information about the Support Lifecycle for various Chocolatey Components, as well as the dependencies between them.
+---
+
+<?! Include "./shared/maintenance-and-support.txt" /?>
+
+<?! Include "./shared/chocolatey-component-dependencies.txt" /?>

--- a/input/en-us/chocolatey-gui-licensed-extension/release-notes.md
+++ b/input/en-us/chocolatey-gui-licensed-extension/release-notes.md
@@ -19,7 +19,9 @@ Please see [Install the Licensed Edition](xref:setup-chocolatey-gui-licensed) fo
 - Refer to [Open Source Release Notes](xref:floss-release-notes) as commercial editions build on top of open source.
 - Chocolatey for Business (C4B) customers - also refer to [Chocolatey Agent Release Notes](xref:agent-release-notes) and [Chocolatey Central Management Release Notes](xref:ccm-release-notes).
 
-<?! Include "../../shared/chocolatey-component-dependencies.txt" /?>
+<?! Include "../../shared/maintenance-and-support-link.txt" /?>
+
+<?! Include "../../shared/chocolatey-component-dependencies-link.txt" /?>
 
 ## 1.0.1 (October 12, 2022)
 

--- a/input/en-us/licensed-extension/release-notes.md
+++ b/input/en-us/licensed-extension/release-notes.md
@@ -36,7 +36,9 @@ Please see [Install the Licensed Edition](xref:setup-licensed) for information o
 >
 > We've identified an issue with Self-Service "Interactive" and UAC - we are working on a fix. Please see [#36](https://github.com/chocolatey/chocolatey-licensed-issues/issues/36) and subscribe for details. Until then, do not turn on the interactive feature of self-service or nothing will work.
 
-<?! Include "../../shared/chocolatey-component-dependencies.txt" /?>
+<?! Include "../../shared/maintenance-and-support-link.txt" /?>
+
+<?! Include "../../shared/chocolatey-component-dependencies-link.txt" /?>
 
 ## 5.0.0 (October 20, 2022)
 

--- a/input/shared/chocolatey-component-dependencies-link.txt
+++ b/input/shared/chocolatey-component-dependencies-link.txt
@@ -1,0 +1,3 @@
+## Chocolatey Component Package Dependencies
+
+Please check out the [Chocolatey Component Package Dependencies](xref:chocolatey-components-dependencies-and-support-lifecycle#chocolatey-component-package-dependencies) section for more information about how each package version relates to the other.

--- a/input/shared/maintenance-and-support-link.txt
+++ b/input/shared/maintenance-and-support-link.txt
@@ -1,0 +1,4 @@
+## Maintenance and Support contract considerations for Perpetual License customers
+
+
+Please check out the [Maintenance and Support contract considerations for Perpetual License customers](xref:chocolatey-components-dependencies-and-support-lifecycle#maintenance-and-support-contract-considerations-for-perpetual-license-customers) section for more information.

--- a/input/shared/maintenance-and-support.txt
+++ b/input/shared/maintenance-and-support.txt
@@ -1,0 +1,27 @@
+## Maintenance and Support Contract Considerations for Perpetual License Customers
+
+Having a Maintenance and Support contract with Chocolatey Software, Inc. consists of two parts:
+
+- Maintenance - allows you to download newer versions of the licensed components of Chocolatey.
+- Support - allows you to submit issue tickets to our Helpdesk and also have access to our Support Team.
+
+During the active period of the contract, you have access to both `Maintenance` and `Support`.
+Once that expires, you would simply need to purchase that contract again to continue access to newer versions of those components.
+
+A Perpetual License means that you have a license which never expires and you are able to use the Chocolatey Licensed Extension with versions of Chocolatey CLI that are compatible.
+While your Maintenance contract is valid, you are able to download updates to the licensed components.
+
+A Perpetual License customer that does not have an active Maintenance contract will not be in a position to upgrade to the latest version of Chocolatey Licensed Extension.
+This can cause problems when there is a dependency that exists between a new version of Chocolatey CLI and Chocolatey Licensed Extension.
+
+> :memo: **NOTE:**
+>
+> We added the dependency requirement to the [release notes](xref:choco-release-notes#march-21-2022) of v1.0.0 of Chocolatey CLI but some customers continued to experience the issue.
+> In the [v1.0.1](xref:choco-release-notes#march-24-2022) and the [v1.1.0](xref:choco-release-notes#march-30-2022) releases of Chocolatey CLI we implemented changes to allow Chocolatey CLI to work with the latest version of Chocolatey Licensed Extension. There are no guarantees that these changes will be applied in the same way to future versions.
+
+If you are in this position, we suggest that you take one of the following actions:
+
+- Request a Maintenance and Support contract renewal, upgrade the Chocolatey Licensed Extension to the latest  version and then upgrade Chocolatey CLI.
+- Forego the Maintenance and Support contract renewal and stay with the version of Chocolatey CLI and Chocolatey Licensed Extension that you use. To prevent accidental upgrade of Chocolatey CLI we would suggest that you [pin](xref:choco-command-pin) to the version you use and ensure you are using an [internal repository](xref:organizational-deployment-guide).
+
+If you have any questions about your Perpetual License or your Maintenance and Support contract, please [reach out to the Sales team](https://chocolatey.org/contact/sales-general).


### PR DESCRIPTION
## Description Of Changes

Added a new fragment with information about Mainteance and Support for
licensed customers, and how this can impact them when we release a new
version of Chocolatey that is no longer compatible with older version
of the Chocolatey Components.

This has direct impacts on some customers that may be using a perpetual
license.

This fragment has been added to the release notes pages for Chocolatey,
Chocolatey Licensed Extension, and the Chocolatey GUI Licensed
Extension, but it can be added to others as required.

## Motivation and Context

With the release of v1.0.0 of Chocolatey CLI, there was some feedback that
this area was as well documented as it could be.  This is an attempt to make
this area as clear as possible.

## Testing

* [x] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made

* [ ] Minor documentation fix (typos etc.).
* [x] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.

## Change Checklist

* [ ] Requires a change to menu structure (top or left hand side)/
* [ ] Menu structure has been updated

## Related Issue

N/A