### PR TITLE
Update alias documentation to mention correct Chocolatey command

### DIFF
--- a/input/en-us/choco/commands/upgrade.md
+++ b/input/en-us/choco/commands/upgrade.md
@@ -17,7 +17,7 @@ RedirectFrom:
 > - chocolatey (Alias for choco)
 > - cinst (Shortcut for choco install)
 > - cpush (Shortcut for choco push)
-> - cuninst (Shortcut for cuninst)
+> - cuninst (Shortcut for choco uninstall)
 > - cup (Shortcut for choco upgrade)
 >
 > We recommend that any scripts calling these shims be updated to use the full command, as


### PR DESCRIPTION
removed self-referential phrase.

## Description Of Changes
string 'cuninst (Shortcut for cuninst)' is self-referential, I'm assuming that's a short command for 'choco uninstall'.

## Testing

* [ ] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made

* [X] Minor documentation fix (typos etc.).
* [ ] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.

## Change Checklist

* [ ] Requires a change to menu structure (top or left hand side)/
* [ ] Menu structure has been updated
