### PR TITLE
(#479) Add YouTube video to both intune docs

### DIFF
--- a/input/en-us/c4b-environments/azure/license-update.md
+++ b/input/en-us/c4b-environments/azure/license-update.md
@@ -14,7 +14,7 @@ If you use the Chocolatey for Business Azure Environment for long periods of tim
 - You will need Chocolatey CLI installed.
 - You will need your new Chocolatey for Business license file.
 - You will need the FQDN of your Chocolatey for Business Azure Environment.
-- You will need the API Key for your Nexus repository (or access to the Resource Group hosting your Azure Key Vault to be able to [retrieve it]((xref:c4b-azure#accessing-services))).
+- You will need the API Key for your Nexus repository (or access to the Resource Group hosting your Azure Key Vault to be able to [retrieve it](xref:c4b-azure#accessing-services)).
 
 
 ## Creating a New License Package

--- a/input/en-us/licensed-extension/intune/index.md
+++ b/input/en-us/licensed-extension/intune/index.md
@@ -9,9 +9,6 @@ Description: Intune documentation
 
 ## Setup Video
 
-<p>
 <div class="ratio ratio-16x9">
     <iframe src="https://www.youtube.com/embed/J12q1AbNw5k" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
-<br>
-</p>

--- a/input/en-us/licensed-extension/intune/index.md
+++ b/input/en-us/licensed-extension/intune/index.md
@@ -6,3 +6,12 @@ Description: Intune documentation
 ---
 
 <?! Include "../../../shared/intune-note.txt" /?>
+
+## Setup Video
+
+<p>
+<div class="ratio ratio-16x9">
+    <iframe src="https://www.youtube.com/embed/J12q1AbNw5k" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+</div>
+<br>
+</p>

--- a/input/en-us/third-party-integrations/intune/index.md
+++ b/input/en-us/third-party-integrations/intune/index.md
@@ -6,3 +6,12 @@ Description: Integrating with Microsoft Intune
 ---
 
 <?! Include "../../../shared/intune-note.txt" /?>
+
+## Setup Video
+
+<p>
+<div class="ratio ratio-16x9">
+    <iframe src="https://www.youtube.com/embed/J12q1AbNw5k" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+</div>
+<br>
+</p>

--- a/input/en-us/third-party-integrations/intune/index.md
+++ b/input/en-us/third-party-integrations/intune/index.md
@@ -9,9 +9,6 @@ Description: Integrating with Microsoft Intune
 
 ## Setup Video
 
-<p>
 <div class="ratio ratio-16x9">
     <iframe src="https://www.youtube.com/embed/J12q1AbNw5k" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
-<br>
-</p>


### PR DESCRIPTION
## Description Of Changes
Add YouTube video embed to intune docs pages.

## Motivation and Context
Link the video we have going over the content of the child pages.

## Testing

* [X] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made

* [ ] Minor documentation fix (typos etc.).
* [X] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.

## Change Checklist

* [ ] Requires a change to menu structure (top or left hand side)/
* [ ] Menu structure has been updated

## Related Issue

Fixes #479 
