### PR TITLE
(maint) Add video check for changes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -41,6 +41,8 @@ Please remove all comments before submitting.
 * [ ] Minor documentation fix (typos etc.).
 * [ ] Major documentation change (refactoring, reformatting or adding documentation to existing page).
 * [ ] New documentation page added.
+* [ ] The change I have made should have a video added, and I have raised an issue for this.
+    * Issue #
 
 ## Change Checklist
 


### PR DESCRIPTION
## Description Of Changes
Added a check to the PR template to remind us that a video of any changes could be made and added to the page. If that is the case, we should raise an issue so we don't forget to create it, and add that issue number to the PR.

## Motivation and Context
It was suggested by @steviecoaster that we add more video to our docs and adding a check in the PR template is a good way for us to remember to do this.

## Testing

* [x] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made

* [x] Minor documentation fix (typos etc.).
* [ ] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.

## Change Checklist

* [ ] Requires a change to menu structure (top or left hand side)/
* [ ] Menu structure has been updated

## Related Issue

N/A
