### PR TITLE
(maint) Fixed incorrect heading used in release notes

### DIFF
--- a/input/en-us/agent/release-notes.md
+++ b/input/en-us/agent/release-notes.md
@@ -39,7 +39,7 @@ This covers the release notes for the Chocolatey Agent Service (`chocolatey-agen
 - Chocolatey Central Management - Add retry logic for running deployments acquired from Chocolatey Central Management Service.
 - Recheck the license on a schedule and shut down if it is invalid.
 
-## Bug Fixes
+### Bug Fixes
 
 - Logging - Exception handling for all the tasks
 


### PR DESCRIPTION
## Description Of Changes

This commit fixes that the release notes incorrectly used a h2 header instead of the expected h3.

## Motivation and Context

To use the correct header.

## Testing

* [ ] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [x] Minor documentation fix (typos etc.).
* [ ] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist

* [ ] Requires a change to menu structure (top or left hand side)/
* [ ] Menu structure has been updated

## Related Issue

N/A

<!-- PLEASE REMOVE ALL COMMENTS BEFORE SUBMITTING -->
