### PR TITLE
(maint) Update the supported Windows Server version

### DIFF
--- a/input/en-us/central-management/setup/index.md
+++ b/input/en-us/central-management/setup/index.md
@@ -30,7 +30,7 @@ When setting up Central Management, currently, the CCM packages do not provision
 Central Management packages require at a minimum:
 
 * Chocolatey for Business (C4B) Edition
-* Windows Server 2012+
+* Windows Server 2016
 
 Each package further defines dependencies that they include.
 

--- a/input/en-us/central-management/setup/service.md
+++ b/input/en-us/central-management/setup/service.md
@@ -22,8 +22,8 @@ This is the service that the agents (chocolatey-agent) communicates with. You co
 >
 > The [database](xref:ccm-database) must be setup and available, along with [logins and access](xref:ccm-database#step-2-set-up-sql-server-logins-and-access).
 
-* Windows Server 2012+
-* PowerShell 4+
+* Windows Server 2016
+* PowerShell 5.1
 
 ## Step 2: Install Central Management Service Package
 

--- a/input/en-us/central-management/setup/website.md
+++ b/input/en-us/central-management/setup/website.md
@@ -18,8 +18,8 @@ This is the Central Management website that gives an API and a web layer to cent
 >
 > The [database](xref:ccm-database) must be setup and available, along with [logins and access](xref:ccm-database#step-2-set-up-sql-server-logins-and-access).
 
-* Windows Server 2012+
-* PowerShell 3+
+* Windows Server 2016
+* PowerShell 5.1
 * IIS Set up and available
 * dotnet-aspnetcoremodule-v2 version 16.0.22108
 * dotnet-6.0-runtime version 6.0.5


### PR DESCRIPTION
## Description Of Changes
Chocolatey Central Management minimum supported version of Windows Server is Windows Server 2016.

## Motivation and Context
The supported version of Windows Server has changed.

## Testing

* [x] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made

* [x] Minor documentation fix (typos etc.).
* [ ] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.

## Change Checklist

* [ ] Requires a change to menu structure (top or left hand side)/
* [ ] Menu structure has been updated

## Related Issue

N/A