### PR TITLE
Add doc for Get-CCMDeploymentStep

### DIFF
--- a/input/en-us/central-management/chococcm/functions/GetCCMDeploymentStep.md
+++ b/input/en-us/central-management/chococcm/functions/GetCCMDeploymentStep.md
@@ -1,9 +1,8 @@
 ---
 Order: 95
-xref: get-ccmdeployment
-Title: Get-CCMDeployment
-Description: Information about the Get-CCMDeployment function
-RedirectFrom: docs/get-ccmdeploymentstep
+xref: get-ccmdeploymentstep
+Title: Get-CCMDeploymentStep
+Description: Information about the Get-CCMDeploymentStep function
 ---
 
 # Get-CCMDeploymentStep

--- a/input/en-us/central-management/chococcm/functions/GetCCMDeploymentStep.md
+++ b/input/en-us/central-management/chococcm/functions/GetCCMDeploymentStep.md
@@ -1,0 +1,107 @@
+---
+Order: 95
+xref: get-ccmdeployment
+Title: Get-CCMDeployment
+Description: Information about the Get-CCMDeployment function
+RedirectFrom: docs/get-ccmdeploymentstep
+---
+
+# Get-CCMDeploymentStep
+
+<!-- This documentation is automatically generated from /Get-CCMDeploymentStep.ps1 using GenerateDocs.ps1. Contributions are welcome at the original location(s). -->
+
+Return information about a CCM Deployment step.
+
+## Syntax
+
+~~~powershell
+Get-CCMDeploymentStep `
+  -InputObject <PSObject> `
+  [-IncludeResults] [<CommonParameters>]
+~~~
+
+~~~powershell
+Get-CCMDeploymentStep `
+  -Id <Int64> `
+  [-IncludeResults] [<CommonParameters>]
+~~~
+
+## Description
+
+Returns detailed information about Central Management Deployment Steps.
+
+## Aliases
+
+None
+
+## Examples
+
+ **EXAMPLE 1**
+
+~~~powershell
+Get-CCMDeploymentStep -Id 583 -IncludeResults
+
+~~~
+
+**EXAMPLE 2**
+
+~~~powershell
+Get-CCMDeploymentStep -InputObject $step -IncludeResults
+
+~~~
+
+## Inputs
+
+None
+
+## Outputs
+
+None
+
+## Parameters
+
+### -InputObject &lt;PSObject&gt;
+
+Retrieves additional details for the given step.
+
+Property               | Value
+---------------------- | --------------
+Aliases                | Step
+Required?              | true
+Position?              | named
+Default Value          |
+Accept Pipeline Input? | true (ByValue)
+
+### -Id &lt;Int64&gt;
+
+Returns the Deployment Step with the given Id.
+
+Property               | Value
+---------------------- | ------------------------------
+Aliases                | DeploymentStepId
+Required?              | true
+Position?              | named
+Default Value          | 0
+Accept Pipeline Input? | true (ByValue, ByPropertyName)
+
+### -IncludeResults
+
+If set, additionally retrieves the results for the targeted step.
+
+Property               | Value
+---------------------- | -----
+Aliases                |
+Required?              | false
+Position?              | named
+Default Value          | False
+Accept Pipeline Input? | false
+
+### &lt;CommonParameters&gt;
+
+This cmdlet supports the common parameters: -Verbose, -Debug, -ErrorAction, -ErrorVariable, -OutBuffer, and -OutVariable. For more information, see `about_CommonParameters` http://go.microsoft.com/fwlink/p/?LinkID=113216 .
+
+[[Function Reference|HelpersReference]]
+
+***NOTE:*** This documentation has been automatically generated from `Import-Module "ChocoCCM" -Force; Get-Help Get-CCMDeploymentStep -Full`.
+
+View the source for [Get-CCMDeploymentStep](/Get-CCMDeploymentStep.ps1)


### PR DESCRIPTION
## Description Of Changes

Add missing documentation for Get-CCMDeploymentStep

## Motivation and Context

One of the commands in ChocoCCM was missing a doc page. :(

## Testing

* [x] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [ ] Minor documentation fix (typos etc.).
* [ ] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [x] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist

* [x] Requires a change to menu structure (top or left hand side)/
* [x] Menu structure has been updated

## Related Issue

N/A
