### PR TITLE
(doc) Add release notes for Chocolatey for Business Azure Environment 0.16.0

### DIFF
--- a/input/en-us/c4b-environments/azure/release-notes.md
+++ b/input/en-us/c4b-environments/azure/release-notes.md
@@ -46,29 +46,29 @@ Description: Release Notes for the Chocolatey for Business Azure Environment
 
 Updates the bundled versions of:
 
-* [Chocolatey 1.1.0](https://docs.chocolatey.org/en-us/choco/release-notes#march-30-2022)
-* [Chocolatey Licensed Extension 4.1.1](https://docs.chocolatey.org/en-us/licensed-extension/release-notes#april-11-2022)
-* [Chocolatey Central Management 0.8.0](https://docs.chocolatey.org/en-us/central-management/release-notes#february-28-2022)
-* [Chocolatey GUI 1.0.0](https://docs.chocolatey.org/en-us/chocolatey-gui/release-notes#march-21-2022)
-* [Chocolatey GUI Licensed Extension 1.0.0](https://docs.chocolatey.org/en-us/chocolatey-gui-licensed-extension/release-notes#march-21-2022)
-* [Chocolatey Agent 1.0.0](https://docs.chocolatey.org/en-us/agent/release-notes#march-21-2022)
+- [Chocolatey 1.1.0](https://docs.chocolatey.org/en-us/choco/release-notes#march-30-2022)
+- [Chocolatey Licensed Extension 4.1.1](https://docs.chocolatey.org/en-us/licensed-extension/release-notes#april-11-2022)
+- [Chocolatey Central Management 0.8.0](https://docs.chocolatey.org/en-us/central-management/release-notes#february-28-2022)
+- [Chocolatey GUI 1.0.0](https://docs.chocolatey.org/en-us/chocolatey-gui/release-notes#march-21-2022)
+- [Chocolatey GUI Licensed Extension 1.0.0](https://docs.chocolatey.org/en-us/chocolatey-gui-licensed-extension/release-notes#march-21-2022)
+- [Chocolatey Agent 1.0.0](https://docs.chocolatey.org/en-us/agent/release-notes#march-21-2022)
 
 ### Features
 
-* Provide easy mechanism for update Certificate - see [#78](https://github.com/chocolatey/c4b-azure/issues/78)
+- Provide easy mechanism for update Certificate - see [#78](https://github.com/chocolatey/c4b-azure/issues/78)
 
 ### Improvements
 
-* Update to the latest Chocolatey components - see [#77](https://github.com/chocolatey/c4b-azure/issues/77)
-* Add Cleanup to Get-UpdatedPackage Jenkins Script - see [#75](https://github.com/chocolatey/c4b-azure/issues/75)
-* Packages from the Licensed Feed aren't updated by existing Jenkins Jobs - see [#72](https://github.com/chocolatey/c4b-azure/issues/72)
-* Bundled Packages contain x86 and x64 Installers - see [#67](https://github.com/chocolatey/c4b-azure/issues/67)
-* Jenkins plugins complain that Jenkins is outdated - see [#65](https://github.com/chocolatey/c4b-azure/issues/65)
+- Update to the latest Chocolatey components - see [#77](https://github.com/chocolatey/c4b-azure/issues/77)
+- Add Cleanup to Get-UpdatedPackage Jenkins Script - see [#75](https://github.com/chocolatey/c4b-azure/issues/75)
+- Packages from the Licensed Feed aren't updated by existing Jenkins Jobs - see [#72](https://github.com/chocolatey/c4b-azure/issues/72)
+- Bundled Packages contain x86 and x64 Installers - see [#67](https://github.com/chocolatey/c4b-azure/issues/67)
+- Jenkins plugins complain that Jenkins is outdated - see [#65](https://github.com/chocolatey/c4b-azure/issues/65)
 
 ### Documentation
 
-* Rename repository to match new name - see [#69](https://github.com/chocolatey/c4b-azure/issues/69)
-* Allow users to manage their licenses - see [#62](https://github.com/chocolatey/c4b-azure/issues/62)
+- Rename repository to match new name - see [#69](https://github.com/chocolatey/c4b-azure/issues/69)
+- Allow users to manage their licenses - see [#62](https://github.com/chocolatey/c4b-azure/issues/62)
 
 ### Bundled Version Update
 
@@ -94,29 +94,29 @@ Updates the bundled versions of:
 
 Updates the bundled versions of:
 
-* [Chocolatey 0.12.1](https://docs.chocolatey.org/en-us/choco/release-notes#january-25th-2022)
-* [Chocolatey Central Management 0.7.0](https://docs.chocolatey.org/en-us/central-management/release-notes#november-17th-2021)
-* [Chocolatey GUI 0.20.0](https://docs.chocolatey.org/en-us/chocolatey-gui/release-notes#february-10-2022).
+- [Chocolatey 0.12.1](https://docs.chocolatey.org/en-us/choco/release-notes#january-25th-2022)
+- [Chocolatey Central Management 0.7.0](https://docs.chocolatey.org/en-us/central-management/release-notes#november-17th-2021)
+- [Chocolatey GUI 0.20.0](https://docs.chocolatey.org/en-us/chocolatey-gui/release-notes#february-10-2022).
 
 ### Breaking Changes
 
-* Internalize Jenkins Plugins - see [#49](https://github.com/chocolatey/c4b-azure/issues/49)
+- Internalize Jenkins Plugins - see [#49](https://github.com/chocolatey/c4b-azure/issues/49)
     In scenarios where the Jenkins plugins were unavailable to download, the deployment would previously fail.
     We have now changed it to contain all of the plugins we require, and to _attempt_ to download the rest.
     This may result in an environment that doesn't fail deployment, but is unlike previous successful deployments.
 
 ### Features
 
-* Upgrades bundled software, as above - see [#60](https://github.com/chocolatey/c4b-azure/issues/60)
-* Internalizes packages on first run with the deployed Jenkins job - see [#46](https://github.com/chocolatey/c4b-azure/issues/46)
-* Adds commas as a valid separator for Jenkins params - see [#50](https://github.com/chocolatey/c4b-azure/issues/50)
-* Adds a HTTP->HTTPS redirect - see [#42](https://github.com/chocolatey/c4b-azure/issues/42)
-* Changes the deployed VM size to `B4ms` - see [#55](https://github.com/chocolatey/c4b-azure/issues/55)
+- Upgrades bundled software, as above - see [#60](https://github.com/chocolatey/c4b-azure/issues/60)
+- Internalizes packages on first run with the deployed Jenkins job - see [#46](https://github.com/chocolatey/c4b-azure/issues/46)
+- Adds commas as a valid separator for Jenkins params - see [#50](https://github.com/chocolatey/c4b-azure/issues/50)
+- Adds a HTTP->HTTPS redirect - see [#42](https://github.com/chocolatey/c4b-azure/issues/42)
+- Changes the deployed VM size to `B4ms` - see [#55](https://github.com/chocolatey/c4b-azure/issues/55)
 
 ### Bug Fixes
 
-* Fixes an issue with generated passwords containing quotes - see [#61](https://github.com/chocolatey/c4b-azure/issues/61)
-* Deployment now correctly installs internalized version of Chocolatey - see [#59](https://github.com/chocolatey/c4b-azure/issues/59)
+- Fixes an issue with generated passwords containing quotes - see [#61](https://github.com/chocolatey/c4b-azure/issues/61)
+- Deployment now correctly installs internalized version of Chocolatey - see [#59](https://github.com/chocolatey/c4b-azure/issues/59)
 
 ### Bundled Version Update
 
@@ -145,16 +145,16 @@ Updates the bundled version of CCM  to the [recently released 0.6.2](https://doc
 
 ### Features
 
-* Upgrades CCM to 0.6.2 - see [#51](https://github.com/chocolatey/c4b-azure/issues/51)
+- Upgrades CCM to 0.6.2 - see [#51](https://github.com/chocolatey/c4b-azure/issues/51)
 
 ### Bug Fixes
 
-* Fixes an issue with package internalization - see [#54](https://github.com/chocolatey/c4b-azure/issues/54)
+- Fixes an issue with package internalization - see [#54](https://github.com/chocolatey/c4b-azure/issues/54)
 
 ### Documentation
 
-* Adds a guide to enabling RDP [here](https://docs.chocolatey.org/en-us/quick-deployment/azure/rdp) - see [#52](https://github.com/chocolatey/c4b-azure/issues/52)
-* Adds a guide for onboarding clients [here](https://docs.chocolatey.org/en-us/quick-deployment/azure/client-setup) - see [#53](https://github.com/chocolatey/c4b-azure/issues/53)
+- Adds a guide to enabling RDP [here](https://docs.chocolatey.org/en-us/quick-deployment/azure/rdp) - see [#52](https://github.com/chocolatey/c4b-azure/issues/52)
+- Adds a guide for onboarding clients [here](https://docs.chocolatey.org/en-us/quick-deployment/azure/client-setup) - see [#53](https://github.com/chocolatey/c4b-azure/issues/53)
 
 ### Bundled Version Updates
 
@@ -172,17 +172,17 @@ Update the bundled version of CCM to the [recently released 0.6.1](https://docs.
 
 ### Features
 
-* Updates CCM to version 0.6.1, and updates dependencies
-* Validates Chocolatey Licence _before_ deploying resources
-* Ensured Chocolatey Agent is installed and checking into the CCM installation
+- Updates CCM to version 0.6.1, and updates dependencies
+- Validates Chocolatey Licence _before_ deploying resources
+- Ensured Chocolatey Agent is installed and checking into the CCM installation
 
 ### Bug Fixes
 
-* Uses `Restart-WebAppPool` instead of `iisreset`, which fixes a rare issue that failed deployments complaining of insufficient permissions
+- Uses `Restart-WebAppPool` instead of `iisreset`, which fixes a rare issue that failed deployments complaining of insufficient permissions
 
 ### Improvements
 
-* Changes the available base packages to offer packages not available in the bundles
+- Changes the available base packages to offer packages not available in the bundles
 
 ### Bundled Version Updates
 
@@ -201,13 +201,13 @@ The first released version! Available on the [Azure Marketplace](https://portal.
 
 ### Features
 
-* QDE Deployment via the Azure Marketplace
-* Deploys CCM, Nexus, and Jenkins to a VM
-* Takes an SSL certificate and FQDN and configures the environment appropriately
+- QDE Deployment via the Azure Marketplace
+- Deploys CCM, Nexus, and Jenkins to a VM
+- Takes an SSL certificate and FQDN and configures the environment appropriately
 
 ### Documentation
 
-* Adds basic docs [here](https://docs.chocolatey.org/en-us/quick-deployment/azure/)
+- Adds basic docs [here](https://docs.chocolatey.org/en-us/quick-deployment/azure/)
 
 ### Bundled Packages
 

--- a/input/en-us/c4b-environments/azure/release-notes.md
+++ b/input/en-us/c4b-environments/azure/release-notes.md
@@ -11,6 +11,37 @@ Description: Release Notes for the Chocolatey for Business Azure Environment
 >
 > Issue links may not be publicly available at this time.
 
+## 0.16.0 (September 7, 2022)
+
+### Improvements
+
+- Update Chocolatey Central Management to 0.10.0 and include new dependencies - see [#94](https://github.com/chocolatey/c4b-azure/issues/94)
+- Update chocolatey.extension to 4.2.0 - see [#99](https://github.com/chocolatey/c4b-azure/issues/99)
+- Update chocolatey-agent to 1.1.0 - see [#100](https://github.com/chocolatey/c4b-azure/issues/100)
+- Deployment should fail if installation of key components is not successful - see [#101](https://github.com/chocolatey/c4b-azure/issues/101)
+
+### Bundled Version Update
+
+| Package                        | Version             |
+|--------------------------------|---------------------|
+| aspnetcore-runtimepackagestore | N/A (Removed)       |
+| chocolatey-agent               | 1.1.0               |
+| chocolatey-management-database | 0.10.0              |
+| chocolatey-management-service  | 0.10.0              |
+| chocolatey-management-web      | 0.10.0              |
+| chocolatey.extension           | 4.2.0               |
+| dotnet-6.0-aspnetruntime       | 6.0.5 (New)         |
+| dotnet-6.0-runtime             | 6.0.5 (New)         |
+| dotnet-aspnetcoremodule-v2     | 16.0.22108 (New)    |
+| dotnetcore-sdk                 | N/A (Removed)       |
+| dotnetcore-windowshosting      | N/A (Removed)       |
+| dotnetfx                       | 4.8.0.20220524      |
+| KB2533623                      | N/A (Removed)       |
+| nexus-repository               | 3.41.1.01           |
+| Temurin11jre                   | 11.0.16.10100       |
+| vcredist140                    | 14.28.29913         |
+| vcredist2015                   | N/A (Removed)       |
+
 ## 0.15.0 (May 18, 2022)
 
 Updates the bundled versions of:


### PR DESCRIPTION
## Description Of Changes

This PR adds the release notes for C4B Azure 0.16.0.

It also changes the character used for lists, from `*` to `-` for previous release notes on this page to bring it inline with the documented standard and what is generated on the source repository's releases.

## Motivation and Context

We've released a new version of C4B Azure and need to add the release notes to the docs site.

## Testing

* [x] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made

* [x] Minor documentation fix (typos etc.).
* [x] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.

## Change Checklist

* [ ] Requires a change to menu structure (top or left hand side)/
* [ ] Menu structure has been updated

## Related Issue

N/A
