### PR TITLE
(doc) Add release notes for Chocolatey GUI 1.1.0

### DIFF
--- a/input/en-us/chocolatey-gui/release-notes.md
+++ b/input/en-us/chocolatey-gui/release-notes.md
@@ -16,6 +16,12 @@ This covers changes for the "chocolateygui" package, which is available as FOSS.
 
 <?! Include "../../shared/chocolatey-component-dependencies.txt" /?>
 
+## [1.1.0](https://github.com/chocolatey/ChocolateyGUI/milestone/29?closed=1) (September 8, 2022)
+
+### Improvement
+
+- Add option to bypass confirmation dialogs of potentially destructive operations - see [#919](https://github.com/chocolatey/ChocolateyGUI/issues/919)
+
 ## [1.0.0](https://github.com/chocolatey/ChocolateyGUI/milestone/28?closed=1) (March 21, 2022)
 
 > :warning: **WARNING**


### PR DESCRIPTION
## Description Of Changes

This PR adds the release notes for Chocolatey GUI 1.1.0

## Motivation and Context

We've released a new version of Chocolatey GUI and need to add the release notes to the docs site.

## Testing

* [x] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made

* [ ] Minor documentation fix (typos etc.).
* [x] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.

## Change Checklist

* [ ] Requires a change to menu structure (top or left hand side)/
* [ ] Menu structure has been updated

## Related Issue

N/A
