### PR TITLE
(#548) Fix bug in license update script for C4BAE

### DIFF
--- a/input/en-us/c4b-environments/azure/license-update.md
+++ b/input/en-us/c4b-environments/azure/license-update.md
@@ -47,7 +47,7 @@ Set-Content -Path $ToolsDir\chocolateyInstall.ps1 -Encoding UTF8 -Value @'
 $ErrorActionPreference = "Stop"
 $ToolsDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
 
-if (-not (Test-Path $env:ChocolateyInstall\license -PathType Directory)) {
+if (-not (Test-Path $env:ChocolateyInstall\license -PathType Container)) {
     $null = New-Item $env:ChocolateyInstall\license -ItemType Directory -Force
 }
 Copy-Item -Path $ToolsDir\chocolatey.license.xml -Destination $env:ChocolateyInstall\license\chocolatey.license.xml -Force


### PR DESCRIPTION
## Description Of Changes

This PR fixes a bug in the license update script wherein an invalid `PathType` was used in a `Test-Path` call.

## Motivation and Context

Customer reported this issue when updating the license for their C4BAE instance, and we validated the bug. Bugs are bad, so we fixed it!

## Testing

* [x] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.
* Validated the script works as expected in a testing environment
* 
## Change Types Made


* [x] Minor documentation fix (typos etc.).
* [ ] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist

* [ ] Requires a change to menu structure (top or left hand side)/
* [ ] Menu structure has been updated

## Related Issue

Fixes #548 

