### PR TITLE
(maint) Add label synchronization

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,3 @@
+- name: "Video"
+  color: "D0E64E"
+  description: "The issue or PR requires a video to be recorded and included in a later PR."

--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -1,0 +1,28 @@
+name: Sync labels
+on:
+  workflow_dispatch:
+  schedule:
+    # Run at the end of the day (most likely UTC)
+    - cron: "0 0 * * *"
+  push:
+    branches:
+      - "master"
+    paths:
+      - ".github/labels.yml"
+
+jobs:
+  labels:
+    # We use ubuntu as the image, as it is typically faster and cheaper (on private repos).
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3.0.2
+      - uses: EndBug/label-sync@v2.2.0
+        with:
+          config-file: |
+            https://raw.githubusercontent.com/chocolatey/.github/master/.github/labels.yml
+            .github/labels.yml
+          request-token: ${{ secrets.SYNC_TOKEN }} # Used when getting the config files.
+          delete-other-labels: true
+          dry-run: false
+          token: ${{ secrets.SYNC_TOKEN }} # Used when updating the lables on the repository


### PR DESCRIPTION
## Description Of Changes

This pull request adds a new workflow file that allows us to synchronize the labels we have configured for use through the whole organization and with a local labels configuration file that can be used to only configure labels valid for this 
repository.

The two labels `Task` and `Wrong Repository` is expected to be removed when this PR is merged, if we want to keep these two labels we should consider adding them to the global labels configuration in https://github.com/chocolatey/.github.

This will require adding the team/user of `choco-bot` with write permissions (or the same permissions in `https://github.com/chocolatey/.github`).

## Motivation and Context

To keep a common set of labels

## Testing

* [ ] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made

* [ ] Minor documentation fix (typos etc.).
* [ ] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.

## Change Checklist

* [ ] Requires a change to menu structure (top or left hand side)/
* [ ] Menu structure has been updated

## Related Issue

N/A
