### PR TITLE
(#555) Fix puppet docs link

### DIFF
--- a/input/en-us/features/integrations.md
+++ b/input/en-us/features/integrations.md
@@ -190,7 +190,7 @@ package { 'git':
 }
 ```
 
-Puppet has some great documentation on getting started with Chocolatey. Be sure to check that out at [Using Windows modules](https://docs.puppet.com/pe/latest/windows_modules.html).
+Puppet has some great documentation on getting started with Chocolatey. Be sure to check that out at [Create, Install, and Repackage with Chocolatey](https://puppet.com/docs/pe/2021.7/managing_windows_nodes.html#create_install_repackage_with_chocolatey).
 
 The Chocolatey team is most familiar with Puppet and has written some documentation for using Puppet with Chocolatey. Please see
 


### PR DESCRIPTION
## Description Of Changes
I fixed the broken URL.

## Motivation and Context
The previous URL returned a 404.

## Testing

* [X] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made
* [X] Minor documentation fix (typos etc.).
* [ ] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist

* [ ] Requires a change to menu structure (top or left hand side)/
* [ ] Menu structure has been updated

## Related Issue

Fixes #555 
