### PR TITLE
(#578) Make Repo Sync Jenkins Job Sync All Package Versions

### DIFF
--- a/input/en-us/guides/organizations/automate-package-internalization.md
+++ b/input/en-us/guides/organizations/automate-package-internalization.md
@@ -265,8 +265,8 @@ Jenkins requires several PowerShell scripts to automate the processes. Create a 
   . .\ConvertTo-ChocoObject.ps1
 
   # get all of the packages from the test repo
-  $testPkgs = choco list --source $TestRepo --limit-output | ConvertTo-ChocoObject
-  $prodPkgs = choco list --source $ProdRepo --limit-output | ConvertTo-ChocoObject
+  $testPkgs = choco list --source $TestRepo --all-versions --limit-output | ConvertTo-ChocoObject
+  $prodPkgs = choco list --source $ProdRepo --all-versions --limit-output | ConvertTo-ChocoObject
   $tempPath = Join-Path -Path $env:TEMP -ChildPath ([GUID]::NewGuid()).GUID
 
   if ($null -eq $testPkgs) {


### PR DESCRIPTION
## Description Of Changes
Add ability for Jenkins job script to scan all package versions hosted on both repos.

## Motivation and Context
Addresses customer ask as well as added to QSG and C4B Azure Enviornment for consistency.

## Testing

* [X] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made

* [ ] Minor documentation fix (typos etc.).
* [X] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist

* [ ] Requires a change to menu structure (top or left hand side)/
* [ ] Menu structure has been updated

## Related Issue
QSG issue: https://github.com/chocolatey/choco-quickstart-scripts/issues/163
C4B Azure issue: https://github.com/chocolatey/c4b-azure/issues/111
Fixes #578 
