### PR TITLE
(#588) Fix template doc to show full page

### DIFF
--- a/input/en-us/guides/create/create-custom-package-templates.md
+++ b/input/en-us/guides/create/create-custom-package-templates.md
@@ -115,7 +115,7 @@ Once installed, call this with `choco new test -t <TEMPLATE NAME> CustomValue=Ye
 
 If you have Chocolatey v0.9.10+, you can manage templates as packages allowing you to upgrade a template when a new version is available. When it comes to packaging templates, Chocolatey takes a conventional approach. You must create a package with the suffix ".template" and have a templates folder.
 
-To manage a template as a package, create a new package with the name "<TEMPLATE NAME>.template". The name of the package minus the ".template" will be the name of the template.
+To manage a template as a package, create a new package with the name `<TEMPLATE NAME>.template`. The name of the package minus the ".template" will be the name of the template.
 
 Then create a templates folder next to the `<TEMPLATE NAME>.template.nuspec`. This folder is where the template goes. The only thing to remember is that the nuspec file created here must end in ".template"  (e.g. `<TEMPLATE NAME>.nuspec.template`) as a Chocolatey package allows only one nuspec file.
 


### PR DESCRIPTION
## Description Of Changes

Te documentation for creating customer package templates abruptly stops due to Markdown being interpreted as HTML and being broken.

NOTE: I haven't previewed this in Docker container as yet, as my Docker install seems to be broken at the moment. I wanted to get this fixed and the change is minimal.

## Motivation and Context

Page is incomplete.

## Testing

* [ ] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made

* [x] Minor documentation fix (typos etc.).
* [ ] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist

* [ ] Requires a change to menu structure (top or left hand side)/
* [ ] Menu structure has been updated

## Related Issue

Fixes #588 