### PR TITLE
(#597) Update FAQ about trusted packages

### DIFF
--- a/input/en-us/faqs.md
+++ b/input/en-us/faqs.md
@@ -388,7 +388,7 @@ Two ways your packages can become trusted:
 * You write the underlying software that the package installs. For instance the ReSharper package that comes directly from JetBrains.
 * You put in a lot of good packages and your packages will eventually become trusted.
 
-For a package to switch to trusted, a moderator must manually make the change. It is not an automated process.
+In most cases, a package will only be switched to trusted after a few versions have been approved by moderators without any changes being required. This is to ensure that the package has been looked at by more than one person, since automated testing does not catch everything. Switching a package to trusted status is a manual change by a moderator. It is not an automated process, and does not happen imediately even if you are the software author. 
 
 > :memo: **NOTE**
 >

--- a/input/en-us/faqs.md
+++ b/input/en-us/faqs.md
@@ -392,11 +392,7 @@ In most cases, a package will only be switched to trusted after a few versions h
 
 > :memo: **NOTE**
 >
-> Once everything is ready, all packages will go under automated verification and validation and be held for fixes if they don't pass, even trusted packages.
-
-> :memo: **NOTE**
->
-> Another note, we've been setting trust per package. That is planned to change at some point for the most part as the trust level has always been about the maintainer and not always the package itself.
+> All packages go under automated verification, validation and virus scanning. If any of the tests don't pass, they are held for the maintainer to fix the package or to make a review comment. This includes trusted packages.
 
 ### How do I install a package version under moderation?
 


### PR DESCRIPTION
## Description Of Changes

This update the wording about under what conditions a package may be marked
as trusted by a moderator.
Also, this updates the memo about automated testing to include the scanner, and clarifies what
happens if the tests do not pass.
Finally, this commit removes the memo about setting trusted status per maintainer, as plans
about trusted status have changed to potentially using package diffs instead of trusted status.

## Motivation and Context

The first change is to fix #597 
The other two changes are things I noticed while making the change.

## Testing

* [x] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [ ] Minor documentation fix (typos etc.).
* [x] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist

* [ ] Requires a change to menu structure (top or left hand side)/
* [ ] Menu structure has been updated

## Related Issue

Fixes #597

