### PR TITLE
(#599) Fix registry key error

### DIFF
--- a/input/en-us/choco/uninstallation.md
+++ b/input/en-us/choco/uninstallation.md
@@ -71,10 +71,10 @@ if (-not (Test-Path $env:ChocolateyInstall)) {
     accidentally overwrite them with absolute path values. Where the registry allows us to see "%SystemRoot%" in a PATH
     entry, PowerShell's registry provider only sees "C:\Windows", for example.
 #>
-$userKey = [Microsoft.Win32.Registry]::CurrentUser.OpenSubKey('Environment')
+$userKey = [Microsoft.Win32.Registry]::CurrentUser.OpenSubKey('Environment',$true)
 $userPath = $userKey.GetValue('PATH', [string]::Empty, 'DoNotExpandEnvironmentNames').ToString()
 
-$machineKey = [Microsoft.Win32.Registry]::LocalMachine.OpenSubKey('SYSTEM\ControlSet001\Control\Session Manager\Environment\')
+$machineKey = [Microsoft.Win32.Registry]::LocalMachine.OpenSubKey('SYSTEM\ControlSet001\Control\Session Manager\Environment\',$true)
 $machinePath = $machineKey.GetValue('PATH', [string]::Empty, 'DoNotExpandEnvironmentNames').ToString()
 
 $backupPATHs = @(


### PR DESCRIPTION

## Description Of Changes

Fix uninstallation script to allow PATH updates by setting the registry key writable in the `OpenSubkey()` method.
## Motivation and Context

To completely remove Chocolatey, it is necessary to remove certain PATH variables.

## Testing

* [x] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made

* [ ] Minor documentation fix (typos etc.).
* [x] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist

* [ ] Requires a change to menu structure (top or left hand side)/
* [ ] Menu structure has been updated

## Related Issue

Fixes #599

