### PR TITLE
(doc) No duplicate package check note removed

### DIFF
--- a/input/en-us/community-repository/moderation/index.md
+++ b/input/en-us/community-repository/moderation/index.md
@@ -219,9 +219,6 @@ Always be explicit that you are waiting on the maintainer to fix and resubmit th
   * Does the download version match the package version?
   * Does the download include both x86 and x64 urls if available?
 * Not a package duplicating another existing package
-    > :memo: **NOTE**
-    >
-    > December 2015: Do not look for duplicate packages at this time. The validator will start handling that after the backlog is manageable.
 * Brand New Packages **ONLY** (no approved or existing version in history, prereleases do not count)
   * Package Id naming - if the naming doesn't follow our conventions, it is grounds for rejecting immediately with the suggestion they resubmit with suggested name. Note that they may have had prereleases already, and it's still okay to move forward with the rejected status as long as the name of the name of package hasn't been previously approved. See [Naming your package](xref:create-packages#naming-your-package)
     * suggest the id split if over 25 chars with no "-" in the id


### PR DESCRIPTION
## Description Of Changes
Remove the note from December 2015 asking moderators not to check for duplicate packages.

## Motivation and Context
The note stated that this would be added to Validator. While we may add this, duplicate packages should be checked in the meantime.

## Testing

* [ ] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made

* [ ] Minor documentation fix (typos etc.).
* [x] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist

* [ ] Requires a change to menu structure (top or left hand side)/
* [ ] Menu structure has been updated

## Related Issue

N/A