### PR TITLE
(#604) Clarify VERIFICATION.txt rule for vendors

### DIFF
--- a/input/en-us/community-repository/moderation/package-validator/rules/cpmr0006.md
+++ b/input/en-us/community-repository/moderation/package-validator/rules/cpmr0006.md
@@ -18,19 +18,6 @@ Please add a file named VERIFICATION.txt. You can see the format for that file i
 
 This check also looks for `VERIFICATION` and `VERIFICATION.md`. Casing doesn't matter for validation.
 
-**NOTE:** Providing checksums in verification is helpful, but OPTIONAL. The package already captures the checksums for binaries and displays that on the package page, so a user can use VERIFICATION to download the actual and verify it against the items listed in the files section of the package page.
-
-### Software Author / Vendor Specific
-
-If you are the software vendor (author), your verification file can be much simpler. Take a look at how NUnit provides verification - https://community.chocolatey.org/packages/nunit-console-runner#files:
-
-> VERIFICATION
-> Verification is intended to assist the Chocolatey moderators and community in verifying that this package's contents are trustworthy.
->
-> This package is published by the NUnit Project itself. The binaries are identical to other package types published by the project, in particular the NUnit.ConsoleRunner nuget package.
-
-Doing something similar is enough for Verification - since you own the binaries and your are the package maintainer, folks are choosing to trust in you already to use the software.  The additional checks with the VirusTotal scans on the community repository may help folks feel even better about using your packages.
-
 ## Reasoning
 
-If you include binaries in the package, even if you are the software vendor, you need to include a VERIFICATION.txt file. This allows moderators and the community build trust in using the package. A verification file tells folks how to verify the files are legitimate, whether specific instructions on verification with the official location, or with a notice that you are the software vendor.
+If you include binaries in the package, even if you are the software vendor, you need to include a VERIFICATION.txt file. This allows moderators and the community build trust in using the package. A verification file tells folks how to verify the files are legitimate with specific instructions on verifying with the official location.


### PR DESCRIPTION
## Description Of Changes
Updated the Package Validator rule with changes for VERIFICATION.txt files for vendors.

## Motivation and Context
The rules were not longer valid.

## Testing

* [x] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [ ] Minor documentation fix (typos etc.).
* [x] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist

* [ ] Requires a change to menu structure (top or left hand side)/
* [ ] Menu structure has been updated

## Related Issue

Fixes #604 


