### PR TITLE
(#642) Add QDE Deprecation Notice

### DIFF
--- a/input/en-us/quick-deployment/index.md
+++ b/input/en-us/quick-deployment/index.md
@@ -6,6 +6,15 @@ Description: High level information about QDE
 RedirectFrom: docs/quick-deployment-environment
 ---
 
+> :choco-danger: **DEPRECATION NOTICE**
+>
+> The Quick Deploy Environment(QDE) solution has been deprecated.
+> As such, we do not recommend new installations of this environment solution.
+> The [Quick Start Guide(QSG)](xref:c4b-quick-start-guide) has been developed as the replacement for the Quick Deploy Environment(QDE).
+> If you are running QDE within your organization, it is still fine to do so.
+> This notice is for any new trial or business customers.
+> We formally no longer support the Quick Deploy Environment(QDE) as a valid setup option.
+
 ## Summary
 
 This is an overview on the Chocolatey Quick Deployment Environment (QDE).


### PR DESCRIPTION
## Description Of Changes
Add warning call out to top of QDE folder index.

## Motivation and Context
QDE is a deprecated solution and needs to be labeled as such. 

## Testing

* [X] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made
* [ ] Minor documentation fix (typos etc.).
* [X] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist

* [ ] Requires a change to menu structure (top or left hand side)/
* [ ] Menu structure has been updated

## Related Issue
#641 

Fixes #642 
