### PR TITLE
(#653) Move QDE Under Chocolatey Environments

### DIFF
--- a/input/en-us/c4b-environments/quick-deployment/index.md
+++ b/input/en-us/c4b-environments/quick-deployment/index.md
@@ -4,7 +4,6 @@ xref: qde
 Title: Quick Deployment Environment (QDE) [DEPRECATED]
 Description: High level information about QDE
 RedirectFrom: docs/quick-deployment-environment
-RedirectFrom: docs/quick-deployment
 ---
 
 > :choco-danger: **DEPRECATION NOTICE**

--- a/input/en-us/c4b-environments/quick-deployment/index.md
+++ b/input/en-us/c4b-environments/quick-deployment/index.md
@@ -1,9 +1,10 @@
 ---
 Order: 150
 xref: qde
-Title: Quick Deployment Environment (QDE)
+Title: Quick Deployment Environment (QDE) [DEPRECATED]
 Description: High level information about QDE
 RedirectFrom: docs/quick-deployment-environment
+RedirectFrom: docs/quick-deployment
 ---
 
 > :choco-danger: **DEPRECATION NOTICE**
@@ -67,19 +68,22 @@ The above articles document how that is done.
 * [QDE SSL/TLS Setup](xref:v2-ssl-setup)
 * [QDE Firewall Changes](xref:v2-firewall-changes)
 * [QDE Client Setup](xref:v2-client-setup) (setting up your client machines)
-* [How do I upgrade QDE?](#how-do-i-upgrade-qde).
+* [How do I upgrade QDE?](xref:qde#how-do-we-upgrade-qde).
 
 ## FAQ
 
 ### How do we take advantage of QDE?
 
 You must have a [Business edition of Chocolatey](https://chocolatey.org/compare) or be on an active trial license. Please [reach out to us](https://chocolatey.org/contact/sales) so we can work to get you all the necessary information needed to get started.
+
 ### What OS format does QDE support?
 
 The QDE disk image is built on **Windows Server 2019 Standard** (Evaluation). The steps to license the VM are detailed in the [QDE Desktop ReadMe File](xref:v2-desktop-readme#step-6-license-the-qde-vm). This is the **only** format that QDE is built in.
+
 ### What hypervisor formats does QDE support?
 
 The QDE disk image comes in the following formats:
+
 1. **VMDK** (for use with VMware vCenter, ESX/i, or VirtualBox)
 1. **VHD** (for use with Microsoft Hyper-V)
 1. **VHD Appliance** (as a drop-in appliance to import into Hyper-V)
@@ -95,9 +99,10 @@ Yes! Chocolatey Central Management (CCM) comes with the ability to group endpoin
 If your QDE VM and all endpoint hosts are within the same internal network or VPN, you can follow the default [QDE Client Setup](xref:v2-client-setup) steps.
 
 If you are exposing QDE via the Internet, you will likely need to adjust your Client Setup script, as outlined in the "[Adjusting Scripts for Client Setup](xref:v2-internet-setup#adjusting-scripts-for-client-setup)" section of the QDE Internet Setup page.  As well, please refer to the question below for further Internet considerations.
+
 ### What if I need to expose QDE via the Internet? What are the safeguards in place to help me in this process?
 
-When initially configuring QDE using the `Set-QDEnironment.ps1` script ([**Step 3** in the QDE Desktop ReadMe file](xref:v2-desktop-readme#run-the-set-qdenvironment.ps1-script)), you have the option to pass the `-InternetEnabled` parameter. This option will configure your connections to Nexus (your NuGet V2 package repository) and the Chocolatey Central Management (CCM) Service to utilize SSL certificates and salts. As well, a role and user credential will be added at the Nexus repository level, to further secure access between your endpoints and your repository.
+When initially configuring QDE using the `Set-QDEnvironment.ps1` script ([**Step 3** in the QDE Desktop ReadMe file](xref:v2-desktop-readme#run-the-set-qdenvironment.ps1-script)), you have the option to pass the `-InternetEnabled` parameter. This option will configure your connections to Nexus (your NuGet V2 package repository) and the Chocolatey Central Management (CCM) Service to utilize SSL certificates and salts. As well, a role and user credential will be added at the Nexus repository level, to further secure access between your endpoints and your repository.
 
 Of course, in order to utilize this extra layer of security, you will be **required** to provide a trusted SSL certificate with a DNS-resolvable Fully Qualified Domain Name (FQDN). Whether you use a tool like LetsEncrypt, or purchase a certificate from a third party and set your Certificate Subject DNS name to resolve to this external IP, is entirely up to you. As well, you will need to be mindful of allowing connections to the Nexus (8443) and CCM Service (24020) ports via your firewall
 

--- a/input/en-us/c4b-environments/quick-deployment/release-notes.md
+++ b/input/en-us/c4b-environments/quick-deployment/release-notes.md
@@ -3,9 +3,8 @@ Order: 10
 xref: qde-release-notes
 Title: Release Notes
 Description: Release Notes for QDE
+RedirectFrom: docs/quick-deployment/release-notes
 ---
-
-# Chocolatey Release Notes - Quick Deployment Environment
 
 ## Summary
 

--- a/input/en-us/c4b-environments/quick-deployment/setup/client-setup.md
+++ b/input/en-us/c4b-environments/quick-deployment/setup/client-setup.md
@@ -4,6 +4,7 @@ xref: v2-client-setup
 Title: Client Setup
 Description: How to setup a client machine to use QDE
 RedirectFrom: docs/quick-deployment-client-setup
+RedirectFrom: docs/quick-deployment/setup/client-setup
 ---
 
 > :choco-info: **NOTE**

--- a/input/en-us/c4b-environments/quick-deployment/setup/client-setup.md
+++ b/input/en-us/c4b-environments/quick-deployment/setup/client-setup.md
@@ -4,7 +4,6 @@ xref: v2-client-setup
 Title: Client Setup
 Description: How to setup a client machine to use QDE
 RedirectFrom: docs/quick-deployment-client-setup
-RedirectFrom: docs/quick-deployment/setup/client-setup
 ---
 
 > :choco-info: **NOTE**

--- a/input/en-us/c4b-environments/quick-deployment/setup/desktop-readme.md
+++ b/input/en-us/c4b-environments/quick-deployment/setup/desktop-readme.md
@@ -4,7 +4,6 @@ xref: v2-desktop-readme
 Title: Desktop Readme
 Description: Online copy of what ships on desktop of QDE image
 RedirectFrom: docs/quick-deployment-desktop-readme
-RedirectFrom: docs/quick-deployment/setup/desktop-readme
 ---
 
 > :choco-info: **NOTE**

--- a/input/en-us/c4b-environments/quick-deployment/setup/desktop-readme.md
+++ b/input/en-us/c4b-environments/quick-deployment/setup/desktop-readme.md
@@ -4,6 +4,7 @@ xref: v2-desktop-readme
 Title: Desktop Readme
 Description: Online copy of what ships on desktop of QDE image
 RedirectFrom: docs/quick-deployment-desktop-readme
+RedirectFrom: docs/quick-deployment/setup/desktop-readme
 ---
 
 > :choco-info: **NOTE**
@@ -33,9 +34,9 @@ If you run into any issues as you set up your QDE and clients, please reach out 
 
 There are some initial steps you will need to have taken before you work through this document.
 Please make sure you have taken those steps ahead of time.
-See the [Online Documentation](#step-3-virtual-environment-setup) for the most up to date information.
+See the [Online Documentation](xref:v2-qde#step-3-virtual-environment-setup) for the most up to date information.
 
-* [QDE Setup](xref:v2-qde)
+- [QDE Setup](xref:v2-qde)
 
 ## Step 1: Expand Disk Size
 
@@ -94,8 +95,8 @@ You will need either the certificate thumbprint or the subject in order to use t
 
 > :choco-info: **NOTE**
 >
-> * `-CertificateDnsName` is optional if you're providing the `-CertificateSubject`, but only if the subject does **not** contain wildcards.
-> * You can also optionally provide the `-InternetEnabled` switch if your QDE instance has a certificate with a public hostname and will be operating over the internet.
+> - `-CertificateDnsName` is optional if you're providing the `-CertificateSubject`, but only if the subject does **not** contain wildcards.
+> - You can also optionally provide the `-InternetEnabled` switch if your QDE instance has a certificate with a public hostname and will be operating over the internet.
 >   This will enable additional security features; take note of the additional output and do not lose the newly-generated passwords or salt values.
 
 ```powershell
@@ -267,7 +268,7 @@ choco apikey add --key="'{{NugetApiKey}}'" --source="'https://chocoserver:8443/r
 
 ### Update pre-configured Jenkins jobs with the new API Key
 
-After updating the Nexus API Key, you'll need to ensure that the preconfigured Jenkins jobs are also updated with the new API key.
+After updating the Nexus API Key, you'll need to ensure that the pre-configured Jenkins jobs are also updated with the new API key.
 To do so:
 
 1. Login to Jenkins after completing the first-time setup (see [above](#jenkins))
@@ -335,9 +336,9 @@ Stop-Process -Name explorer -Force
 
 ## See Also
 
-* [Quick Deployment Environment](xref:qde)
-* [QDE Setup](xref:v2-qde)
-* [QDE Desktop ReadMe File](xref:v2-desktop-readme)
-* [QDE SSL/TLS Setup](xref:v2-ssl-setup)
-* [QDE Firewall Changes](xref:v2-firewall-changes)
-* [QDE Client Setup](xref:v2-client-setup) (setting up your client machines)
+- [Quick Deployment Environment](xref:qde)
+- [QDE Setup](xref:v2-qde)
+- [QDE Desktop ReadMe File](xref:v2-desktop-readme)
+- [QDE SSL/TLS Setup](xref:v2-ssl-setup)
+- [QDE Firewall Changes](xref:v2-firewall-changes)
+- [QDE Client Setup](xref:v2-client-setup) (setting up your client machines)

--- a/input/en-us/c4b-environments/quick-deployment/setup/firewall-changes.md
+++ b/input/en-us/c4b-environments/quick-deployment/setup/firewall-changes.md
@@ -4,6 +4,7 @@ xref: v2-firewall-changes
 Title: Firewall Changes
 Description: How has the firewall on the QDE image been changed
 RedirectFrom: docs/quick-deployment-firewall-changes
+RedirectFrom: docs/quick-deployment/setup/firewall-changes
 ---
 
 > :choco-info: **NOTE**

--- a/input/en-us/c4b-environments/quick-deployment/setup/firewall-changes.md
+++ b/input/en-us/c4b-environments/quick-deployment/setup/firewall-changes.md
@@ -4,7 +4,6 @@ xref: v2-firewall-changes
 Title: Firewall Changes
 Description: How has the firewall on the QDE image been changed
 RedirectFrom: docs/quick-deployment-firewall-changes
-RedirectFrom: docs/quick-deployment/setup/firewall-changes
 ---
 
 > :choco-info: **NOTE**

--- a/input/en-us/c4b-environments/quick-deployment/setup/index.md
+++ b/input/en-us/c4b-environments/quick-deployment/setup/index.md
@@ -4,7 +4,6 @@ xref: v2-qde
 Title: Setup
 Description: How to setup QDE
 RedirectFrom: docs/quick-deployment-setup
-RedirectFrom: docs/quick-deployment/setup
 ---
 
 > :choco-info: **NOTE**

--- a/input/en-us/c4b-environments/quick-deployment/setup/index.md
+++ b/input/en-us/c4b-environments/quick-deployment/setup/index.md
@@ -4,6 +4,7 @@ xref: v2-qde
 Title: Setup
 Description: How to setup QDE
 RedirectFrom: docs/quick-deployment-setup
+RedirectFrom: docs/quick-deployment/setup
 ---
 
 > :choco-info: **NOTE**
@@ -19,7 +20,6 @@ Once you have this downloaded, it will be ready for extraction and import into y
 >
 > Please follow these steps in **exact** order.
 > These will be very important later when you are trying to use the environment.
-
 
 ## Step 0: Setup Considerations
 
@@ -151,8 +151,10 @@ Choose one of the following methods for what your hypervisor environment support
 1. Create a new VM.
 1. When prompted for OS type, choose `Windows Server 2019` (if available), or `Windows Server 2016 or later`.
 1. Adjust the hardware specifications of the VM. For a performant system, the following are recommended:
-    - 4 vCPUs
-    - 8 GB RAM
+
+* 4 vCPUs
+* 8 GB RAM
+
 1. Use the "x" icon at the far right of `Hard disk 1` to remove it.
 1. In the `VM Options` tab, and under the `Boot Options` dropdown, set your `Firmware` to `BIOS` (**not** UEFI). Click `Next`, then `Finish`.
 1. Now go back into the VM configuration using the `Edit Settings` context menu.

--- a/input/en-us/c4b-environments/quick-deployment/setup/internet-setup.md
+++ b/input/en-us/c4b-environments/quick-deployment/setup/internet-setup.md
@@ -4,7 +4,6 @@ xref: v2-internet-setup
 Title: Internet Setup
 Description: How to make QDE accessible from the internet
 RedirectFrom: docs/quick-deployment-internet-setup
-RedirectFrom: docs/quick-deployment/setup/internet-setup
 ---
 
 > :choco-info: **NOTE**

--- a/input/en-us/c4b-environments/quick-deployment/setup/internet-setup.md
+++ b/input/en-us/c4b-environments/quick-deployment/setup/internet-setup.md
@@ -4,6 +4,7 @@ xref: v2-internet-setup
 Title: Internet Setup
 Description: How to make QDE accessible from the internet
 RedirectFrom: docs/quick-deployment-internet-setup
+RedirectFrom: docs/quick-deployment/setup/internet-setup
 ---
 
 > :choco-info: **NOTE**
@@ -184,7 +185,7 @@ It is also less secure, and thus **not recommended** for a server that is Intern
 The `New-SSLCertificate.ps1` mentioned above will create a Java KeyStore (JKS) version of an SSL certificate, that can be used to secure communication between your endpoints and your Nexus repositories.
 As mentioned in the section above, this certificate will need to be trusted by your endpoints.
 
-Additionally, when logging in and resetting your administrative credential in the Nexus web UI, there is a checkbox to allow “Anonymous” access.
+Additionally, when logging in and resetting your administrative credential in the Nexus web UI, there is a checkbox to allow "Anonymous" access.
 This is convenient for endpoints that will be accessing Nexus strictly from your internal network, but will need to be changed if you are planning to expose Nexus to your endpoints over the Internet.
 You can follow two paths to accomplish this:
 

--- a/input/en-us/c4b-environments/quick-deployment/setup/ssl-setup.md
+++ b/input/en-us/c4b-environments/quick-deployment/setup/ssl-setup.md
@@ -4,9 +4,10 @@ xref: v2-ssl-setup
 Title: SSL Setup
 Description: How to setup QDE to use SSL
 RedirectFrom: docs/quick-deployment-ssl-setup
+RedirectFrom: docs/quick-deployment/setup/ssl-setup
 ---
 
-# Quick Deployment Environment SSL Setup
+## Quick Deployment Environment SSL Setup
 
 > :choco-info: **NOTE**
 >

--- a/input/en-us/c4b-environments/quick-deployment/setup/ssl-setup.md
+++ b/input/en-us/c4b-environments/quick-deployment/setup/ssl-setup.md
@@ -4,7 +4,6 @@ xref: v2-ssl-setup
 Title: SSL Setup
 Description: How to setup QDE to use SSL
 RedirectFrom: docs/quick-deployment-ssl-setup
-RedirectFrom: docs/quick-deployment/setup/ssl-setup
 ---
 
 ## Quick Deployment Environment SSL Setup

--- a/input/en-us/c4b-environments/quick-deployment/setup/upgrade-license.md
+++ b/input/en-us/c4b-environments/quick-deployment/setup/upgrade-license.md
@@ -4,15 +4,16 @@ xref: v2-upgrade-license
 Title: Upgrade License
 Description: How to upgrade and deploy the Chocolatey License package
 RedirectFrom: docs/quick-deployment-upgrade-license
+RedirectFrom: docs/quick-deployment/setup/upgrade-license
 ---
 
-# Upgrading your license in the Quick Deployment Environment
+## Upgrading your license in the Quick Deployment Environment
 
 You may receive a trial extension license, or a new license when you renew your currently purchased license. Upon receiving that new file, you will need to upgrade the `chocolatey-license` package in your Nexus repository (or repository server if you've moved to your own separate from QDE).
 
 On the QDE server in the `C:\choco-setup\files` folder you will find a `CreateLicensePackage.ps1` script. This script will have been updated when you provisioned the QDE server with the proper hostname for your environment. This script will package the new license file on the server and push it to your repository.
 
-# Upgrade Process
+### Upgrade Process
 
 Steps:
 

--- a/input/en-us/c4b-environments/quick-deployment/setup/upgrade-license.md
+++ b/input/en-us/c4b-environments/quick-deployment/setup/upgrade-license.md
@@ -4,7 +4,6 @@ xref: v2-upgrade-license
 Title: Upgrade License
 Description: How to upgrade and deploy the Chocolatey License package
 RedirectFrom: docs/quick-deployment-upgrade-license
-RedirectFrom: docs/quick-deployment/setup/upgrade-license
 ---
 
 ## Upgrading your license in the Quick Deployment Environment

--- a/input/en-us/c4b-environments/quick-deployment/setup/upgrade-nexus-qde.md
+++ b/input/en-us/c4b-environments/quick-deployment/setup/upgrade-nexus-qde.md
@@ -3,9 +3,10 @@ Order: 70
 xref: v2-upgrade-nexus-qde
 Title: Upgrade Nexus
 Description: How to upgrade Nexus installed on QDE
+RedirectFrom: docs/quick-deployment/setup/upgrade-nexus-qde
 ---
 
-# Upgrade Nexus in Quick Deploy Environment
+## Upgrade Nexus in Quick Deploy Environment
 
 This document outlines the process for upgrading Nexus running inside our Quick Deployment Environment.
 The script provided assumes your server has access to the internet to download the Nexus package from the community repository.
@@ -17,12 +18,13 @@ If your server is restricted then internalize the package to your internal repos
 > and do not have a Nexus instance configured with SSL, leave off the package parameters.
 >
 > This command will backup the SSL configuration to the root of your User Profile in a NexusBackup folder.
-# Instructions
+
+## Instructions
 
 1. Internalize the nexus-repository package and push to your internal repo
 2. choco upgrade the nexus-repository package (Example command provided below, which preserves SSL Configuration)
 
-## Example Upgrade Command:
+### Example Upgrade Command:
 
 > :choco-info: **NOTE**
 >

--- a/input/en-us/c4b-environments/quick-deployment/setup/upgrade-nexus-qde.md
+++ b/input/en-us/c4b-environments/quick-deployment/setup/upgrade-nexus-qde.md
@@ -3,7 +3,6 @@ Order: 70
 xref: v2-upgrade-nexus-qde
 Title: Upgrade Nexus
 Description: How to upgrade Nexus installed on QDE
-RedirectFrom: docs/quick-deployment/setup/upgrade-nexus-qde
 ---
 
 ## Upgrade Nexus in Quick Deploy Environment

--- a/input/en-us/c4b-environments/quick-deployment/v1/client-setup.md
+++ b/input/en-us/c4b-environments/quick-deployment/v1/client-setup.md
@@ -4,6 +4,7 @@ xref: v1-client-setup
 Title: Client Setup
 Description: How to setup a client machine to use QDE v1
 RedirectFrom: docs/quick-deployment-client-setup-v1
+RedirectFrom: docs/quick-deployment/v1/client-setup
 ---
 
 > :choco-info: **NOTE**

--- a/input/en-us/c4b-environments/quick-deployment/v1/client-setup.md
+++ b/input/en-us/c4b-environments/quick-deployment/v1/client-setup.md
@@ -4,7 +4,6 @@ xref: v1-client-setup
 Title: Client Setup
 Description: How to setup a client machine to use QDE v1
 RedirectFrom: docs/quick-deployment-client-setup-v1
-RedirectFrom: docs/quick-deployment/v1/client-setup
 ---
 
 > :choco-info: **NOTE**

--- a/input/en-us/c4b-environments/quick-deployment/v1/desktop-readme.md
+++ b/input/en-us/c4b-environments/quick-deployment/v1/desktop-readme.md
@@ -4,6 +4,7 @@ xref: v1-desktop-readme
 Title: Desktop Readme
 Description: Online copy of what ships on desktop of QDE v1 image
 RedirectFrom: docs/quick-deployment-desktop-readme-v1
+RedirectFrom: docs/quick-deployment/v1/desktop-readme
 ---
 
 > :choco-info: **NOTE**
@@ -172,7 +173,7 @@ Once logged in perform the following steps:
 If you change your API key, you will need to change the key in the Jenkins jobs that are pre-configured for you.
 See the next section for information on how to connect to Jenkins.
 
-#### Choco Apikey Command
+### Choco Apikey Command
 
 To help make pushing packages easier, the `choco apikey` command is available.
 This will store your API key for a specific source as part of Chocolatey's configuration.

--- a/input/en-us/c4b-environments/quick-deployment/v1/desktop-readme.md
+++ b/input/en-us/c4b-environments/quick-deployment/v1/desktop-readme.md
@@ -4,7 +4,6 @@ xref: v1-desktop-readme
 Title: Desktop Readme
 Description: Online copy of what ships on desktop of QDE v1 image
 RedirectFrom: docs/quick-deployment-desktop-readme-v1
-RedirectFrom: docs/quick-deployment/v1/desktop-readme
 ---
 
 > :choco-info: **NOTE**

--- a/input/en-us/c4b-environments/quick-deployment/v1/firewall-changes.md
+++ b/input/en-us/c4b-environments/quick-deployment/v1/firewall-changes.md
@@ -4,7 +4,6 @@ xref: v1-firewall-changes
 Title: Firewall Changes
 Description: How has the firewall on the QDE v1 image been changed
 RedirectFrom: docs/quick-deployment-firewall-changes-v1
-RedirectFrom: docs/quick-deployment/v1/firewall-changes
 ---
 
 > :choco-info: **NOTE**

--- a/input/en-us/c4b-environments/quick-deployment/v1/firewall-changes.md
+++ b/input/en-us/c4b-environments/quick-deployment/v1/firewall-changes.md
@@ -4,6 +4,7 @@ xref: v1-firewall-changes
 Title: Firewall Changes
 Description: How has the firewall on the QDE v1 image been changed
 RedirectFrom: docs/quick-deployment-firewall-changes-v1
+RedirectFrom: docs/quick-deployment/v1/firewall-changes
 ---
 
 > :choco-info: **NOTE**

--- a/input/en-us/c4b-environments/quick-deployment/v1/index.md
+++ b/input/en-us/c4b-environments/quick-deployment/v1/index.md
@@ -3,5 +3,4 @@ Order: 30
 xref: v1-qde
 Title: QDE v1
 Description: Information about the initial release of the Chocolatey Quick Deployment Environment
-RedirectFrom: docs/quick-deployment/v1
 ---

--- a/input/en-us/c4b-environments/quick-deployment/v1/index.md
+++ b/input/en-us/c4b-environments/quick-deployment/v1/index.md
@@ -3,4 +3,5 @@ Order: 30
 xref: v1-qde
 Title: QDE v1
 Description: Information about the initial release of the Chocolatey Quick Deployment Environment
+RedirectFrom: docs/quick-deployment/v1
 ---

--- a/input/en-us/c4b-environments/quick-deployment/v1/setup.md
+++ b/input/en-us/c4b-environments/quick-deployment/v1/setup.md
@@ -4,6 +4,7 @@ xref: v1-qde-setup
 Title: Setup
 Description: How to setup QDE v1
 RedirectFrom: docs/quick-deployment-setup-v1
+RedirectFrom: docs/quick-deployment/v1/setup
 ---
 
 > :choco-info: **NOTE**

--- a/input/en-us/c4b-environments/quick-deployment/v1/setup.md
+++ b/input/en-us/c4b-environments/quick-deployment/v1/setup.md
@@ -4,7 +4,6 @@ xref: v1-qde-setup
 Title: Setup
 Description: How to setup QDE v1
 RedirectFrom: docs/quick-deployment-setup-v1
-RedirectFrom: docs/quick-deployment/v1/setup
 ---
 
 > :choco-info: **NOTE**

--- a/input/en-us/c4b-environments/quick-deployment/v1/ssl-setup.md
+++ b/input/en-us/c4b-environments/quick-deployment/v1/ssl-setup.md
@@ -4,7 +4,6 @@ xref: v1-ssl-setup
 Title: SSL Setup
 Description: How to setup QDE v1 to use SSL
 RedirectFrom: docs/quick-deployment-ssl-setup-v1
-RedirectFrom: docs/quick-deployment/v1/ssl-setup
 ---
 
 > :choco-info: **NOTE**

--- a/input/en-us/c4b-environments/quick-deployment/v1/ssl-setup.md
+++ b/input/en-us/c4b-environments/quick-deployment/v1/ssl-setup.md
@@ -4,9 +4,8 @@ xref: v1-ssl-setup
 Title: SSL Setup
 Description: How to setup QDE v1 to use SSL
 RedirectFrom: docs/quick-deployment-ssl-setup-v1
+RedirectFrom: docs/quick-deployment/v1/ssl-setup
 ---
-
-# Quick Deployment Environment SSL Setup
 
 > :choco-info: **NOTE**
 >
@@ -41,11 +40,10 @@ Once complete, this script will generate new SSL certificates for all services a
 ```powershell
 Set-ExecutionPolicy Bypass -Scope Process -Force; . C:\choco-setup\files\New-SSLCertificate.ps1
 ```
+
 > :choco-warning: **WARNING**
 >
 > Timezones are super important here and time synchronization is really important when generating SSL Certificates. You want to make sure you have this correct and good. Otherwise there is a potential edge case you could generate an SSL Certificate that is not yet valid.
-
-
 
 > :choco-warning: **WARNING**
 >
@@ -55,6 +53,5 @@ Set-ExecutionPolicy Bypass -Scope Process -Force; . C:\choco-setup\files\New-SSL
 > You can provide your own certificate that is already trusted on machines as part of the [SSL/TLS Setup](xref:v1-ssl-setup). Your other option is to host the script to trust the certificate with an already trusted certificate. You will find a template that you will need to edit at `c:\choco_setup_files` (in the QDE) named `Import-ChocoServerCertificate.ps1`.
 >
 > Please contact support if you need help here.
-
 
 [Quick Deployment Environment](xref:v1-qde)


### PR DESCRIPTION
## Description Of Changes
- Delete docs from current section and put under Chocolatey Environments
- Put redirect from links on all pages from last location
- Also did some minor linting changes to fix broken links and standardize

## Motivation and Context
Reduce confusion when navigating docs. Also make some fixes where the docs were previously broken.

## Testing

* [X] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made

* [X] Minor documentation fix (typos etc.).
* [ ] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist

* [X] Requires a change to menu structure (top or left hand side)/
* [X] Menu structure has been updated

## Related Issue
Task in larger project #641 

Fixes #653 
