### PR TITLE
(#673) Add third party notice to environment documentation

### DIFF
--- a/input/en-us/c4b-environments/azure/index.md
+++ b/input/en-us/c4b-environments/azure/index.md
@@ -29,6 +29,8 @@ Currently, to deploy the Chocolatey for Business Azure Environment you will need
 
 For portions of this document using PowerShell, we assume you have installed a recent version of the [Az modules](https://www.powershellgallery.com/packages/Az/) (easily available by running `choco install az.powershell` in an elevated prompt), and have logged in to your account using `Connect-AzAccount`. You can also set a variable, `$ResourceGroupName`, to the name of the resource group you deployed the Chocolatey for Business Azure Environment to as we will use this with the PowerShell code snippets below.
 
+<?! Include "../../../shared/third-party-notice.txt" /?>
+
 ## Deploying the Chocolatey for Business Azure Environment
 
 The Chocolatey for Business Azure Environment is available as a deployable resource in the [Microsoft Azure Marketplace](https://azuremarketplace.microsoft.com/en-us/marketplace/apps/chocolateysoftwareinc1605695330527.c4b_azure_qde).
@@ -303,3 +305,4 @@ We have seen an occasional issue with IISReset that cannot be replicated. This r
 > the remote computer or to the domain administrator global group.
 
 If you see this error, you should redeploy the resource.
+

--- a/input/en-us/guides/organizations/quick-start-guide/chocolatey-for-business-quick-start-guide.md
+++ b/input/en-us/guides/organizations/quick-start-guide/chocolatey-for-business-quick-start-guide.md
@@ -50,6 +50,8 @@ Below are the minimum requirements for setting up your C4B server via this guide
 - Open outgoing (egress) Internet access
 - Administrator user rights
 
+<?! Include "../../../../shared/third-party-notice.txt" /?>
+
 ## Installation
 
 ### Step 0: Preparation of C4B Server

--- a/input/shared/third-party-notice.txt
+++ b/input/shared/third-party-notice.txt
@@ -1,0 +1,31 @@
+## Third Party Software Notice
+
+This solution relies on software delivered as a Chocolatey package from the Chocolatey Community Repository. These packages
+have been internalized and made available within the repository included with the solution.
+
+This software includes, but is not limited to:
+
+- Sonatype Nexus (`nexus-repository`)
+- Jenkins (`jenkins`)
+- Microsoft SQL Server Express (`sql-server-express`)
+- Microsoft SQL Server Management Studio (`sql-server-management-studio`)
+- .Net Runtime (`dotnet-6.0-runtime`)
+- .Net ASP Net Core Runtime (`dotnet-6.0-aspnetruntime`)
+- .Net ASP Net Core Module for IIS (`dotnet-6.0-aspnetcoremodule-v2`)
+
+### Responsibility
+
+This solution has been provided as a quick way to get up and running with Chocolatey For Business. It is not a SaaS solution. It is the responsibility
+of you, the customer, to ensure the versions of software included as part of the solution is kept updated according to your needs.
+
+For Chocolatey For Business products, you can subscribe to an Announcements mailing list which will email you when we release a new version of any of the
+products that Chocolatey Software maintains. These packages include:
+
+- Chocolatey CLI (`chocolatey`)
+- Chocolatey Licensed Extension (`chocolatey.extension`)
+- Chocolatey Agent (`chocolatey-agent`)
+- Chocolatey GUI (`chocolateygui`)
+- Chocolatey GUI Licensed Extension (`chocolateygui.extension`)
+- Chocolatey Central Management (`chocolatey-management-database`,`chocolatey-management-service`,`chocolatey-management-web`)
+
+Please subscribe to the [mailing list](https://groups.google.com/forum/#!forum/chocolatey-announce) if you would like to receive those announcements.


### PR DESCRIPTION


## Description Of Changes

Adds documentation around which packages are 3rd party software, and outlines the responsibility of the customer.

## Motivation and Context

From a security perspective we should clearly outline what software Chocolatey Software _does not own_.

## Testing

* [x] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made

* [ ] Minor documentation fix (typos etc.).
* [x] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist

* [ ] Requires a change to menu structure (top or left hand side)/
* [ ] Menu structure has been updated

## Related Issue

Fixes #673 
