### PR TITLE
(maint) Split Warning and Note Code Blocks

### DIFF
--- a/input/shared/chocolatey-component-dependencies.txt
+++ b/input/shared/chocolatey-component-dependencies.txt
@@ -23,7 +23,7 @@ The following table aims to illustrate those dependencies, based on the latest s
 > | chocolateygui           | v1.0.0  |
 > | chocolatey.extension    | v4.0.0  |
 > | chocolatey              | v1.0.0  |
->
+
 > :choco-info: **NOTE**
 >
 > Newer package versions may be available at the time of installation, and Chocolatey will pick the highest


### PR DESCRIPTION
## Description Of Changes
- Split warning and note to separate code blocks for formatting

## Motivation and Context
Was loading wrong on page.

## Testing

* [X] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made

* [X] Minor documentation fix (typos etc.).
* [ ] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist

* [ ] Requires a change to menu structure (top or left hand side)/
* [ ] Menu structure has been updated

## Related Issue
Didn't raise issue as it was a one line change. Not worth the time.
