### PR TITLE
Add support lifecycle, update Choco requirements

### DIFF
--- a/input/en-us/choco/setup.md
+++ b/input/en-us/choco/setup.md
@@ -2,7 +2,7 @@
 Order: 20
 xref: setup-choco
 Title: Setup / Install
-Description: Techniques for how to install Chocolatey
+Description: How to install Chocolatey CLI
 RedirectFrom:
   - docs/installation
   - docs/install
@@ -10,21 +10,30 @@ RedirectFrom:
 
 ## Requirements
 
-* Windows 7+ / Windows Server 2003+
-* PowerShell v2+ (Not PowerShell Core yet though)(minimum is v3 for install from this website due to [TLS 1.2 requirement](https://blog.chocolatey.org/2020/01/remove-support-for-old-tls-versions/))
-* .NET Framework 4+ (the installation will attempt to install .NET 4.0 if you do not have it installed)(minimum is 4.5 for install from this website due to [TLS 1.2 requirement](https://blog.chocolatey.org/2020/01/remove-support-for-old-tls-versions/))
+- [A supported version of Windows](xref:chocolatey-components-dependencies-and-support-lifecycle#supported-windows-versions)
+- Windows PowerShell v2.0 or higher
+  - Windows PowerShell v3 is required for directly installing Chocolatey CLI from the Chocolatey Community Repository due to the [TLS 1.2 requirement](https://blog.chocolatey.org/2020/01/remove-support-for-old-tls-versions/)
 
-That's it! All you need is choco.exe (that you get from the installation scripts) and you are good to go! No Visual Studio required.
+### Chocolatey CLI v2.0+
 
-## Installing Chocolatey
+- .NET Framework 4.8
+  - The installation script will attempt to install .NET 4.8 if it is not installed.
 
-Chocolatey installs in seconds. You are just a few steps from running choco right now!
+### Chocolatey CLI v1.x
 
-1. First, ensure that you are using an **[administrative shell](http://www.howtogeek.com/194041/how-to-open-the-command-prompt-as-administrator-in-windows-8.1/)** - you can also install as a non-admin, check out <a href="#non-administrative-install">Non-Administrative Installation</a>.
+- .NET Framework 4+
+  - The installation will attempt to install .NET 4.0 if you do not have it installed
+  - .NET Framework 4.5+ is required for installing directly from the Chocolatey Community Repository, due to the [TLS 1.2 requirement](https://blog.chocolatey.org/2020/01/remove-support-for-old-tls-versions/)
+
+## Installing Chocolatey CLI
+
+1. First, ensure that you are using an **[administrative shell](http://www.howtogeek.com/194041/how-to-open-the-command-prompt-as-administrator-in-windows-8.1/)**.
+   - Refer to [Non-Administrative Installation](#non-administrative-install) for information on installing without administrative rights.
 1. Copy the text specific to your command shell - [cmd.exe](#install-with-cmd.exe) or [powershell.exe](#install-with-powershell.exe).
 1. Paste the copied text into your shell and press Enter.
 1. Wait a few seconds for the command to complete.
-1. If you don't see any errors, you are ready to use Chocolatey! Type `choco` or `choco -?` now, or see [Getting Started](xref:getting-started) for usage instructions.
+1. If you don't see any errors, you are ready to use Chocolatey CLI!
+1. Type `choco` or `choco -?` now, or see [Getting Started](xref:getting-started) for usage instructions.
 
 > :choco-info: **NOTE**
 > * If you are behind a proxy, please see <a href="#installing-behind-a-proxy">Installing behind a proxy</a>.
@@ -74,7 +83,7 @@ The load by default is really hard to see, so you should check to ensure it is t
 
 ## More Install Options
 
-<p><strong>Troubleshooting? Proxy? Need more options?</strong></p>
+**Troubleshooting? Proxy? Need more options?**
 
 <button class="btn btn-success btn-collapse collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#moreInstallOptions" aria-expanded="false" aria-controls="moreInstallOptions">More Install Options</button>
 

--- a/input/en-us/chocolatey-components-dependencies-and-support-lifecycle.md
+++ b/input/en-us/chocolatey-components-dependencies-and-support-lifecycle.md
@@ -5,6 +5,52 @@ Title: Chocolatey Components Dependencies and Support Lifecycle
 Description: Provides information about the Support Lifecycle for various Chocolatey Components, as well as the dependencies between them.
 ---
 
+## Product Support Lifecycle
+
+All of the latest released stable versions of Chocolatey products (Chocolatey CLI, Chocolatey GUI, Chocolatey Central Management, etc.) are fully supported and will periodically receive new features, bug fixes, and security fixes as appropriate.
+We recommend customers update to the latest versions to benefit from new features and fixes as they are released.
+
+### Pre-v1.0 Products
+
+For any products that have not yet reached v1.0, **only the latest version is supported**.
+We will continue to add features, fix bugs, and address security concerns as normal while we work towards a v1.0 release.
+
+### Version 1.0+ Products
+
+Once a product reaches v1.0, we recommend customers move to that version as soon as possible.
+We will not continue to support v0.x versions once a product reaches v1.0.
+
+### Version 2.0+ Products
+
+Once a product reaches the second major release, the following will apply:
+
+1. We will support the previous major version with **security fixes** for licensed customers.
+   - For example: at v2.0, the latest v1.x version of the product will receive security fixes; at v3.0, only the latest v2.x version of the product will continue to receive security fixes.
+1. We will support the previous major version with certain bug fixes (excepting bug fixes that require breaking changes) for licensed customers for six months following the release of the next major version.
+1. No new features will be backported to the previous major version.
+
+## Supported Windows Versions
+
+Chocolatey products' support for Windows operating systems follows Microsoft's support lifecycle: if the Windows version is supported by Microsoft, Chocolatey products are supported on that version of Windows.
+
+This information is up to date as of April 2023.
+
+### Clients
+
+- Windows 11
+- Windows 10 22H2
+- Windows 10 21H2
+- Windows 10 20H2 (Enterprise and Education editions **only**)
+
+### Servers
+
+- Windows Server 2022
+- Windows Server 2019
+- Windows Server 2016
+- Windows Server 2012 R2
+- Windows Server 2012
+- Windows Server 2008 R2 (in Azure only)
+
 <?! Include "./shared/maintenance-and-support.txt" /?>
 
 <?! Include "./shared/chocolatey-component-dependencies.txt" /?>

--- a/input/en-us/troubleshooting.md
+++ b/input/en-us/troubleshooting.md
@@ -22,9 +22,16 @@ Also consider the [frequently asked questions](xref:faqs).
 
 ### The request was aborted: Could not create SSL/TLS secure channel
 
-If you see the following: Exception calling "DownloadString" with "1" argument(s): "The request was aborted: Could not create SSL/TLS secure channel." then you are likely running an older machine that needs to be upgraded to be able to use TLS 1.2 at a minimum.
+If you see the following error:
 
-community.chocolatey.org now requires TLS 1.2 at a minimum. Please see https://blog.chocolatey.org/2020/01/remove-support-for-old-tls-versions/. The post provides options if you have older clients that need to install Chocolatey.
+```sh
+Exception calling "DownloadString" with "1" argument(s): "The request was aborted: Could not create SSL/TLS secure channel."
+```
+
+The [Chocolatey Community Repository](https://community.chocolatey.org) now requires TLS 1.2 as a minimum, as mentioned in [this blog post](https://blog.chocolatey.org/2020/01/remove-support-for-old-tls-versions/).
+
+If you see this error when attempting to download Chocolatey CLI or any other packages from the Chocolatey Community Repository, you are likely running an older operating system that needs to be upgraded to be able to use TLS 1.2 as a minimum.
+See the [Microsoft documentation on enabling TLS 1.2 on older operating systems](https://learn.microsoft.com/en-us/mem/configmgr/core/plan-design/security/enable-tls-1-2-client#bkmk_winhttp).
 
 ### The underlying connection was closed
 

--- a/input/shared/chocolatey-component-dependencies.txt
+++ b/input/shared/chocolatey-component-dependencies.txt
@@ -2,9 +2,15 @@
 
 Some of the Chocolatey component packages have dependencies on other Chocolatey components.
 The following table aims to illustrate those dependencies, based on the latest shipped version of each component.
+Please refer to our [Support Lifecycle information](xref:chocolatey-components-dependencies-and-support-lifecycle#product-support-lifecycle) for details on which versions are supported for licensed and open source customers.
 
 | Package Name / Dependency      | chocolatey  | chocolatey.extension | chocolateygui |
 |------------------------------- |-------------|----------------------|---------------|
+| chocolatey v2.0.0              |             |                      |               |
+| chocolatey.extension v6.0.0    | v2.0.0      |                      |               |
+| chocolatey-agent v2.0.0        |             | v6.0.0               |               |
+| chocolateygui v2.0.0           | v2.0.0      |                      |               |
+| chocolateygui.extension v2.0.0 |             | v6.0.0               | v2.0.0        |
 | chocolatey v1.4.0              |             |                      |               |
 | chocolatey.extension v5.0.3    | v1.2.0      |                      |               |
 | chocolatey-agent v1.1.2        |             | v4.0.0               |               |
@@ -19,10 +25,10 @@ The following table aims to illustrate those dependencies, based on the latest s
 >
 > | Package Name            | Version |
 > | ----------------------- | ------- |
-> | chocolateygui.extension | v1.0.3  |
-> | chocolateygui           | v1.1.2  |
-> | chocolatey.extension    | v4.0.0  |
-> | chocolatey              | v1.0.0  |
+> | chocolateygui.extension | v2.0.0  |
+> | chocolateygui           | v2.0.0  |
+> | chocolatey.extension    | v6.0.0  |
+> | chocolatey              | v2.0.0  |
 
 > :choco-info: **NOTE**
 >


### PR DESCRIPTION
## Description Of Changes

- Update Chocolatey CLI requirements
- Added a new page that enumerates the support lifecycle and supported Windows versions
- Add a link to MS docs on enabling TLS 1.2 on older operating systems to the troubleshooting page

## Motivation and Context

As we get closer to v2.0, we need to update our support info and requirements for the new chocolatey versions.

## Testing

* [x] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [ ] Minor documentation fix (typos etc.).
* [x] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist

* [x] Requires a change to menu structure (top or left hand side)/
* [x] Menu structure has been updated

## Related Issue

[Clickup](https://app.clickup.com/t/20540031/PROJ-406)