### PR TITLE
(#706) Add specific share images for release notes

### DIFF
--- a/input/_Layout.cshtml
+++ b/input/_Layout.cshtml
@@ -7,19 +7,29 @@
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         @{
             string title = @Document.ContainsKey(Keys.Title) ? $"Chocolatey Software Docs | {Document.GetString(Keys.Title)}" : "Chocolatey Software Docs";
+            string description = @Document.ContainsKey(WebKeys.Description) ? @Document.GetString(WebKeys.Description) : "Chocolatey is software management automation for Windows that wraps installers, executables, zips, and scripts into compiled packages. Chocolatey integrates w/SCCM, Puppet, Chef, etc. Chocolatey is trusted by businesses to manage software deployments.";
+            string ogImage = @Document.ContainsKey("OgImage") ? @Document.GetString("OgImage") : "https://docs.chocolatey.org/assets/images/global-shared/facebook-share.png";
         }
-        <meta name="description" content="Chocolatey is software management automation for Windows that wraps installers, executables, zips, and scripts into compiled packages. Chocolatey integrates w/SCCM, Puppet, Chef, etc. Chocolatey is trusted by businesses to manage software deployments." />
+        <meta name="description" content="@description" />
         @* Twitter Card data *@
-        <meta name="twitter:card" content="summary">
         <meta name="twitter:site" content="@@chocolateynuget">
         <meta name="twitter:title" content="@title">
-        <meta name="twitter:image" content="https://docs.chocolatey.org/assets/images/global-shared/twitter-share.png">
+        @if (Document.ContainsKey("TwitterImage"))
+        {
+            <meta name="twitter:card" content="summary_large_image">
+            <meta name="twitter:image" content='@Document.GetString("TwitterImage")'>
+        }
+        else
+        {
+            <meta name="twitter:card" content="summary">
+            <meta name="twitter:image" content="https://docs.chocolatey.org/assets/images/global-shared/twitter-share.png">
+        }
         @* Open Graph data *@
         <meta property="og:title" content="@title" />
-        <meta property="og:description" content="Chocolatey is software management automation for Windows that wraps installers, executables, zips, and scripts into compiled packages. Chocolatey integrates w/SCCM, Puppet, Chef, etc. Chocolatey is trusted by businesses to manage software deployments." />
+        <meta property="og:description" content="@description" />
         <meta property="og:site_name" content="Chocolatey Software" />
         <meta property="og:type" content="product" />
-        <meta property="og:image" content="https://docs.chocolatey.org/assets/images/global-shared/facebook-share.png" />
+        <meta property="og:image" content="@ogImage" />
         <meta property="og:url" content="@Context.GetLink().TrimEnd('/')@Document.GetLink()" />
         @* Additional data *@
         <meta property="product:brand" content="Chocolatey Software" />

--- a/input/en-us/agent/release-notes.md
+++ b/input/en-us/agent/release-notes.md
@@ -3,6 +3,8 @@ Order: 10
 xref: agent-release-notes
 Title: Release Notes
 Description: Release Notes for Chocolatey Agent
+OgImage: https://img.chocolatey.org/social-share/release-notes-chocolatey-agent-og.png
+TwitterImage: https://img.chocolatey.org/social-share/release-notes-chocolatey-agent-twitter.png
 RedirectFrom: docs/release-notes-agent
 ---
 

--- a/input/en-us/c4b-environments/azure/release-notes.md
+++ b/input/en-us/c4b-environments/azure/release-notes.md
@@ -3,6 +3,8 @@ Order: 10
 xref: c4b-azure-release-notes
 Title: Release Notes
 Description: Release Notes for the Chocolatey for Business Azure Environment
+OgImage: https://img.chocolatey.org/social-share/release-notes-chocolatey-for-business-azure-environment-og.png
+TwitterImage: https://img.chocolatey.org/social-share/release-notes-chocolatey-for-business-azure-environment-twitter.png
 ---
 
 # Chocolatey for Business Azure Environment Release Notes

--- a/input/en-us/central-management/chococcm/release-notes.md
+++ b/input/en-us/central-management/chococcm/release-notes.md
@@ -3,6 +3,8 @@ Order: 20
 xref: chococcm-release-notes
 Title: Release Notes
 Description: Release Notes for ChocoCCM
+OgImage: https://img.chocolatey.org/social-share/release-notes-choco-ccm-og.png
+TwitterImage: https://img.chocolatey.org/social-share/release-notes-choco-ccm-twitter.png
 ---
 
 # Chocolatey Release Notes - ChocoCCM

--- a/input/en-us/central-management/release-notes.md
+++ b/input/en-us/central-management/release-notes.md
@@ -3,6 +3,8 @@ Order: 10
 xref: ccm-release-notes
 Title: Release Notes
 Description: Release Notes for Chocolatey Central Management
+OgImage: https://img.chocolatey.org/social-share/release-notes-chocolatey-central-management-og.png
+TwitterImage: https://img.chocolatey.org/social-share/release-notes-chocolatey-central-management-twitter.png
 RedirectFrom: docs/release-notes-central-management
 ---
 

--- a/input/en-us/choco/release-notes.md
+++ b/input/en-us/choco/release-notes.md
@@ -3,6 +3,8 @@ Order: 10
 xref: choco-release-notes
 Title: Release Notes
 Description: Release Notes for Chocolatey CLI
+OgImage: https://img.chocolatey.org/social-share/release-notes-chocolatey-cli-og.png
+TwitterImage: https://img.chocolatey.org/social-share/release-notes-chocolatey-cli-twitter.png
 RedirectFrom: docs/release-notes-choco-cli
 ---
 

--- a/input/en-us/chocolatey-gui-licensed-extension/release-notes.md
+++ b/input/en-us/chocolatey-gui-licensed-extension/release-notes.md
@@ -3,6 +3,8 @@ Order: 10
 xref: chocolatey-gui-licensed-extension-release-notes
 Title: Release Notes
 Description: Release Notes for Chocolatey GUI Extension
+OgImage: https://img.chocolatey.org/social-share/release-notes-chocolatey-gui-licensed-extension-og.png
+TwitterImage: https://img.chocolatey.org/social-share/release-notes-chocolatey-gui-licensed-extension-twitter.png
 ---
 
 # Chocolatey Release Notes - Chocolatey GUI Licensed Extension

--- a/input/en-us/chocolatey-gui/release-notes.md
+++ b/input/en-us/chocolatey-gui/release-notes.md
@@ -3,6 +3,8 @@ Order: 10
 xref: chocolateygui-release-notes
 Title: Release Notes
 Description: Release Notes for Chocolatey GUI
+OgImage: https://img.chocolatey.org/social-share/release-notes-chocolatey-gui-og.png
+TwitterImage: https://img.chocolatey.org/social-share/release-notes-chocolatey-gui-twitter.png
 RedirectFrom: docs/release-notes-chocolatey-gui
 ---
 

--- a/input/en-us/index.md
+++ b/input/en-us/index.md
@@ -2,7 +2,7 @@
 Order: 10
 xref: home
 Title: Chocolatey - Software Management for Windows
-Description: Chocolatey Documentation
+Description: Chocolatey is software management automation for Windows that wraps installers, executables, zips, and scripts into compiled packages. Chocolatey integrates w/SCCM, Puppet, Chef, etc. Chocolatey is trusted by businesses to manage software deployments.
 RedirectFrom:
   - docs/home
   - docs/

--- a/input/en-us/licensed-extension/release-notes.md
+++ b/input/en-us/licensed-extension/release-notes.md
@@ -2,7 +2,9 @@
 Order: 10
 xref: licensed-extension-release-notes
 Title: Release Notes
-Description: Release Notes for Chocolatey Extension
+Description: Release Notes for Chocolatey Licensed Extension
+OgImage: https://img.chocolatey.org/social-share/release-notes-chocolatey-licensed-extension-og.png
+TwitterImage: https://img.chocolatey.org/social-share/release-notes-chocolatey-licensed-extension-twitter.png
 RedirectFrom: docs/release-notes-extension
 ---
 


### PR DESCRIPTION
## Description Of Changes
This adds in new parameters that can be added to the frontmatter of
any markdown page, "TwitterImage" and "OgImage". These should be links
to an image that is meant to be used when the link is shared on social
media. The "TwitterImage" parameter is used when the link is shared on
Twitter, and the "OgImage" parameter is used when the link is shared on
Facebook or most other platforms like Discord or Slack.

The "TwitterImage" utilizes the "summary_large_image" type, which
requires an image ratio of 2:1. The "OgImage" must be 1200x630 pixels.

## Motivation and Context
This will help our releases stand out when the link is posted on Social Media.

## Testing

* [x] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

For each new image added on the files changed, ensure the url works. Take the url and paste it and ensure it takes you to the correct image on img.chocolatey.org.

## Change Types Made

* [x] Minor documentation fix (typos etc.).
* [ ] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist

* [ ] Requires a change to menu structure (top or left hand side)/
* [ ] Menu structure has been updated

## Related Issue
* #706 
* ENGTASKS-3119

Fixes #706
