### PR TITLE
Add warning for the upgrade guide for new releases

### DIFF
--- a/input/en-us/agent/release-notes.md
+++ b/input/en-us/agent/release-notes.md
@@ -33,6 +33,10 @@ This covers the release notes for the Chocolatey Agent Service (`chocolatey-agen
 
 ## 2.0.0 (May 31, 2023)
 
+> :choco-warning: **WARNING**
+>
+> Refer to our [Upgrade Guide](xref:upgrading-to-chocolatey-v2-v6) for recommendations before upgrading from 1.x versions to 2.0.0.
+
 ### Breaking Changes
 
 - Upgrade to target version 4.8 of the .NET Framework.

--- a/input/en-us/choco/release-notes.md
+++ b/input/en-us/choco/release-notes.md
@@ -23,6 +23,10 @@ This covers changes for the "chocolatey" and "chocolatey.lib" packages, which ar
 
 ## 2.0.0 (May 31, 2023)
 
+> :choco-warning: **WARNING**
+>
+> Refer to our [Upgrade Guide](xref:upgrading-to-chocolatey-v2-v6) for recommendations before upgrading from 1.x versions to 2.0.0.
+
 ### Breaking Changes
 
 - Change behavior of `choco list` to be local only - see [#158](https://github.com/chocolatey/choco/issues/158).

--- a/input/en-us/chocolatey-gui-licensed-extension/release-notes.md
+++ b/input/en-us/chocolatey-gui-licensed-extension/release-notes.md
@@ -28,6 +28,10 @@ Please see [Install the Licensed Edition](xref:setup-chocolatey-gui-licensed) fo
 
 ## 2.0.0 (May 31, 2023)
 
+> :choco-warning: **WARNING**
+>
+> Refer to our [Upgrade Guide](xref:upgrading-to-chocolatey-v2-v6) for recommendations before upgrading from 1.x versions to 2.0.0.
+
 ### Improvement
 
 - Update to use latest releases of Chocolatey products.

--- a/input/en-us/chocolatey-gui/release-notes.md
+++ b/input/en-us/chocolatey-gui/release-notes.md
@@ -21,6 +21,10 @@ This covers changes for the "chocolateygui" package, which is available as FOSS.
 
 ## 2.0.0 (May 31, 2023)
 
+> :choco-warning: **WARNING**
+>
+> Refer to our [Upgrade Guide](xref:upgrading-to-chocolatey-v2-v6) for recommendations before upgrading from 1.x versions to 2.0.0.
+
 ### Breaking Changes
 
 - Upgrade to target version 3.1.0 of Chocolatey.NuGet.Client and version 2.0.0 of Chocolatey.Lib assemblies - see [#974](https://github.com/chocolatey/ChocolateyGUI/issues/974).

--- a/input/en-us/licensed-extension/release-notes.md
+++ b/input/en-us/licensed-extension/release-notes.md
@@ -45,6 +45,10 @@ Please see [Install the Licensed Edition](xref:setup-licensed) for information o
 
 ## 6.0.0 (May 31, 2023)
 
+> :choco-warning: **WARNING**
+>
+> Refer to our [Upgrade Guide](xref:upgrading-to-chocolatey-v2-v6) for recommendations before upgrading from 5.x and earlier versions to 6.0.0.
+
 ### Breaking Changes
 
 - Upgrade to target version 4.8 of the .NET Framework.


### PR DESCRIPTION

## Description Of Changes

Added a notice to the v2 / v6 release notes sections to review the upgrade guide prior to upgrading.

## Motivation and Context

There are some pitfalls we'd prefer customers are warned about and can avoid.

## Testing

* [x] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [ ] Minor documentation fix (typos etc.).
* [X] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist

* [ ] Requires a change to menu structure (top or left hand side)/
* [ ] Menu structure has been updated

## Related Issue

N/A