### PR TITLE
(doc) Document removal of -a from list command

### DIFF
--- a/input/en-us/guides/upgrading-to-chocolatey-v2-v6.md
+++ b/input/en-us/guides/upgrading-to-chocolatey-v2-v6.md
@@ -107,7 +107,7 @@ If you need side-by-side functionality, **we do not recommend** you upgrade to C
 
 ### The List Command Now Lists Local Packages Only and the `--local-only` and `-lo` Options Have Been Removed
 
-In version 1.0.0 of Chocolatey CLI, we added notices that the `choco list` command will list only local packages, and deprecated the `--local-only` and `-lo` options. See this [GitHub issue for more information](https://github.com/chocolatey/choco/issues/158).
+In version 1.0.0 of Chocolatey CLI, we added notices that the `choco list` command will list only local packages, and deprecated the `--local-only` and `-lo` options. See this [GitHub issue for more information](https://github.com/chocolatey/choco/issues/158). We have also removed the `-a`, `--all`, `--allversions`, and `--all-versions` options from the `list` command as you cannot have multiple versions of a package installed.
 
 Running `choco list --local-only` or `choco list -lo` will now show this message:
 


### PR DESCRIPTION
## Description Of Changes
The `-a` option has been removed from the list command to this has been added to the docs.

## Motivation and Context
This hasn't been documented.

## Testing

* [ ] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made

* [ ] Minor documentation fix (typos etc.).
* [x] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist

* [ ] Requires a change to menu structure (top or left hand side)/
* [ ] Menu structure has been updated

## Related Issue

https://github.com/chocolatey/choco/issues/3177#issuecomment-1570959127
