### PR TITLE
(doc) Add warning about SemVer v2 support on CCR

### DIFF
--- a/input/en-us/guides/upgrading-to-chocolatey-v2-v6.md
+++ b/input/en-us/guides/upgrading-to-chocolatey-v2-v6.md
@@ -95,9 +95,11 @@ Adding NuGet v3 feed support to Chocolatey CLI has been a long-term goal that we
 
 ### SemVer 2.0.0 Support
 
-We have added support for [SemVer 2.0.0](https://semver.org/spec/v2.0.0.html) that allows previously invalid pre-release version numbering such as `1.0.1-alpha.23` to now be used alongside the current four part version numbering (`1.2.3.4`). The only constraint on the version number segments is that they must fit into the range `0` to `2147483647`.
+> :choco-warning: **WARNING**
+>
+> The Chocolatey Community Repository does not support SemVer 2.0.0 at this time, so this is supported only on third-party repositories.
 
-The Chocolatey Community Repository does not support SemVer 2.0.0 at this time, so this is supported only on third-party repositories.
+We have added support for [SemVer 2.0.0](https://semver.org/spec/v2.0.0.html) that allows previously invalid pre-release version numbering such as `1.0.1-alpha.23` to now be used alongside the current four part version numbering (`1.2.3.4`). The only constraint on the version number segments is that they must fit into the range `0` to `2147483647`.
 
 ### Supported Operating Systems
 


### PR DESCRIPTION
## Description Of Changes
Adds a warning for CCR not supporting SemVer v2.

## Motivation and Context
Better to call it out specifically.

## Testing

* [ ] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made

* [ ] Minor documentation fix (typos etc.).
* [x] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist

* [ ] Requires a change to menu structure (top or left hand side)/
* [ ] Menu structure has been updated

## Related Issue
