### PR TITLE
(doc) Change highlight text to match the page

### DIFF
--- a/input/en-us/highlights/highlight.md
+++ b/input/en-us/highlights/highlight.md
@@ -1,7 +1,7 @@
 ---
 Title: Chocolatey CLI v2.0.0
 Link: /en-us/choco/new-in-v2
-LinkText: See the highlights
+LinkText: See what's new
 ShouldOutput: false
 ShowInNavbar: false
 ShowInSidebar: false


### PR DESCRIPTION
## Description Of Changes

The change in this commit updates the link text used
for the highlight shown in the sidebar to match more
closely the page it links to, as well as being the same
as the list of highlights shown on a different page.

## Motivation and Context

The existing link text implied the highlight would navigate to all of the highlights that we have, but instead navigates to the page of this specific highlight.
As well as it does not match the link text used when viewing all of the highlights.

## Testing

* [x] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made

* [x] Minor documentation fix (typos etc.).
* [ ] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist

* [ ] Requires a change to menu structure (top or left hand side)/
* [ ] Menu structure has been updated

## Related Issue

N/A
