### PR TITLE
(#723) Update Jenkins package from jobs to scripts

### DIFF
--- a/input/en-us/c4b-environments/azure/index.md
+++ b/input/en-us/c4b-environments/azure/index.md
@@ -273,7 +273,7 @@ This is based on:
 
 As of version 2.0.0 of Chocolatey CLI, the `choco list` command only lists local packages. The Jenkins scripts included in the C4B Azure Environment prior to version 0.19.0 used this command when interrogating the environment's Nexus repositories. This results in the Jenkins jobs that use these scripts failing to run after updating Chocolatey CLI on ChocoServer itself to version 2.0.0 or above.
 
-To fix these scripts, you need to install a package called `chocolatey-licensed-jenkins-jobs` on ChocoServer. Start by internalizing it:
+To fix these scripts, you need to install a package called `chocolatey-licensed-jenkins-scripts` on ChocoServer. Start by internalizing it:
 
 1. Ensure you have your login credentials for Jenkins and Chocolatey Central Management, as described in the [Accessing Services](#accessing-services) section.
 1. Log into Jenkins at `https://<FQDN>/jenkins`
@@ -281,7 +281,7 @@ To fix these scripts, you need to install a package called `chocolatey-licensed-
 
     ![Location of Jenkins job play button](/assets/images/c4b-azure/Jenkins-Play-Button.png)
 
-1. Enter `chocolatey-licensed-jenkins-jobs` under the `P_PKG_LIST` parameter
+1. Enter `chocolatey-licensed-jenkins-scripts` under the `P_PKG_LIST` parameter
 1. Change the `P_DST_URL` parameter so that it ends with `ChocolateyInternal` rather than `ChocolateyTest`, this is being changed because the job that promotes packages between these repositories will not work if you have already upgraded to Chocolatey CLI v2.0.0 or above
 1. Click `Build`
 
@@ -289,14 +289,14 @@ To fix these scripts, you need to install a package called `chocolatey-licensed-
 
 > :choco-info: **NOTE**
 >
-> You may wish to run this job a second time, leaving the `P_DST_URL` as its default value. This will allow future updates to the `chocolatey-licensed-jenkins-jobs` package to be automatically internalized.
+> You may wish to run this job a second time, leaving the `P_DST_URL` as its default value. This will allow future updates to the `chocolatey-licensed-jenkins-scripts` package to be automatically internalized.
 
-Now you need to deploy the `chocolatey-licensed-jenkins-jobs` package to ChocoServer:
+Now you need to deploy the `chocolatey-licensed-jenkins-scripts` package to ChocoServer:
 
 1. Log into Chocolatey Central Management at `https://<FQDN>/`
 1. Navigate to `Groups` and create a group the contains only ChocoServer if that does not already exist
 1. Create a [deployment](xref:ccm-deployments) that targets the group containing ChocoServer
-1. Add a basic step, selecting the `choco install` command and specifying the package name `chocolatey-licensed-jenkins-jobs`
+1. Add a basic step, selecting the `choco install` command and specifying the package name `chocolatey-licensed-jenkins-scripts`
 1. Move this deployment to the Ready [state](xref:ccm-deployments#deployment-states) and then run it
 
 ### Status Message: Exist soft deleted vault with the same name.  (Code:ConflictError)


### PR DESCRIPTION
## Description Of Changes

This PR changes the name of the package containing the Jenkins scripts specified in the C4B Azure Environment documentation from `chocolatey-licensed-jenkins-jobs` to `chocolatey-licensed-jenkins-scripts`.

## Motivation and Context

The package does not actually touch the jenkins jobs themselves, but rather the scripts that are called by the jobs and so the previous name didn't make sense and also complicated the naming of potential future package.

## Testing

* [X] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made

* [X] Minor documentation fix (typos etc.).
* [ ] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist

* [ ] Requires a change to menu structure (top or left hand side)/
* [ ] Menu structure has been updated

## Related Issue

Related to #723
