### PR TITLE
(doc) Add GitLab Package Registry support

### DIFF
--- a/input/en-us/guides/upgrading-to-chocolatey-v2-v6.md
+++ b/input/en-us/guides/upgrading-to-chocolatey-v2-v6.md
@@ -87,6 +87,7 @@ If you are unable to upgrade to .NET Framework 4.8, **we do not recommend** you 
 Chocolatey CLI has supported NuGet v2 feeds since its earliest days. But, like all things, time and technology marches on and NuGet v3 feeds provide new opportunities for package management. Chocolatey CLI now supports NuGet v3 package feeds and listed below are some of the repository managers that also support them:
 
 * [GitHub Packages](https://github.com/features/packages)
+* [GitLab Package Registry](https://docs.gitlab.com/ee/user/packages/package_registry/) ([only feeds without authentication](https://github.com/chocolatey/choco/issues/3217#issuecomment-1596710688))
 * [Sonatype Nexus](https://www.sonatype.com/products/sonatype-nexus-repository)
 * [JFrog Artifactory](https://jfrog.com/artifactory/)
 * [ProGet](https://inedo.com/proget)


### PR DESCRIPTION
## Description Of Changes
Added GitLab Package Registry support.

## Motivation and Context
GitLab Package Registry is supported for unauthenticated feeds. See https://github.com/chocolatey/choco/issues/3217#issuecomment-1596710688

## Testing

* [ ] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made

* [x] Minor documentation fix (typos etc.).
* [ ] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist

* [ ] Requires a change to menu structure (top or left hand side)/
* [ ] Menu structure has been updated

## Related Issue

N/A