### PR TITLE
(doc)  ID cannot contain the word chocolatey

### DIFF
--- a/input/en-us/create/create-packages.md
+++ b/input/en-us/create/create-packages.md
@@ -307,6 +307,7 @@ There are some guidelines in terms of the package **ID** (`<id>` tag in the nusp
 * If you want to package an open source application, first search for any pre-existing packages on services like [Repology](https://repology.org/).
   If there are already published packages for the application on another repository, **use the same package id**.
   This will make it easier for users which work with multiple platforms, so they don't have to remember and use different package names.
+* Do not use `chocolatey` in your package ID as this indicates an official package. You can use `choco` instead, but you must include the word 'Unofficial' in the package title.
 
 These guidelines are already commonly applied on packages for all major Linux distributions, because they lead to a more consistent user experience for software repositories, result in easier to remember package IDs, and reduce unnecessary considerations on naming packages for package creators.
 


### PR DESCRIPTION
## Description Of Changes
Adding a note to confirm that package ID's cannot contain the word `chocolatey`.

## Motivation and Context
A package with the name `chocolatey` may give the impression that it is official and supported. While this is known, it's not documented.

## Testing

* [ ] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made

* [x] Minor documentation fix (typos etc.).
* [ ] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist

* [ ] Requires a change to menu structure (top or left hand side)/
* [ ] Menu structure has been updated

## Related Issue

N/A