### PR TITLE
(#770) Clarify Package Environment variables and their contents

### DIFF
--- a/input/en-us/create/functions/index.md
+++ b/input/en-us/create/functions/index.md
@@ -122,9 +122,12 @@ Chocolatey makes a number of environment variables available (You can access any
 
  * TEMP/TMP - Overridden to the CacheLocation, but may be the same as the original TEMP folder.
  * ChocolateyInstall - Top level folder where Chocolatey is installed.
- * ChocolateyPackageName - The name of the package, equivalent to the `<id />` field in the nuspec.
+ * ChocolateyPackageName - The name of the package, equivalent to the lower case `<id />` field in the nuspec.
  * ChocolateyPackageTitle - The title of the package, equivalent to the `<title />` field in the nuspec.
- * ChocolateyPackageVersion - The version of the package, equivalent to the `<version />` field in the nuspec.
+ * ChocolateyPackageVersion - The version of the package.
+   * Prior to Chocolatey CLI version 2.1.0 this is equivalent to the `<version />` field in the nuspec.
+   * Starting with Chocolatey CLI version 2.1.0 this is equivalent to the [normalized version](xref:upgrading-to-chocolatey-v2-v6#package-version-normalization) of the `<version />` field in the nuspec.
+   * If you rely on `ChocolateyPackageVersion` in a URL, ensure that all possible permutations of the package version work (eg: `1.0.0.0`, `1.0.0`, `1.0`, `1.0.00.0`).
 
 #### Advanced Environment Variables
 

--- a/input/en-us/create/functions/index.md
+++ b/input/en-us/create/functions/index.md
@@ -146,7 +146,7 @@ The following are more advanced settings:
 
 Some environment variables are set based on options that are passed, configuration and/or features that are turned on:
 
- * ChocolateyExitOnRebootDetected - Are we exiting on a detected reboot? Set by ` --exit-when-reboot-detected`  or the feature `exitOnRebootDetected`.
+ * ChocolateyExitOnRebootDetected - Are we exiting on a detected reboot? Set by `--exit-when-reboot-detected`  or the feature `exitOnRebootDetected`.
  * ChocolateyEnvironmentDebug - Was `--debug` passed? If using the built-in PowerShell host, this is always true (but only logs debug messages to console if `--debug` was passed).
  * ChocolateyEnvironmentVerbose - Was `--verbose` passed? If using the built-in PowerShell host, this is always true (but only logs verbose messages to console if `--verbose` was passed).
  * ChocolateyForce - Was `--force` passed?

--- a/input/en-us/create/functions/index.md
+++ b/input/en-us/create/functions/index.md
@@ -1,4 +1,4 @@
-﻿---
+---
 Order: 40
 xref: powershell-reference
 Title: PowerShell Reference
@@ -120,11 +120,11 @@ There are also a number of environment variables providing access to some values
 
 Chocolatey makes a number of environment variables available (You can access any of these with $env:TheVariableNameBelow):
 
- * TEMP/TMP - Overridden to the CacheLocation, but may be the same as the original TEMP folder
- * ChocolateyInstall - Top level folder where Chocolatey is installed
- * ChocolateyPackageName - The name of the package, equivalent to the `<id />` field in the nuspec
- * ChocolateyPackageTitle - The title of the package, equivalent to the `<title />` field in the nuspec
- * ChocolateyPackageVersion - The version of the package, equivalent to the `<version />` field in the nuspec
+ * TEMP/TMP - Overridden to the CacheLocation, but may be the same as the original TEMP folder.
+ * ChocolateyInstall - Top level folder where Chocolatey is installed.
+ * ChocolateyPackageName - The name of the package, equivalent to the `<id />` field in the nuspec.
+ * ChocolateyPackageTitle - The title of the package, equivalent to the `<title />` field in the nuspec.
+ * ChocolateyPackageVersion - The version of the package, equivalent to the `<version />` field in the nuspec.
 
 #### Advanced Environment Variables
 
@@ -143,14 +143,14 @@ The following are more advanced settings:
 
 Some environment variables are set based on options that are passed, configuration and/or features that are turned on:
 
- * ChocolateyExitOnRebootDetected - Are we exiting on a detected reboot? Set by ` --exit-when-reboot-detected`  or the feature `exitOnRebootDetected`
- * ChocolateyEnvironmentDebug - Was `--debug` passed? If using the built-in PowerShell host, this is always true (but only logs debug messages to console if `--debug` was passed)
- * ChocolateyEnvironmentVerbose - Was `--verbose` passed? If using the built-in PowerShell host, this is always true (but only logs verbose messages to console if `--verbose` was passed)
+ * ChocolateyExitOnRebootDetected - Are we exiting on a detected reboot? Set by ` --exit-when-reboot-detected`  or the feature `exitOnRebootDetected`.
+ * ChocolateyEnvironmentDebug - Was `--debug` passed? If using the built-in PowerShell host, this is always true (but only logs debug messages to console if `--debug` was passed).
+ * ChocolateyEnvironmentVerbose - Was `--verbose` passed? If using the built-in PowerShell host, this is always true (but only logs verbose messages to console if `--verbose` was passed).
  * ChocolateyForce - Was `--force` passed?
  * ChocolateyForceX86 - Was `-x86` passed?
- * ChocolateyRequestTimeout - How long before a web request will time out. Set by config `webRequestTimeoutSeconds`
- * ChocolateyResponseTimeout - How long to wait for a download to complete? Set by config `commandExecutionTimeoutSeconds`
- * ChocolateyPowerShellHost - Are we using the built-in PowerShell host? Set by `--use-system-powershell` or the feature `powershellHost`
+ * ChocolateyRequestTimeout - How long before a web request will time out. Set by config `webRequestTimeoutSeconds`.
+ * ChocolateyResponseTimeout - How long to wait for a download to complete? Set by config `commandExecutionTimeoutSeconds`.
+ * ChocolateyPowerShellHost - Are we using the built-in PowerShell host? Set by `--use-system-powershell` or the feature `powershellHost`.
 
 #### Business Edition Variables
 
@@ -163,8 +163,8 @@ Some environment variables are set based on options that are passed, configurati
 
 The following are experimental or use not recommended:
 
- * OS_IS64BIT = This may not return correctly - it may depend on the process the app is running under
- * CHOCOLATEY_VERSION_PRODUCT = the version of Choco that may match CHOCOLATEY_VERSION but may be different - based on git describe
+ * OS_IS64BIT = This may not return correctly - it may depend on the process the app is running under.
+ * CHOCOLATEY_VERSION_PRODUCT = the version of Choco that may match CHOCOLATEY_VERSION but may be different - based on git describe.
  * IS_ADMIN = Is the user an administrator? But doesn't tell you if the process is elevated.
 
 #### Not Useful Or Anti-Pattern If Used
@@ -178,14 +178,14 @@ The following are experimental or use not recommended:
  * ChocolateyChecksumType32 - Was `--download-checksum-type` passed?
  * ChocolateyChecksum64 - Was `--download-checksum-x64` passed?
  * ChocolateyChecksumType64 - Was `--download-checksum-type-x64` passed?
- * ChocolateyPackageExitCode - The exit code of the script that just ran - usually set by `Set-PowerShellExitCode`
+ * ChocolateyPackageExitCode - The exit code of the script that just ran - usually set by `Set-PowerShellExitCode`.
  * ChocolateyLastPathUpdate - Set by Chocolatey as part of install, but not used for anything in particular in packaging.
- * ChocolateyProxyLocation - The explicit proxy location as set in the configuration `proxy`
- * ChocolateyDownloadCache - Use available download cache? Set by `--skip-download-cache`, `--use-download-cache`, or feature `downloadCache`
- * ChocolateyProxyBypassList - Explicitly set locations to ignore in configuration `proxyBypassList`
- * ChocolateyProxyBypassOnLocal - Should the proxy bypass on local connections? Set based on configuration `proxyBypassOnLocal`
+ * ChocolateyProxyLocation - The explicit proxy location as set in the configuration `proxy`.
+ * ChocolateyDownloadCache - Use available download cache? Set by `--skip-download-cache`, `--use-download-cache`, or feature `downloadCache`.
+ * ChocolateyProxyBypassList - Explicitly set locations to ignore in configuration `proxyBypassList`.
+ * ChocolateyProxyBypassOnLocal - Should the proxy bypass on local connections? Set based on configuration `proxyBypassOnLocal`.
  * http_proxy - Set by original `http_proxy` passthrough, or same as `ChocolateyProxyLocation` if explicitly set.
  * https_proxy - Set by original `https_proxy` passthrough, or same as `ChocolateyProxyLocation` if explicitly set.
  * no_proxy- Set by original `no_proxy` passthrough, or same as `ChocolateyProxyBypassList` if explicitly set.
- * ChocolateyPackageFolder - Not for use in package automation scripts. Recommend using `$toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"` as per template generated by `choco new`
- * ChocolateyToolsLocation - Not for use in package automation scripts. Recommend using Get-ToolsLocation instead
+ * ChocolateyPackageFolder - Not for use in package automation scripts. Recommend using `$toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"` as per template generated by `choco new`.
+ * ChocolateyToolsLocation - Not for use in package automation scripts. Recommend using Get-ToolsLocation instead.

--- a/input/en-us/guides/upgrading-to-chocolatey-v2-v6.md
+++ b/input/en-us/guides/upgrading-to-chocolatey-v2-v6.md
@@ -44,6 +44,10 @@ This is [discussed in more depth later](#side-by-side-installs-have-been-removed
 
 ### Package Version Normalization
 
+> :choco-note: **NOTE**
+>
+> **Important information for package maintainers.** The `ChocolateyPackageVersion` [environment variable](xref:powershell-reference#environment-variables) follows the below version normalization. If your package scripts use this variable, and the nuspec specified version falls outside of the normalized format, then they may not behave as expected. We recommend using specific version numbers within your scripts rather depending on these environment variables.
+
 Due to newer semantic version requirements imposed by the NuGet libraries, some version numbers may appear differently than they did in Chocolatey CLI v1.x. Chocolatey CLI 2.0.0 and later will [normalize version numbers](xref:version-normalization) to comply with these new requirements.
 
 ### Optimizing Performance


### PR DESCRIPTION
## Description Of Changes

Add a note to the upgrade guide for Package Maintainers to be aware that the ChocolateyPackageVersion is normalized in Chocolatey CLI Version 2.0.0. Add some clarifying words around the ChocolateyPackageName variable that it is a lower case version of the id.

## Motivation and Context

The normalization of Version numbers could behave differently depending on the package scripts. There used to be at least one package that expected ChocolateyPackageName to exactly match the nuspec file and it didn't work when the casing was changed.

## Testing

* [x] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made

* [x] Minor documentation fix (typos etc.).
* [ ] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist

* [ ] Requires a change to menu structure (top or left hand side)/
* [ ] Menu structure has been updated

## Related Issue

- Fixes #770 