### PR TITLE
(#768) Add for for KeyVaultSecretDoesNotExist error when starting C4B Azure Environment VM

### DIFF
--- a/input/en-us/c4b-environments/azure/index.md
+++ b/input/en-us/c4b-environments/azure/index.md
@@ -333,3 +333,16 @@ We have seen an occasional issue with IISReset that cannot be replicated. This r
 > the remote computer or to the domain administrator global group.
 
 If you see this error, you should redeploy the resource.
+
+### Environment VM unable to start due to missing secret  (Error: KeyVaultSecretDoesNotExist)
+
+During the deployment of the Chocolatey for Business Azure Environment your supplied certificate is converted from a [secret](https://learn.microsoft.com/en-us/azure/key-vault/secrets/about-secrets) object to a [certificate](https://learn.microsoft.com/en-us/azure/key-vault/certificates/about-certificates) object within the environment's [KeyVault](https://portal.azure.com/#blade/HubsExtension/BrowseResource/resourceType/Microsoft.KeyVault%2Fvaults)
+
+The Chocolatey for Business Azure Environment's Virtual Machine may retain a reference to the certificate from prior to the conversion, and if it is shut down then it will not be able to start again due to the referenced secret no longer existing.
+
+To fix this, use the PowerShell Az modules as follows:
+
+```PowerShell
+if (-not $ResourceGroupName) {$ResourceGroupName = Read-Host 'Enter the ResourceGroupName'}
+Get-AzVM -ResourceGroupName $ResourceGroupName | Remove-AzVMSecret | Update-AzVM
+```

--- a/input/en-us/c4b-environments/azure/index.md
+++ b/input/en-us/c4b-environments/azure/index.md
@@ -343,6 +343,8 @@ The Chocolatey for Business Azure Environment's Virtual Machine may retain a ref
 To fix this, use the PowerShell Az modules as follows:
 
 ```PowerShell
-if (-not $ResourceGroupName) {$ResourceGroupName = Read-Host 'Enter the ResourceGroupName'}
+if (-not $ResourceGroupName) {
+    $ResourceGroupName = Read-Host 'Enter the ResourceGroupName'
+}
 Get-AzVM -ResourceGroupName $ResourceGroupName | Remove-AzVMSecret | Update-AzVM
 ```


### PR DESCRIPTION
## Description Of Changes

The PR adds a new section to the "Common Errors and Resolutions" section of the Chocolatey for Business Azure Environment docs covering how to fix an issue where the environment's VM cannot start due to having a reference to a secret that is missing from the environment's KeyVault.

## Motivation and Context

While the root cause of this issue is fixed in version 0.19.0 of the Chocolatey for Business Azure Environment, it can still impact environments deployed prior to that release and so the fix should be documented and available.

## Testing

* [X] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made

* [ ] Minor documentation fix (typos etc.).
* [X] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist

* [ ] Requires a change to menu structure (top or left hand side)/
* [ ] Menu structure has been updated

## Related Issue

Fixes #768
