### PR TITLE
Update choco 2.0.0 release notes

### DIFF
--- a/input/en-us/choco/release-notes.md
+++ b/input/en-us/choco/release-notes.md
@@ -141,6 +141,7 @@ A fix has been found for this problem, and will be released in a future alpha re
 
 - Fix - NuGet does not deal with blocking version conflicts from existing installed packages - see [#116](https://github.com/chocolatey/choco/issues/116).
 - Fix - NuGet doesn't handle conflicts of versions in an install request when HighestVersion dependency - see [#507](https://github.com/chocolatey/choco/issues/507).
+- Fix - Push command does not honor proxy settings - see [#1271](https://github.com/chocolatey/choco/issues/1271).
 - Fix - Filenames that contain apostrophes aren't handled correctly when calculating checksums - see [#1590](https://github.com/chocolatey/choco/issues/1590).
 - Fix - Chocolatey CLI does not override NuGet proxy with its own - see [#1720](https://github.com/chocolatey/choco/issues/1720).
 - Fix - `choco pack` command fails with error on Linux when using file greater than 2 GB - see [#2278](https://github.com/chocolatey/choco/issues/2278).


### PR DESCRIPTION
## Description Of Changes

Add note about push command proxy support.

## Motivation and Context

The uplift of the NuGet libraries fixed the proxy support on the push command.

## Testing

* [x] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made

* [x] Minor documentation fix (typos etc.).
* [ ] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist

* [ ] Requires a change to menu structure (top or left hand side)/
* [ ] Menu structure has been updated

## Related Issue

N/A