### PR TITLE
(doc) Update writing rules and guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,15 @@ This site is built using [Statiq](https://statiq.dev/).
 
 The original template that was used to create this docs site came from the work that was done by [Patrik Svensson](https://github.com/patriksvensson), on his [Spectre.Console](https://spectresystems.github.io/spectre.console/) and [Spectre.Cli](https://spectresystems.github.io/spectre.cli/) docs sites. Huge thank you to Patrik for all his help!
 
+## Writing Documentation
+
+Listed below are some of the areas we consider important when writing. We have two goals:
+
+* **Consistency**. It's important when writing to be consistent in all areas including, but not limited to, headings, code style, formatting, use of bold and italics. We acknowledge that as our writing style has evolved not all of our writing has followed. When we write we should be consistent.
+* **Clarity**. When writing we must remember to write for others and not just for ourselves. It's important to understand that jargon or acronyms can cause confusion, misunderstanding and a barrier for others who are not familiar with the terms. Avoid using jargon where you can and only use acronyms once they have been defined. Ensure any [jargon or acronyms used are documented](https://docs.chocolatey.org/en-us/information/jargon-buster).
+
+To help with these goals, please refer to our guides on [writing documentation](https://design.chocolatey.org/content-and-marketing/writing-documentation) and the use of [language and grammar](https://design.chocolatey.org/content-and-marketing/language-and-grammar).
+
 ## Building the site
 
 ### Setup


### PR DESCRIPTION
## Description Of Changes
Move the writing guidelines from the [blog repository](https://github.com/chocolatey/blog#guidelines), which is private, to here, which is public, and extend them.

Once this is approved, I'll update the blog writing section to point to this so we have it all in one place.

Note that this is not final and will evolve as our writing does. If we stick to the two core goals (which again could evolve) then we will be going in the right direction for the community and customers.

## Motivation and Context
To ensure we are all on the same page of writing documentation, I took what we commonly do and put it down on 'paper' so that we are all writing consistent and clear documentation.

## Testing

* [ ] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

This is a change to the README file so doesn't affect the publishd docs.

## Change Types Made

* [x] Minor documentation fix (typos etc.).
* [ ] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist

* [ ] Requires a change to menu structure (top or left hand side)/
* [ ] Menu structure has been updated

## Related Issue

N/A