### PR TITLE
(#784) Update home page highlight section

### DIFF
--- a/input/en-us/highlights/2023-05/choco-v2-release-notes.md
+++ b/input/en-us/highlights/2023-05/choco-v2-release-notes.md
@@ -3,6 +3,7 @@ Title: Chocolatey CLI v2.0.0 Release Notes
 Link: /en-us/choco/release-notes#may-31-2023
 LinkText: Read the notes
 PostedDateTime: 2023-05-31T01:00:00Z
+ShowOnHome: false
 ---
 
 Discover the new improvements, essential bug fixes, and important breaking changes in Chocolatey CLI v2.0.0 by exploring the detailed release notes.

--- a/input/en-us/highlights/2023-07/_directory.yml
+++ b/input/en-us/highlights/2023-07/_directory.yml
@@ -1,0 +1,3 @@
+ShouldOutput: false
+ShowInNavbar: false
+ShowInSidebar: false

--- a/input/en-us/highlights/2023-07/choco-troubleshooting-dependencies.md
+++ b/input/en-us/highlights/2023-07/choco-troubleshooting-dependencies.md
@@ -1,0 +1,8 @@
+---
+Title: Dependency Troubleshooting in Chocolatey CLI
+Link: /en-us/choco/troubleshooting/dependency-troubles
+LinkText: Get dependency troubleshooting help
+PostedDateTime: 2023-07-14T03:00:00Z
+---
+
+Discover how to troubleshoot and resolve installation and upgrade errors caused by dependency issues. Learn step-by-step instructions on resolving package failures and ensuring a consistent state by running the appropriate commands.

--- a/input/en-us/highlights/2023-07/choco-troubleshooting-unable-to-load-service-index.md
+++ b/input/en-us/highlights/2023-07/choco-troubleshooting-unable-to-load-service-index.md
@@ -1,0 +1,8 @@
+---
+Title: Resolving Chocolatey CLI Package Source Communication Issues
+Link: /en-us/choco/troubleshooting/unable-to-load-service-index
+LinkText: Fix package source issues
+PostedDateTime: 2023-07-13T03:00:00Z
+---
+
+Diagnose and resolve communication issues with Chocolatey CLI package sources, including SSL/TLS and certificate errors, and find solutions to ensure seamless package management.

--- a/input/en-us/highlights/2023-07/index.md
+++ b/input/en-us/highlights/2023-07/index.md
@@ -1,0 +1,4 @@
+---
+PostedDateTime: 2023-07-01T00:00:00Z
+ShowOnHome: false
+---

--- a/input/en-us/highlights/2023-07/proxy-considerations-and-limitations.md
+++ b/input/en-us/highlights/2023-07/proxy-considerations-and-limitations.md
@@ -1,0 +1,9 @@
+---
+Title: |
+    Proxy Configuration in Chocolatey: Precedence and Known Limitations
+Link: /en-us/guides/usage/proxy-settings-for-chocolatey#proxy-configuration-priority
+LinkText: Learn about proxies
+PostedDateTime: 2023-07-14T04:00:00Z
+---
+
+Explore the priority order for configuring proxies in Chocolatey and learn about known limitations affecting certain Chocolatey products' proxy settings.


### PR DESCRIPTION
## Description Of Changes
This adds new highlights for documentation that was added within the last month.

To ensure that the highlight section did not become too long, one old post has been removed, however it will still be accessible via the dedicated highlights page.

## Motivation and Context
This section is meant to be updated regularly with notable documentation changes.

## Testing

* [x] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made=
* [ ] Minor documentation fix (typos etc.).
* [x] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [x] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist

* [ ] Requires a change to menu structure (top or left hand side)/
* [ ] Menu structure has been updated

## Related Issue
#784
Fixes #784

## Screenshot

![Screenshot 2023-07-18 at 10 59 23 AM](https://github.com/chocolatey/docs/assets/42750725/f1454159-1b23-45b3-83b2-e57db9ddce16)
