### PR TITLE
(#786) Set required memory for container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,6 +10,10 @@
 			"NODE_VERSION": "20"
 		}
 	},
+	"hostRequirements": {
+		"cpus": 4,
+		"memory": "8gb"
+	},
 	"settings": {},
 	"extensions": [
 		"ms-dotnettools.csharp",


### PR DESCRIPTION
## Description Of Changes
Sets the required memory for the docs repo container to 4 GB. Note that this is the amount that I need to set it to. The issue #786 didn't specify a memory number.

## Motivation and Context
Less than 4GB memory in the container, _in my setup_, causes the site not to build.

## Testing

* [ ] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made

* [ ] Minor documentation fix (typos etc.).
* [ ] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist

* [ ] Requires a change to menu structure (top or left hand side)/
* [ ] Menu structure has been updated

## Related Issue

Fixes #786 
