### PR TITLE
(doc) Add link to upgrade guide

### DIFF
--- a/input/en-us/choco/new-in-v2.md
+++ b/input/en-us/choco/new-in-v2.md
@@ -7,6 +7,10 @@ Description: A summary of the notable differences when upgrading from Chocolatey
 
 # What's New in Chocolatey CLI v2.0.0
 
+> **Note**
+>
+> This is a high-level overview of what's new in Chocolatey CLI 2.0.0. If you are ready to upgrade, please read the [upgrade guide](xref:upgrading-to-chocolatey-v2-v6).
+
 ## NuGet v3 Feed Support
 
 You can now use NuGet v3 package feeds with Chocolatey CLI!
@@ -107,3 +111,7 @@ On reaching these limits, Chocolatey CLI will warn you to refine your query to g
   Use `choco install packagename -s ./local/path/to/folder` instead, and ensure packages are packed with `choco pack` before attempting to install them.
 - Package version numbers will no longer retain leading zeroes in any parts of the version number when using `choco pack`.
   For example, `09.00.001` will be normalized to `9.0.1`.
+
+## Ready To Upgrade?
+
+If you are ready to upgrade, please read our [upgrade guide](xref:upgrading-to-chocolatey-v2-v6).


### PR DESCRIPTION
## Description Of Changes
After reading the overview of 2.x, we should provide the next steps by linking to the upgrade guide.

## Motivation and Context
The upgrade is not linked to so people do not know the next steps.

## Testing

* [ ] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [x] Minor documentation fix (typos etc.).
* [ ] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist

* [ ] Requires a change to menu structure (top or left hand side)/
* [ ] Menu structure has been updated

## Related Issue
N/A