### PR TITLE
(#790) No support for v2 and v3 group repos in Nexus

### DIFF
--- a/input/en-us/guides/upgrading-to-chocolatey-v2-v6.md
+++ b/input/en-us/guides/upgrading-to-chocolatey-v2-v6.md
@@ -38,6 +38,8 @@ The Sonatype Nexus Repository Manager has an [issue that can cause it to go into
 
 To work around this issue, please ensure that you have 29 or less package versions of any Chocolatey product in your internal Sonatype Nexus NuGet v2 feed repository _before_ you start the upgrade.
 
+Sonatype Nexus [does not support mixed v2 and v3 NuGet group repositories](https://help.sonatype.com/repomanager3/nexus-repository-administration/formats/nuget-repositories/grouping-nuget-repositories#GroupingNuGetRepositories-NuGetGroupVersion3APISupport). If you already use a v2 NuGet group or proxy repository, then you cannot add a v3 repository to the group.
+
 ### Side-By-Side Installs Have Been Removed
 
 This is [discussed in more depth later](#side-by-side-installs-have-been-removed-1), but we wanted to highlight it here as it is a very important consideration to make before upgrading.


### PR DESCRIPTION
## Description Of Changes
Add note that Nexus does not support micing v2 and v3 group repositories.

## Motivation and Context
Something we should highlight in the upgrad eguide as customers may want to move to using v3 repositories.

## Testing

* [ ] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made

* [ ] Minor documentation fix (typos etc.).
* [x] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    
## Change Checklist

* [ ] Requires a change to menu structure (top or left hand side)/
* [ ] Menu structure has been updated

## Related Issue

Fixes #790