### PR TITLE
Adds Deployment Examples Placeholder

### DIFF
--- a/input/en-us/c4b-environments/quick-deployment/index.md
+++ b/input/en-us/c4b-environments/quick-deployment/index.md
@@ -65,7 +65,7 @@ The above articles document how that is done.
 * [QDE Setup](xref:v2-qde)
 * [QDE Desktop ReadMe File](xref:v2-desktop-readme) (included here for convenience)
 * [QDE SSL/TLS Setup](xref:v2-ssl-setup)
-* [QDE Firewall Changes](xref:v2-firewall-changes)
+* [QSE Firewall Rules](xref:firewall-rules)
 * [QDE Client Setup](xref:v2-client-setup) (setting up your client machines)
 * [How do I upgrade QDE?](xref:qde#how-do-we-upgrade-qde).
 

--- a/input/en-us/c4b-environments/quick-deployment/setup/desktop-readme.md
+++ b/input/en-us/c4b-environments/quick-deployment/setup/desktop-readme.md
@@ -339,5 +339,5 @@ Stop-Process -Name explorer -Force
 - [QDE Setup](xref:v2-qde)
 - [QDE Desktop ReadMe File](xref:v2-desktop-readme)
 - [QDE SSL/TLS Setup](xref:v2-ssl-setup)
-- [QDE Firewall Changes](xref:v2-firewall-changes)
+- [QSE Firewall Rules](xref:firewall-rules)
 - [QDE Client Setup](xref:v2-client-setup) (setting up your client machines)

--- a/input/en-us/c4b-environments/quick-deployment/setup/index.md
+++ b/input/en-us/c4b-environments/quick-deployment/setup/index.md
@@ -268,7 +268,7 @@ If you would like to change the credentials associated with the database, you wi
 
 ## Step 4: Firewall Changes
 
-See [QDE Firewall Changes](xref:v2-firewall-changes).
+See [QSE Firewall Changes](xref:firewall-rules).
 
 ## Step 5: Install and Configure Chocolatey on Clients
 

--- a/input/en-us/c4b-environments/quick-deployment/setup/internet-setup.md
+++ b/input/en-us/c4b-environments/quick-deployment/setup/internet-setup.md
@@ -16,7 +16,7 @@ RedirectFrom: docs/quick-deployment-internet-setup
 > See the following QDE v2.0+ documents for more information on how to handle this setup or certificate renewals in newer versions:
 >
 > * [QDE Desktop Readme](xref:v2-desktop-readme)
-> * [QDE Firewall Changes](xref:v2-firewall-changes)
+> * [QDE Firewall Changes](xref:firewall-rules)
 > * [QDE SSL Setup](xref:v2-ssl-setup)
 
 With an unprecedented amount of employees working from home, there is a much greater demand to serve their software lifecycle needs remotely. Thus, many organizations would like the option to make the Chocolatey Quick Deployment Environment (QDE) Internet-accessible. This document walks you through some options you will need to consider, if you choose this route.
@@ -43,7 +43,7 @@ In general, it is not required or may not be advisable to have these accessible 
 You can access these via a Remote Desktop session on the QDE server itself, or opening these ports up to your internal network.
 Again, we **strongly** advise against opening these ports up to the public Internet for security reasons.
 
-Further details on firewall changes can be found on the [QDE Firewall Setup](xref:v2-firewall-changes) page.
+Further details on firewall changes can be found on the [QSE Firewall Rules](xref:firewall-rules) page.
 
 ## SSL Certificate Setup
 

--- a/input/en-us/c4b-environments/quick-deployment/setup/ssl-setup.md
+++ b/input/en-us/c4b-environments/quick-deployment/setup/ssl-setup.md
@@ -17,7 +17,7 @@ During normal setup, all required SSL certificates are retrieved or generated as
 You will only need to run this script yourself in the following cases:
 
 * You want to expose this to the internet so clients can connect from outside your network, and you didn't set this up initially.
-  See [the Firewall Changes document](xref:v2-firewall-changes) document for more information and additional scripts to run in this case.
+  See [the Firewall Changes document](xref:firewall-rules) document for more information and additional scripts to run in this case.
 * If you change the hostname of the QDE server, or add it to a domain after having already completed setup.
 * If you would like to change/replace the initial SSL/TLS certificates that were provided or generated during setup, for example to replace an expiring certificate.
 

--- a/input/en-us/c4b-environments/quick-deployment/v1/firewall-changes.md
+++ b/input/en-us/c4b-environments/quick-deployment/v1/firewall-changes.md
@@ -9,7 +9,7 @@ RedirectFrom: docs/quick-deployment-firewall-changes-v1
 > :choco-info: **NOTE**
 >
 > This document is for **Version 1** of the Quick Deployment Environment.
-> If you're using a newer version of QDE, please refer to the [newer QDE Firewall Changes page](xref:v2-firewall-changes).
+> If you're using a newer version of QDE, please refer to the [newer QSE Firewall Rules page](xref:firewall-rules).
 
 ## External Ports
 

--- a/input/en-us/central-management/usage/examples/deployments.md
+++ b/input/en-us/central-management/usage/examples/deployments.md
@@ -1,0 +1,10 @@
+---
+Order: 10
+xref: ccm-example-deployments
+Title: Deployments
+Description: Example deployments that can be imported into Chocolatey Central Management for immediate use
+---
+
+> :choco-warning: **WARNING**
+>
+> This is a Work in Progress. Please check back later.

--- a/input/en-us/central-management/usage/examples/index.md
+++ b/input/en-us/central-management/usage/examples/index.md
@@ -1,0 +1,6 @@
+---
+Order: 40
+xref: ccm-usage-examples
+Title: Examples
+Description: Suggested configurations, deployments, and usages for Chocolatey Central Management
+---

--- a/input/en-us/central-management/usage/website/index.md
+++ b/input/en-us/central-management/usage/website/index.md
@@ -2,5 +2,5 @@
 Order: 10
 xref: ccm-usage-website
 Title: Website
-Description: Information about how to works with the different entities/functionality contained within Chocolatey Central Management Website
+Description: Information about how to work with the different entities/functionality contained within the Chocolatey Central Management Website
 ---


### PR DESCRIPTION
## Description Of Changes
Adds a placeholder for the deployment examples / templates / recipes.

Also: corrects a minor typo / phrasing issue, and removes/changes some broken xref links that were preventing this from building/deploying.

## Motivation and Context
We are creating a short link and associated linkage in CCM, and need a target to send folk to - even if it's currently WIP.

## Testing

* [x] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made

* [x] Minor documentation fix (typos etc.).
* ~[ ] Major documentation change (refactoring, reformatting or adding documentation to existing page).~
* [x] New documentation page added.
* ~[ ] The change I have made should have a video added, and I have raised an issue for this.~

## Change Checklist

* [x] Requires a change to menu structure (top or left hand side)/
* [x] Menu structure has been updated

## Related Issue

Fixes #823
