### PR TITLE
Add missing QDE redirect

### DIFF
--- a/input/en-us/c4b-environments/quick-start-environment/qde-deprecation.md
+++ b/input/en-us/c4b-environments/quick-start-environment/qde-deprecation.md
@@ -6,6 +6,7 @@ Description: Landing page for old QDE links
 ShowInNavbar: false
 ShowInSidebar: false
 RedirectFrom:
+- en-us/c4b-environments/quick-deployment
 - en-us/c4b-environments/quick-deployment/release-notes
 - en-us/c4b-environments/quick-deployment/setup
 - en-us/c4b-environments/quick-deployment/setup/desktop-readme


### PR DESCRIPTION
## Description Of Changes
Missed a redirect when removing QDE docs. This PR fixes it.

## Motivation and Context
I messed up and missed a page in my original PR 😢 

## Testing

* [X] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made

* [X] Minor documentation fix (typos etc.).
* ~[ ] Major documentation change (refactoring, reformatting or adding documentation to existing page).~
* ~[ ] New documentation page added.~
* ~[ ] The change I have made should have a video added, and I have raised an issue for this.~
    * ~Issue #~

## Change Checklist

* ~[ ] Requires a change to menu structure (top or left hand side)/~
* ~[ ] Menu structure has been updated~

## Related Issue

