### PR TITLE
(doc) Remove Nexus issue link as it's no longer accessible

### DIFF
--- a/input/en-us/guides/upgrading-to-chocolatey-v2-v6.md
+++ b/input/en-us/guides/upgrading-to-chocolatey-v2-v6.md
@@ -47,7 +47,7 @@ Before downgrading from 2.x and 6.x to 1.x and 5.x of Chocolatey products, pleas
 
 ### Sonatype Nexus Repository Sources
 
-The Sonatype Nexus Repository Manager has an [issue that can cause it to go into an infinite loop of querying for packages from a NuGet v2 feed](https://issues.sonatype.org/browse/NEXUS-13426) (you will need a login for the Sonatype Jira system to view the issue). This only affects Sonatype Nexus NuGet v2 feeds as it has been fixed for NuGet v3 feeds.
+The Sonatype Nexus Repository Manager has an issue that can cause it to go into an infinite loop of querying for packages from a NuGet v2 feed. This only affects Sonatype Nexus NuGet v2 feeds as it has been fixed for NuGet v3 feeds.
 
 To work around this issue, please ensure that you have 29 or less package versions of any Chocolatey product in your internal Sonatype Nexus NuGet v2 feed repository _before_ you start the upgrade.
 


### PR DESCRIPTION
## Description Of Changes
Removed the link to the [Nexus infinite paging issue](https://issues.sonatype.org/browse/NEXUS-13426) as it no longer exists (even after logging in).

## Motivation and Context
The link is no longer accessible.

## Testing
N/A - this was just removing a link from the markdown.

## Change Types Made

* [x] Minor documentation fix (typos etc.).
* [ ] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.

## Change Checklist

* [ ] Requires a change to menu structure (top or left hand side)
* [ ] Menu structure has been updated

## Related Issue
N/A