### PR TITLE
(#862) Normalize Export Buttons

### DIFF
--- a/input/en-us/central-management/usage/website/computers.md
+++ b/input/en-us/central-management/usage/website/computers.md
@@ -49,7 +49,7 @@ You will be presented with a list of the installed software packages for the mac
 >
 > Starting with Chocolatey Central Management 0.11.0, the packages installed on a computer can be exported to a `packages.config` file.
 
-From the Computer details page in Chocolatey Central Management, select the `Export to packages.config` button.
+From the Computer details page in Chocolatey Central Management, click the `Export` button and select the `Export to packages.config` option.
 
 ![Computer details screen highlighting Export to packages.config button](/assets/images/computers/ccm-computers-details-export-packages-config.png)
 


### PR DESCRIPTION
## Description Of Changes
This updates the verbiage used when selecting an export option. Export options are now all in one single button and selectable in dropdown.

## Motivation and Context
This changed, and needs to be updated.

## Testing

* [x] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made
* [ ] Minor documentation fix (typos etc.).
* [x] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.

## Change Checklist

* [ ] Requires a change to menu structure (top or left hand side)/
* [ ] Menu structure has been updated

## Related Issue
* #862
