### PR TITLE
(#862) Deployment to upgrade or uninstall  a piece of Software

### DIFF
--- a/input/en-us/central-management/usage/website/software.md
+++ b/input/en-us/central-management/usage/website/software.md
@@ -21,9 +21,33 @@ The Software main page lists all installed software in any computers that have c
 
 ![Software main page](/assets/images/software/ccm-software-main.png)
 
+## Upgrade Individual Software
+
+In the leftmost column of the Software table you will find an :gear: **Actions** menu which will display an **Upgrade** option on outdated Software.
+
+![Finding the Upgrade menu entry for a specific Software entry](/assets/images/software/ccm-software-upgrade-menu.png)
+
+Clicking this option will create a New Deployment Plan. This Deployment Plan will create one Deployment Step with a [Temporary Group](xref:ccm-groups#temporary-groups) that contains all the Computers the outdated Software is currently installed on.
+
+![Automatically created Deployment Plan showing Temporary Group](/assets/images/software/ccm-software-temporary-group.png)
+
+From here, the Deployment Plan can be edited and deployed as outlined in the [Deployment Plans documentation](xref:ccm-deployments).
+
+## Uninstall Individual Software
+
+In the leftmost column of the Software table you will find an :gear: **Actions** menu which will display an **Uninstall** option.
+
+![Finding the Upgrade menu entry for a specific Software entry](/assets/images/software/ccm-software-uninstall-menu.png)
+
+Clicking this option will create a New Deployment Plan. This Deployment Plan will create one Deployment Step with a [Temporary Group](xref:ccm-groups#temporary-groups) that contains all the Computers the Software is currently installed on.
+
+![Automatically created Deployment Plan showing Temporary Group](/assets/images/software/ccm-software-temporary-group.png)
+
+From here, the Deployment Plan can be edited and deployed as outlined in the [Deployment Plans documentation](xref:ccm-deployments).
+
 ## Software Details
 
-In the rightmost column of the Software table (you may need to scroll) you will find an :gear: **Actions** menu which will display a **Details** option.
+In the leftmost column of the Software table you will find an :gear: **Actions** menu which will display a **Details** option.
 Clicking this option will take you to the **Software Details** page.
 
 ![Finding the Details menu entry for a specific Software entry](/assets/images/software/ccm-software-details-menu.png)
@@ -31,6 +55,30 @@ Clicking this option will take you to the **Software Details** page.
 On the _Software Details_ page, you'll find a searchable list of all computers that currently have the package installed, as well as a more verbose view of the package information.
 
 ![Software Details page](/assets/images/software/ccm-software-details-page.png)
+
+### Upgrade Individual Software
+
+From the Software Details page of an outdated Software in Chocolatey Central Management, click the **Create New Deployment Plan** button and select the **Upgrade Software** option.
+
+![Button to upgrade individual Software on a Computer from the Software Details page](/assets/images/software/ccm-software-details-upgrade-software.png)
+
+Clicking this option will create a New Deployment Plan. This Deployment Plan will create one Deployment Step with a [Temporary Group](xref:ccm-groups#temporary-groups) that contains all the Computers the Software is currently installed on.
+
+![Automatically created Deployment Plan showing Temporary Group](/assets/images/software/ccm-software-temporary-group.png)
+
+From here, the Deployment Plan can be edited and deployed as outlined in the [Deployment Plan documentation](xref:ccm-deployments).
+
+### Uninstall Individual Software
+
+From the Software Details in Chocolatey Central Management, click the **Create New Deployment Plan** button and select the **Uninstall Software** option.
+
+![Button to uninstall individual outdated Software on a Computer from the Software Details page](/assets/images/software/ccm-software-details-uninstall-software.png)
+
+Clicking this option will create a New Deployment Plan. This Deployment Plan will create one Deployment Step with a [Temporary Group](xref:ccm-groups#temporary-groups) that contains all the Computers the Software is currently installed on.
+
+![Automatically created Deployment Plan showing Temporary Group](/assets/images/software/ccm-software-temporary-group.png)
+
+From here, the Deployment Plan can be edited and deployed as outlined in the [Deployment Plan documentation](xref:ccm-deployments).
 
 ## Related Topics
 


### PR DESCRIPTION
## Description Of Changes
This makes changes to the Software documentation to outline how to
create a Deployment Plan for a piece of Software automatically. There
are two options available on these pages which are to either upgrade or
uninstall the Software.

## Motivation and Context
This is documentation to reflect Chocolatey Central Management 0.12.0

## Testing

* [x] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made

* [ ] Minor documentation fix (typos etc.).
* [x] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist

* [ ] Requires a change to menu structure (top or left hand side)/
* [ ] Menu structure has been updated

## Related Issue
* #862
