### PR TITLE
(#862) Draft Deployment Plan from Computer

### DIFF
--- a/input/en-us/central-management/usage/website/computers.md
+++ b/input/en-us/central-management/usage/website/computers.md
@@ -43,6 +43,28 @@ You will be presented with a list of the installed software packages for the mac
 
 ![Computer details screen showing installed software](/assets/images/computers/ccm-computers-details.png)
 
+## Creating a Draft Deployment Plan for a Computer
+
+Creating a Draft Deployment Plan for a Computer can be done from two pages:
+
+1. In the leftmost column of the Computer table you will find an :gear: **Actions** menu which will display a **Create New Deployment Plan** option.
+
+    ![Finding the Create New Deployment Plan menu entry for a specific Computer on the Computers page](/assets/images/computers/ccm-computers-create-new-deployment-plan-menu.png)
+
+1. From the Computer Details page, click the :gear: **Actions** button and select the **Create New Deployment Plan** option.
+
+    ![Button to create a new draft Deployment Plan from the Computer Details page](/assets/images/computers/ccm-computer-details-draft-deployment-plan-button.png)
+
+Clicking this option will create a New Deployment Plan. This Deployment Plan will create one Deployment Step with a [Temporary Group](#xref:ccm-groups#temporary-groups) that contains the Computer selected. Upon arriving on the Edit Deployment Plan screen, this Deployment Step will be opened and ready to add a script command. 
+
+![Automatically created Deployment Plan showing the Deployment Step modal script command area](/assets/images/computers/ccm-computers-add-script-command.png)
+
+The Deployment Plan can be saved without adding a script command, however it will be ineligible for deployment. A red warning icon will be shown on the Deployment Step, that when clicking will show a message.
+
+![Red popover warning on Deployment Step with ineligible deployment message](/assets/images/computers/ccm-computers-ineligible-deployment-warning.png)
+
+After adding a script command to the Deployment Step, the Deployment Plan can be deployed as outlined in the [Deployment Plans documentation](xref:ccm-deployments).
+
 ### Exporting a `packages.config` file for a computer
 
 > :choco-info: **NOTE**


### PR DESCRIPTION
## Description Of Changes
This adds documentation on how to create a new draft Deployment Plan for a Computer. A new section has been added to the Computers page.

## Motivation and Context
This reflects changes made in Chocolatey Central Management 0.12.0.

## Testing

* [x] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made
* [ ] Minor documentation fix (typos etc.).
* [x] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist

* [ ] Requires a change to menu structure (top or left hand side)/
* [ ] Menu structure has been updated

## Related Issue
#862