### PR TITLE
(maint) Remove duplicate 2.2.1 release notes

### DIFF
--- a/input/en-us/choco/release-notes.md
+++ b/input/en-us/choco/release-notes.md
@@ -83,26 +83,6 @@ This covers changes for the "chocolatey" and "chocolatey.lib" packages, which ar
 - Improve error message that is shown when defaultPushSource configuration value hasn't been set and no explicit source has been provided - see [#3280](https://github.com/chocolatey/choco/pull/3280).
 
 
-## 2.2.1 (August 3, 2023)
-
-> :choco-warning: **WARNING**
->
->  Chocolatey CLI 2.2.1 was removed from public availability due to a bug identified just prior to the release.
-
-> :choco-warning: **WARNING**
->
-> Refer to our [Upgrade Guide](xref:upgrading-to-chocolatey-v2-v6) for recommendations before upgrading from 1.x versions to 2.x.
-
-### Bug Fixes
-
-- Fix - Can't find `choco.exe` after upgrading Chocolatey CLI using the MSI - see [#3286](https://github.com/chocolatey/choco/issues/3286).
-- Fix - Unable to do non-elevated operations when `cachelocation` is set to a restricted directory - see [#3291](https://github.com/chocolatey/choco/issues/3291).
-
-### Dependency Change
-
-- Update bundled 7zip executables to v23.01 - see [#3285](https://github.com/chocolatey/choco/issues/3285).
-
-
 ## 2.1.0 (June 29, 2023)
 
 > :choco-warning: **WARNING**


### PR DESCRIPTION

## Description Of Changes

The original release notes for 2.2.1 were added in commit 74406cce6ada4155019e9ec70db909e76044a963. They were inadvertently put in the wrong order. When they were moved in commit
423ed34b55524f8c23c5bccab9c8427828abc516, it looks like they weren't removed from the original spot. This commit removes them from the former location leaving them in the correct location.

## Motivation and Context

Remove the duplicated release notes.

## Testing

* [x] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made

* [x] Minor documentation fix (typos etc.).
* [ ] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist

* [ ] Requires a change to menu structure (top or left hand side)/
* [ ] Menu structure has been updated

## Related Issue

N/A
