### PR TITLE
(#862) Add documentation for duplicating deployment steps

### DIFF
--- a/input/en-us/central-management/usage/website/deployments.md
+++ b/input/en-us/central-management/usage/website/deployments.md
@@ -99,6 +99,11 @@ You will also need to have at least one Group of computers already defined.
     ![Chocolatey Central Management Deployment Step Save button](/assets/images/deployments/ccm-deployments-step-save.png)
 
 1. Continue to add steps until your Deployment Plan is complete.
+
+1. (Optional, requires Chocolatey Central Management v0.12.0) If you need to create multiple similar Deployment Steps, you can use the Duplicate Deployment Step button on an individual Deployment Step to make a copy of it.
+
+    ![Chocolatey Central Management Deployment Step Duplicate button](/assets/images/deployments/ccm-deployments-step-duplicate.png)
+
 1. Select :floppy_disk: **Save** to save the changes to the Deployment Plan.
 
 <?! Include "../../../../shared/import-deployment-plan.txt" /?>


### PR DESCRIPTION
## Description Of Changes

- Add mention of duplicating deployment steps to the deployments documentation.

Note: this still needs relevant images added before it will build

## Motivation and Context

New features, new docs.

## Testing

* [ ] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [ ] Minor documentation fix (typos etc.).
* [x] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist

* [ ] Requires a change to menu structure (top or left hand side)/
* [ ] Menu structure has been updated

## Related Issue

- #862
