### PR TITLE
(#862) Add information about maintenance page

### DIFF
--- a/input/en-us/central-management/usage/website/administration/maintenance.md
+++ b/input/en-us/central-management/usage/website/administration/maintenance.md
@@ -5,6 +5,20 @@ Title: Maintenance
 Description: Information about using the maintenance functions within the Chocolatey Central Management Administration section.
 ---
 
-> :choco-warning: **WARNING**
->
-> This is a Work in Progress. Please check back later.
+## Caches
+
+To improve overall performance of the Chocolatey Central Management Website, a number of different caches are used.
+
+If/when required, these caches can be cleared, either individually, or all at once.
+
+![Caches tab within the Maintenance section of the Administration | Settings page](/assets/images/ccm/administration/maintenance/caches.png)
+
+## Website Logs
+
+It is possible to review, and download, the logs for the Chocolatey Central Management Website.
+
+Clicking the `Download all` button will download all the available Website logs in a `WebSiteLogs.zip` file.
+
+Clicking the `Refresh` button will load any additional logs that have been created since the page was first opened.
+
+![Websites Logs tab within the Maintenance section of the Administration | Settings page](/assets/images/ccm/administration/maintenance/website-logs.png)


### PR DESCRIPTION
## Description Of Changes

This replaces the Work in Progress page that was left here. 

## Motivation and Context

Having a work in progress section isn't very helpful

## Testing

* [x] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made

* [x] Minor documentation fix (typos etc.).
* [ ] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist

* [ ] Requires a change to menu structure (top or left hand side)/
* [ ] Menu structure has been updated

## Related Issue

Relates to #862 