### PR TITLE
(#881) Consolidate CCM windows server requirements

### DIFF
--- a/input/en-us/central-management/setup/database.md
+++ b/input/en-us/central-management/setup/database.md
@@ -19,6 +19,7 @@ At the end of this, we should have a fully ready to go SQL Server:
 
 ## Step 1: Complete Prerequisites
 
+* [High-level Requirements](xref:ccm-setup#high-level-requirements)
 * SQL Server 2019 or later.
 
 > :choco-info: **NOTE**

--- a/input/en-us/central-management/setup/service.md
+++ b/input/en-us/central-management/setup/service.md
@@ -22,7 +22,7 @@ This is the service that the agents (`chocolatey-agent`) communicates with. You 
 >
 > The [database](xref:ccm-database) must be setup and available, along with [logins and access](xref:ccm-database#step-2-set-up-sql-server-logins-and-access).
 
-* Windows Server 2019
+* [High-level Requirements](xref:ccm-setup#high-level-requirements)
 * PowerShell 5.1
 
 ## Step 2: Install Chocolatey Central Management Service Package

--- a/input/en-us/central-management/setup/website.md
+++ b/input/en-us/central-management/setup/website.md
@@ -18,7 +18,7 @@ This is the Chocolatey Central Management website that gives an API and a web la
 >
 > The [database](xref:ccm-database) must be setup and available, along with [logins and access](xref:ccm-database#step-2-set-up-sql-server-logins-and-access).
 
-* Windows Server 2016
+* [High-level Requirements](xref:ccm-setup#high-level-requirements)
 * PowerShell 5.1
 * IIS Set up and available
 * dotnet-aspnetcoremodule-v2 version 16.0.23055


### PR DESCRIPTION
## Description Of Changes

- Point the CCM website/service/database requirements back to the high-level requirements on the main CCM setup page

## Motivation and Context

Previously there was some conflicting information as to what versions of Windows Server are required for CCM to run.
This removes the conflicting information and points back to the high-level requirements section so that all the common information can be in one place.

## Testing

* [x] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [ ] Minor documentation fix (typos etc.).
* [x] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist

* [ ] Requires a change to menu structure (top or left hand side)/
* [ ] Menu structure has been updated

## Related Issue

Fixes #881 
