### PR TITLE
(doc) Fill out stubbed rule CPMR0019

### DIFF
--- a/input/en-us/community-repository/moderation/package-validator/rules/cpmr0019.md
+++ b/input/en-us/community-repository/moderation/package-validator/rules/cpmr0019.md
@@ -1,23 +1,21 @@
 ---
 Order: 19
 xref: cpmr0019
-Title: CPMR0019 - Nupsec Contains Templated Values (nuspec)
+Title: CPMR0019 - Nuspec Contains Templated Values (nuspec)
 Description: Information on how to remediate the Chocolatey Package Moderation Rule 0019
 RuleType: Requirement
 ---
 
 <?! Include "../../../../../shared/package-validator-rule-requirement.txt" /?>
 
-> :choco-info: **NOTE**
->
-> This page is a stub that has not yet been filled out. If you have questions about this issue, please ask in the review or reach out on [Community Chat](https://ch0.co/community)
-
 ## Issue
 
-In the nuspec,
+In the nuspec, templates values that were added by Chocolatey CLI have been left in the file. These values are not considered to be valid information, and only a placeholder for what users can make use of.
 
 ## Recommended Solution
 
-Please update _ so that _
+Any templated values given by Chocolatey CLI should be replaced with an appropriate value for the Software the Package is responsible for, or removed if no proper information is available.
 
 ## Reasoning
+
+As these are informations given to users, having such invalid placeholders in the nuspec file only serves to confuse users and cause packages to be considered of bad quality.


### PR DESCRIPTION
## Description Of Changes

This updates the Package Validator Rule to have some information about
the rule that was flagged.

## Motivation and Context

I noticed a typo on the page, and figured to fill out some information at the same time.

## Testing

* [x] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [ ] Minor documentation fix (typos etc.).
* [x] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.

## Change Checklist

* [ ] Requires a change to menu structure (top or left-hand side)/
* [ ] Menu structure has been updated

## Related Issue

N/A