### PR TITLE
(#935) Fix Template Package Creation Doc

### DIFF
--- a/input/en-us/guides/create/create-template.md
+++ b/input/en-us/guides/create/create-template.md
@@ -1,3 +1,4 @@
+---
 Order: 41
 xref: howto-create-package-template
 Title: How to create a Package Template
@@ -77,7 +78,8 @@ Let's see this usage of a template in practice. In an **elevated** PowerShell wi
 ```powershell
 # Substitute the country USA with your own Country below
 Set-Location '~\tutorials'
-choco new template-tutorial --version='1.0.0' --template='TutorialTemplate' Country:USA --build-package
+choco new template-tutorial --version='1.0.0' --template='TutorialTemplate' Country=USA
+choco pack .\template-tutorial\template-tutorial.nuspec
 ```
 
 #### Install Your Templated Package


### PR DESCRIPTION
## Description Of Changes
- Minor markdown lint change
- Replace `: ` with `=` to get template value to pass correctly in choco new command
- Remove --build-package part of choco new command
- Add choco pack after choco new

## Motivation and Context
Fix document to get templated values passed correctly and get package to generate sucessfully.

## Testing

* [X] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made
* [X] Minor documentation fix (typos etc.).
* [ ] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist
* [ ] Requires a change to menu structure (top or left-hand side)/
* [ ] Menu structure has been updated

## Related Issue

Fixes #935 
