### PR TITLE
Add notes for CLE and Agent Releases

### DIFF
--- a/input/en-us/agent/release-notes.md
+++ b/input/en-us/agent/release-notes.md
@@ -30,6 +30,20 @@ This covers the release notes for the Chocolatey Agent Service (`chocolatey-agen
 <?! Include "../../shared/chocolatey-component-dependencies.txt" /?>
 
 
+## 2.1.2 (January 31, 2024)
+
+### Bug Fix
+
+- [Security] Fix - Prevent usage of options when running in Self-Service mode.
+
+
+## 1.1.4 (January 31, 2024)
+
+### Bug Fix
+
+- [Security] Fix - Prevent usage of options when running in Self-Service mode.
+
+
 ## 2.1.1 (December 19, 2023)
 
 ### Bug Fix

--- a/input/en-us/licensed-extension/release-notes.md
+++ b/input/en-us/licensed-extension/release-notes.md
@@ -42,6 +42,20 @@ Please see [Install the Licensed Edition](xref:setup-licensed) for information o
 <?! Include "../../shared/chocolatey-component-dependencies-link.txt" /?>
 
 
+## 6.1.2 (January 31, 2024)
+
+### Bug Fixes
+
+- [Security] Fix - Prevent usage of options when running in Self-Service mode.
+
+
+## 5.0.5 (January 31, 2024)
+
+### Bug Fixes
+
+- [Security] Fix - Prevent usage of options when running in Self-Service mode.
+
+
 ## 6.1.1 (December 19, 2023)
 
 ### Bug Fixes


### PR DESCRIPTION
## Description Of Changes

This commit adds the release notes for CLE 6.1.2. and 5.0.5 and Agent 2.1.2 and 1.1.4.

## Motivation and Context

We are shipping a bug fix release of both CLE and Agent, which is also being back ported to the previous supported version.

## Testing

* [x] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made

* [x] Minor documentation fix (typos etc.).
* [ ] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist

* [ ] Requires a change to menu structure (top or left-hand side)/
* [ ] Menu structure has been updated

## Related Issue

N/A