### PR TITLE
Update deprecate-a-chocolatey-package.md

### DIFF
--- a/input/en-us/community-repository/maintainers/deprecate-a-chocolatey-package.md
+++ b/input/en-us/community-repository/maintainers/deprecate-a-chocolatey-package.md
@@ -30,7 +30,7 @@ When deprecating a Chocolatey Package, the following steps should be followed:
   * **Replace** `<files>...</files>` section in `.nuspec` with `<files />` tag to prevent any file from being included with the package.
   * **Remove all files** except the `.nuspec` from the Chocolatey Package.
 ### The package is no longer available and is not being superseded
-  * **Remove** `<dependencies>...</dependencies>` if any.
+  * **Remove** `<dependencies>...</dependencies>` if any, except if there is only a dependency linking to the install ([packagename].install) or the portable ([packagename].portable) version of this same package.
   * **Remove** the content of `tools\chocolateyInstall.ps1`  if any.
   * **Remove all files** except the `.nuspec` and `tools\chocolateyInstall.ps1` from the Chocolatey Package.
 

--- a/input/en-us/community-repository/maintainers/deprecate-a-chocolatey-package.md
+++ b/input/en-us/community-repository/maintainers/deprecate-a-chocolatey-package.md
@@ -25,10 +25,20 @@ When deprecating a Chocolatey Package, the following steps should be followed:
 * Create a **[new version](xref:create-packages#package-fix-version-notation)** of the deprecated Chocolatey Package.
 * Prepend **[Deprecated]** to the **title** of the package (e.g. `<title>[Deprecated] Software Title</title>`
 * Update the package **description**: Why is the package being deprecated?
-* Add a **[dependency](http://docs.nuget.org/docs/reference/nuspec-reference#Specifying_Dependencies) on the other package** (if the package is being superseded).
-* **Remove all files** except the `.nuspec` from the Chocolatey Package.
-* Replace `<files>...</files>` section in `.nuspec` with `<files />` tag to prevent any file from being included with the package.
-* **Remove the iconUrl**.
-* **[Unlist all versions](xref:list-unlist-a-package)** from the package gallery, **except** the final deprecated version. The final deprecated version is required so that there is an update path to the new package.
+### The package is being superseded
+  * Add a **[dependency](http://docs.nuget.org/docs/reference/nuspec-reference#Specifying_Dependencies) on the other package**.
+  * **Replace** `<files>...</files>` section in `.nuspec` with `<files />` tag to prevent any file from being included with the package.
+  * **Remove all files** except the `.nuspec` from the Chocolatey Package.
+### The package is no longer available and is not being superseded
+  * **Remove** `<dependency>...</dependency>`.
+  * **Remove** the content of `tools\chocolateyInstall.ps1`.
+  * **Remove all files** except the `.nuspec` and `tools\chocolateyInstall.ps1` the from the Chocolatey Package.
 
-By following this process, any existing users who try to update the old package will automatically get the new package, as it will be installed as a dependency.
+In both cases:
+* If they are no longer available, **remove** `<projectSourceUrl>...</projectSourceUrl>`, `<docsUrl>...</docsUrl>`, `<mailingListUrl>...</mailingListUrl>`, `<bugTrackerUrl>...</bugTrackerUrl>`, `<releaseNotes>...</releaseNotes>`
+* **Remove the iconUrl**.
+* **[Unlist all versions](xref:list-unlist-a-package)** from the package gallery, **except** the final deprecated version. The final deprecated version is required to, depending on the case, provide an update path to the new package or provide an empty package.
+
+By following this process, any existing users who try to update the old package will automatically get either:
+* **The new package**, as it will be installed as a dependency if the package is being superseded.
+* **A new version package doing nothing** if the package does no longer exist.

--- a/input/en-us/community-repository/maintainers/deprecate-a-chocolatey-package.md
+++ b/input/en-us/community-repository/maintainers/deprecate-a-chocolatey-package.md
@@ -30,7 +30,7 @@ When deprecating a Chocolatey Package, the following steps should be followed:
   * **Replace** `<files>...</files>` section in `.nuspec` with `<files />` tag to prevent any file from being included with the package.
   * **Remove all files** except the `.nuspec` from the Chocolatey Package.
 ### The package is no longer available and is not being superseded
-  * **Remove** `<dependencies>...</dependencies>` if any, except if there is only a dependency linking to the install ([packagename].install) or the portable ([packagename].portable) version of this same package.
+  * **Remove** `<dependencies>...</dependencies>` if any, except if there is only a dependency linking to the install ([packagename].install) or the portable ([packagename].portable) version of this same package. In this case, remember to update the package version of the targeted package.
   * **Remove** the content of `tools\chocolateyInstall.ps1`  if any.
   * **Remove all files** except the `.nuspec` and `tools\chocolateyInstall.ps1` from the Chocolatey Package.
 

--- a/input/en-us/community-repository/maintainers/deprecate-a-chocolatey-package.md
+++ b/input/en-us/community-repository/maintainers/deprecate-a-chocolatey-package.md
@@ -30,9 +30,9 @@ When deprecating a Chocolatey Package, the following steps should be followed:
   * **Replace** `<files>...</files>` section in `.nuspec` with `<files />` tag to prevent any file from being included with the package.
   * **Remove all files** except the `.nuspec` from the Chocolatey Package.
 ### The package is no longer available and is not being superseded
-  * **Remove** `<dependency>...</dependency>`.
-  * **Remove** the content of `tools\chocolateyInstall.ps1`.
-  * **Remove all files** except the `.nuspec` and `tools\chocolateyInstall.ps1` the from the Chocolatey Package.
+  * **Remove** `<dependencies>...</dependencies>` if any.
+  * **Remove** the content of `tools\chocolateyInstall.ps1`  if any.
+  * **Remove all files** except the `.nuspec` and `tools\chocolateyInstall.ps1` from the Chocolatey Package.
 
 In both cases:
 * If they are no longer available, **remove** `<projectSourceUrl>...</projectSourceUrl>`, `<docsUrl>...</docsUrl>`, `<mailingListUrl>...</mailingListUrl>`, `<bugTrackerUrl>...</bugTrackerUrl>`, `<releaseNotes>...</releaseNotes>`


### PR DESCRIPTION
## Description Of Changes
Added instructions where a deprecated package is not being superseded and so, it's not possible to provide a dependency to a new package. 

## Motivation and Context
This procedure does not work as-is when a package is not being superseded.

## Testing
Tested on the deprecation of https://community.chocolatey.org/tjs, https://community.chocolatey.org/tjs.install, https://community.chocolatey.org/tjs.portable packages.

## Change Types Made
* [ ] Minor documentation fix (typos etc.).
* [x] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist
* [ ] Requires a change to menu structure (top or left-hand side)/
* [ ] Menu structure has been updated

## Related Issue
(https://github.com/chocolatey/docs/issues/948)