### PR TITLE
Fixing command formatting under the section "Install using NuGet Package Manager"

### DIFF
--- a/input/en-us/choco/setup.md
+++ b/input/en-us/choco/setup.md
@@ -651,9 +651,9 @@ Run `installChocolatey.cmd` from an elevated `cmd.exe` command prompt and it wil
 
 When you have Visual Studio 2010+ and the NuGet extension installed (pre-installed on any newer versions of Visual Studio), you can simply type the following three commands and you will have Chocolatey installed on your machine.
 
- `Install-Package chocolatey`
- `Initialize-Chocolatey`
- `Uninstall-Package chocolatey`
+ * `Install-Package chocolatey`
+ * `Initialize-Chocolatey`
+ * `Uninstall-Package chocolatey`
 
 ### Install using NuGet.exe from PowerShell
 


### PR DESCRIPTION
## Description Of Changes
Adjusted the formatting of the alternate installation method in the section **Install using NuGet Package Manager** so the three commands do not all appear (visually) to be one command.

## Motivation and Context
When viewing the docs, I read the command in the screenshot below as a single command when it is clearly three. Since reading is hard, I figured making this a list would be more helpful and accessible. 

_We could also change it to be an ordered list (lets see if there is discussion on that)_

## Testing

* [x] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made
* [x] Minor documentation fix (typos etc.).
* [ ] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist

* [ ] Requires a change to menu structure (top or left-hand side)/
* [ ] Menu structure has been updated

## Related Issue
None

## Fixes 
None