### PR TITLE
(doc) Add link to side-by-side package naming docs

### DIFF
--- a/input/en-us/guides/upgrading-to-chocolatey-v2-v6.md
+++ b/input/en-us/guides/upgrading-to-chocolatey-v2-v6.md
@@ -136,7 +136,7 @@ In the example above, `gitreleasemanager.portable` has two versions installed: 0
 
 Once this is complete, you can install the package again, without side-by-side, by running `choco install gitreleasemanager.portable`.
 
-If you need side-by-side functionality, or cannot uninstall packages installed side-by-side, **we do not recommend** you upgrade to Chocolatey CLI version 2.0.0 at this time. Please see our [Support Lifecycle](xref:chocolatey-components-dependencies-and-support-lifecycle) for Chocolatey products.
+If you need side-by-side functionality, or cannot uninstall packages installed side-by-side, **we do not recommend** you upgrade to Chocolatey CLI version 2.0.0 at this time. If you are able to put in some extra work, we [have documented an option that may work for you](xref:create-packages#naming-packages-to-allow-for-side-by-side-installation). Please see our [Support Lifecycle](xref:chocolatey-components-dependencies-and-support-lifecycle) for Chocolatey products.
 
 ### The List Command Now Lists Local Packages Only and the `--local-only` and `-lo` Options Have Been Removed
 


### PR DESCRIPTION
## Description Of Changes
Added link to side-by-side package naming documentation as an option for people upgrading to 2.x

## Motivation and Context
Was responding to a support issue this morning and realised we say that side-by-side installs have been removed, but don't link to the docs that talk about naming packages differently to get, potentially, the same issue.

## Testing

* [x] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made

* [x] Minor documentation fix (typos etc.).
* [ ] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist

* [ ] Requires a change to menu structure (top or left-hand side)/
* [ ] Menu structure has been updated

## Related Issue
N/A