### PR TITLE
(doc) Add documention of new hook rule

### DIFF
--- a/input/en-us/community-repository/moderation/package-validator/rules/cpmr0074.md
+++ b/input/en-us/community-repository/moderation/package-validator/rules/cpmr0074.md
@@ -1,0 +1,19 @@
+---
+Order: 0074
+xref: cpmr0074
+Title: CPMR0074 - Dependency On Hook Package (nuspec)
+---
+
+<?! Include "../../../../../shared/package-validator-rule-requirement.txt" /?>
+
+## Issue
+
+Within the nuspec, a dependency on a package with the `.hook` suffix was found. Packages, other than `.hook` packages, should not have such a dependency.
+
+## Recommended Solution
+
+Remove any dependency that specifies a package with a `.hook` suffix.
+
+## Reasoning
+
+Since a `.hook` package will introduce scripts that will be installed on the user's computer and run before or after any install, upgrade or uninstall that the user attempts, such packages should never be automatically installed. A user should explicitly opt into using such packages, and other packages should not go against this practice.


### PR DESCRIPTION
## Description Of Changes

This adds a new page for the upcoming rule about not allowing non-hook
packages taking a dependency on a hook package.

## Motivation and Context

We need to document all rules that we have in package validator.

## Testing

* [x] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made

* [ ] Minor documentation fix (typos etc.).
* [ ] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [x] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.

## Change Checklist

* [ ] Requires a change to menu structure (top or left-hand side)/
* [ ] Menu structure has been updated

## Related Issue

- https://app.clickup.com/t/8687xvy17
- https://app.clickup.com/t/8687xvxxy