### PR TITLE
(doc) Update Invalid URL rule severity

### DIFF
--- a/input/en-us/community-repository/moderation/package-validator/rules/cpmr0031.md
+++ b/input/en-us/community-repository/moderation/package-validator/rules/cpmr0031.md
@@ -3,26 +3,26 @@ Order: 31
 xref: cpmr0031
 Title: CPMR0031 - Invalid URL (nuspec)
 Description: Information on how to remediate the Chocolatey Package Moderation Rule 0031
-RuleType: Requirement
+RuleType: Note
 ---
 
-<?! Include "../../../../../shared/package-validator-rule-requirement.txt" /?>
+<?! Include "../../../../../shared/package-validator-rule-note.txt" /?>
 
 ## Issue
 
 In the nuspec, one of the URLs provided is invalid. Usually this means that the URL does not actually go to a website.
 
-The following URL's, if invalid, will be marked as a Requirement (needs to be fixed).
+The following URL's, if invalid, will be marked as a Note.
 
-* bugTrackerUrl - Requirement
-* docsUrl - Requirement
-* iconUrl - Requirement
-* licenseUrl - Requirement
-* mailingListUrl - Requirement
-* packageSourceUrl - Requirement
-* projectSourceUrl - Requirement
-* projectUrl - Requirement
-* wikiUrl - Requirement
+* bugTrackerUrl - Note
+* docsUrl - Note
+* iconUrl - Note
+* licenseUrl - Note
+* mailingListUrl - Note
+* packageSourceUrl - Note
+* projectSourceUrl - Note
+* projectUrl - Note
+* wikiUrl - Note
 
 > :choco-info: **NOTE**
 >


### PR DESCRIPTION
## Description Of Changes

This commit updates the severity of the URL that is currently marked as
a requirement when validating URLs. This is done to reflect upcoming
changes to package validator that makes similar changes.

## Motivation and Context

To reflect changes coming to package validator.

## Testing

* [x] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [x] Minor documentation fix (typos etc.).
* [ ] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist

* [ ] Requires a change to menu structure (top or left-hand side)/
* [ ] Menu structure has been updated

## Related Issue

N/A