### PR TITLE
(#489) Document rule CPMR0062

### DIFF
--- a/input/en-us/community-repository/moderation/package-validator/rules/cpmr0062.md
+++ b/input/en-us/community-repository/moderation/package-validator/rules/cpmr0062.md
@@ -8,16 +8,14 @@ RuleType: Note
 
 <?! Include "../../../../../shared/package-validator-rule-note.txt" /?>
 
-> :choco-info: **NOTE**
->
-> This page is a stub that has not yet been filled out. If you have questions about this issue, please ask in the review or reach out on [Community Chat](https://ch0.co/community)
-
 ## Issue
 
-In the nuspec,
+In the nuspec, one or more dependencies were found, and one of them depends on the Chocolatey CLI package (`chocolatey`).
 
 ## Recommended Solution
 
-Please update _ so that _
+Please ensure that you are using and requiring the functionality of the Chocolatey CLI dependency version in one of your automation scripts. If no automation script requires functionality only available in the defined version, please remove this dependency.
 
 ## Reasoning
+
+Specifying a dependency on Chocolatey CLI is considered an antipattern and can have repercussions when a package is uninstalled while the user decides to also remove their dependencies at the same time. As such, a dependency on Chocolatey CLI should be used sparingly and only when needed.


### PR DESCRIPTION
## Description Of Changes

This documents the rule about adding a dependency on Chocolatey CLI with
the known reasons why such a dependency should not be used.


## Motivation and Context

To document our rules.

## Testing

* [x] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [ ] Minor documentation fix (typos etc.).
* [x] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist

* [ ] Requires a change to menu structure (top or left-hand side)/
* [ ] Menu structure has been updated

## Related Issue

#489