### PR TITLE
(doc) Add restricted Background Service option

### DIFF
--- a/input/en-us/features/self-service-anywhere.md
+++ b/input/en-us/features/self-service-anywhere.md
@@ -75,6 +75,8 @@ Chocolatey CLI allows a number of different options that can be used to configur
   * `--uninstall-arguments-sensitive`
   * `--use-system-powershell`
   * `--virus-positives-minimum`
+* Added in Chocolatey Agent 2.1.3 and Chocolatey Licensed Extension 6.2.0:
+  * `--ignore-pinned`
 
 ### See It In Action
 


### PR DESCRIPTION
## Description Of Changes

Add `--ignore-pinned` to list of banned options for Background Service

## Motivation and Context

Following the release of Chocolatey CLI 2.3.0, an additional option has been added to the `choco upgrade` command. After discussion, it has been decided that this new option should not be allowed to be used via the Background Service.

## Testing

* [x] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [x] Minor documentation fix (typos etc.).
* [ ] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist

* [ ] Requires a change to menu structure (top or left-hand side)/
* [ ] Menu structure has been updated

## Related Issue

N/A