### PR TITLE
Update cpmr0024.md explaining the prerelease tag should be in the version

### DIFF
--- a/input/en-us/community-repository/moderation/package-validator/rules/cpmr0024.md
+++ b/input/en-us/community-repository/moderation/package-validator/rules/cpmr0024.md
@@ -14,10 +14,10 @@ RuleType: Requirement
 
 ## Issue
 
-In the nuspec,
+The `<id>` field in the package `.nuspec` file, contains a prerelease version name such as `alpha`, `beta`, etc.
 
 ## Recommended Solution
 
-Please update _ so that _
+Please update the `<id>` field in the `.nuspec` file to ensure it only contains the name. The prerelease version name should be added to the `<version>` field. Prerelease packages can be [installed](https://docs.chocolatey.org/en-us/choco/commands/install#options-and-switches) or [upgraded](https://docs.chocolatey.org/en-us/choco/commands/upgrade#options-and-switches) using the `--pre` option in Chocolatey CLI.
 
 ## Reasoning


### PR DESCRIPTION
Explain the solution to cpmr0024

## Description Of Changes
Explain that the prerelease tag should be in the version

## Motivation and Context
cpmr0024 page was a template, not a complete explanation

## Change Types Made
* [ ] Minor documentation fix (typos etc.).
* [ ] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [X] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist

* [ ] Requires a change to menu structure (top or left-hand side)/
* [ ] Menu structure has been updated

## Related Issue
<!-- Make sure you have raised an issue for this pull request before continuing. -->
[Related Issue](https://github.com/chocolatey/docs/issues/990)
