### PR TITLE
(#994) Add note about chocolatey-community user to package triage process

### DIFF
--- a/input/en-us/community-repository/users/package-triage-process.md
+++ b/input/en-us/community-repository/users/package-triage-process.md
@@ -41,6 +41,10 @@ Package maintainers are unlikely to provide fixes to versions of packages that a
 > * dtgm
 > * adgellida
 
+> :choco-info: **WARNING**
+>
+> If the maintainer of the package is `chocolatey-community`, do not follow these steps. Instead, open an issue or discussion at the [chocolatey-community/chocolatey-packages](https://github.com/chocolatey-community/chocolatey-packages/issues) package source repository. These packages that are managed and maintained by core community team, and communication for these goes through the Github repository. 
+
 If a package needs to be fixed or updated. Here are the steps to follow:
 
 1. The first steps are:


### PR DESCRIPTION
## Description Of Changes

 Adds note about chocolatey-community user to package triage process.

## Motivation and Context

See #994

## Testing

* [x] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made

* [ ] Minor documentation fix (typos etc.).
* [x] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist

* [ ] Requires a change to menu structure (top or left-hand side)/
* [ ] Menu structure has been updated

## Related Issue

Fixes #994


