### PR TITLE
(doc) Replaces Dependency Table with Links in Agent & GUI Release Notes

### DIFF
--- a/input/en-us/agent/release-notes.md
+++ b/input/en-us/agent/release-notes.md
@@ -27,8 +27,9 @@ This covers the release notes for the Chocolatey Agent Service (`chocolatey-agen
 
 - Please see https://github.com/chocolatey/chocolatey-licensed-issues/labels/AgentService
 
-<?! Include "../../shared/chocolatey-component-dependencies.txt" /?>
+<?! Include "../../shared/maintenance-and-support-link.txt" /?>
 
+<?! Include "../../shared/chocolatey-component-dependencies-link.txt" /?>
 
 ## 2.1.3 (June 5, 2024){#v2.1.3}
 

--- a/input/en-us/chocolatey-gui/business-features/branding.md
+++ b/input/en-us/chocolatey-gui/business-features/branding.md
@@ -5,6 +5,6 @@ Title: Branding
 Description: Information about applying branding to the Chocolatey GUI application
 ---
 
-There is a Chocolatey for Business feature that allows applying branding to the Chocolatey GUI application.  This allows customers to make Chocolatey GUI "look" more like there internal application.
+There is a Chocolatey for Business feature that allows applying branding to the Chocolatey GUI application.  This allows customers to make Chocolatey GUI "look" more like their internal application.
 
 Visit the [branding page](xref:branding) for full details on how this can be achieved.

--- a/input/en-us/chocolatey-gui/release-notes.md
+++ b/input/en-us/chocolatey-gui/release-notes.md
@@ -16,7 +16,9 @@ This covers changes for the "chocolateygui" package, which is available as FOSS.
 >
 > For commercial editions, please also refer to [Licensed Release Notes](xref:licensed-extension-release-notes), as well at the [Chocolatey GUI Licensed Extension Release Notes](xref:chocolatey-gui-licensed-extension-release-notes).
 
-<?! Include "../../shared/chocolatey-component-dependencies.txt" /?>
+<?! Include "../../shared/maintenance-and-support-link.txt" /?>
+
+<?! Include "../../shared/chocolatey-component-dependencies-link.txt" /?>
 
 ## 2.1.1 (April 29, 2024)
 


### PR DESCRIPTION
## Description Of Changes

This commit replaces two instances of the full dependency table at the top of release notes that I believe should have been changed.

## Motivation and Context

Other release notes have had the full table stub replaced with stubs containing links to the doc pages.

## Testing

* [x] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made

* [x] Minor documentation fix (typos etc.).
* ~[ ] Major documentation change (refactoring, reformatting or adding documentation to existing page).~
* ~[ ] New documentation page added.~
* ~[ ] The change I have made should have a video added, and I have raised an issue for this.~


## Change Checklist

* ~[ ] Requires a change to menu structure (top or left-hand side)/~
* ~[ ] Menu structure has been updated~

