### PR TITLE
(#1007) Retain Tab Component CSS

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
   },
   "dependencies": {
     "choco-astro": "0.1.0",
-    "choco-theme": "0.7.1"
+    "choco-theme": "0.7.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3047,9 +3047,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"choco-theme@npm:0.7.1":
-  version: 0.7.1
-  resolution: "choco-theme@npm:0.7.1"
+"choco-theme@npm:0.7.2":
+  version: 0.7.2
+  resolution: "choco-theme@npm:0.7.2"
   dependencies:
     "@fortawesome/fontawesome-free": "npm:^6.1.2"
     "@playwright/test": "npm:^1.44.1"
@@ -3088,7 +3088,7 @@ __metadata:
     stylelint-config-twbs-bootstrap: "npm:^14.0.0"
     ts-node: "npm:^10.9.2"
     typescript: "npm:^5.4.5"
-  checksum: 10c0/c9622fe33492261ebbfe0679b233ba9ed018dde056f438d10c7f3b44eb760e545d0907c794fbd9e79c944b73e85177888528ad1155d638e348718b8843f84133
+  checksum: 10c0/823d704a31f57cab47e467c11e743801d74fa838a24b45cf457b249d8230fed17926db5d2cd0a5392825f33f63cfc149f609ea1a6388a17c43313894d8f221bc
   languageName: node
   linkType: hard
 
@@ -4111,7 +4111,7 @@ __metadata:
   resolution: "docs@workspace:."
   dependencies:
     choco-astro: "npm:0.1.0"
-    choco-theme: "npm:0.7.1"
+    choco-theme: "npm:0.7.2"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Description Of Changes
The purgeCSS flow has been adjusted to ensure that any classes on Astro Components are retained. This ensures that the Astro Components are styled
correctly.

In addition, this is now checking for a value
when trigger automation for tabs with a multi
version. This ensures no invalid JSON errors.

## Motivation and Context
We want this to render correctly.

## Testing

1. Review changes at https://github.com/chocolatey/choco-theme/pull/408
2. Run this PR 
3. Go to http://localhost:5086/en-us/central-management/setup/database/#database-authentication-scenarios
4. Play with the tab container, and notice it's "normal"
5. In your browser, open up the Dev Tools, and notice there are no Red JS errors. 
6. If all appear good, merge the PR at https://github.com/chocolatey/choco-theme/pull/408
7. Notify @st3phhays to release and update choco-theme here and take this PR out of draft.
8. After updating, this can be merged

* [x] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made
* [x] Minor documentation fix (typos etc.).
* [ ] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist

* [ ] Requires a change to menu structure (top or left-hand side)/
* [ ] Menu structure has been updated

## Related Issue
* https://github.com/chocolatey/choco-theme/issues/407
* #1007 

Fixes #1007
