### PR TITLE
(#997) Update Terms Page to Use Astro

### DIFF
--- a/src/content/docs/en-us/information/terms.mdx
+++ b/src/content/docs/en-us/information/terms.mdx
@@ -4,10 +4,10 @@ xref: terms
 title: Terms of Use
 description: Terms of Use for Chocolatey
 ---
-import Callout from '@choco/components/Callout.astro';
-import Iframe from '@choco/components/Iframe.astro';
-import Xref from '@components/Xref.astro';
+import TermsLastUpdated from '@components/global/TermsLastUpdated.astro';
+import TermsToc from '@components/global/TermsToc.astro';
+import TermsContent from '@components/global/TermsContent.astro';
 
-<p>@Html.Partial("global-partials/_TermsLastUpdated")</p>
-@Html.Partial("global-partials/_TermsToc")
-@Html.Partial("global-partials/_TermsContent")
+<p><TermsLastUpdated /></p>
+<TermsToc />
+<TermsContent />


### PR DESCRIPTION
## Description Of Changes
The Terms page has been updated to use the correct Astro Components to render all the content needed. This was missed on the initial switchover to Astro.

## Motivation and Context
This page is not working currently.

## Testing

* [x] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

1. Review the PR at https://github.com/chocolatey/choco-theme/pull/409
1. Pull down this PR.
2. Run the site
3. Go to http://localhost:5086/en-us/information/terms and notice there is now content. The TOC is on the page, and not in the right hand nav bar.

## Change Types Made

* [x] Minor documentation fix (typos etc.).
* [ ] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.


## Change Checklist

* [ ] Requires a change to menu structure (top or left-hand side)/
* [ ] Menu structure has been updated

## Related Issue
Relates to #997
