### PR TITLE
(maint) fix link to Sontype issue from Jira to GitHub issues

### DIFF
--- a/src/content/docs/en-us/chocolatey-gui/known-issues.mdx
+++ b/src/content/docs/en-us/chocolatey-gui/known-issues.mdx
@@ -15,7 +15,7 @@ In some implementations of NuGet v3 feeds, we have observed that the repository 
 As a result, there are cases where Chocolatey GUI may not be able to display all packages that the repository server has in its list.
 
 Currently, we are aware of this affecting Sonatype Nexus NuGet v3 repository feeds, but any repository implementation that reports incorrect metadata may result in similar issues.
-Follow [the NEXUS-37861 Jira ticket](https://issues.sonatype.org/browse/NEXUS-38761) for further information on when this will be resolved by Sonatype.
+Follow [this Nexus GitHub issue](https://github.com/sonatype/nexus-public/issues/418) for further information on when this will be resolved by Sonatype.
 
 ### Technical details
 


### PR DESCRIPTION

## Description Of Changes

Fix link from Sonatype Jira (abandoned) to GitHub Issues.

## Motivation and Context

Sonatype abandoned Jira and we had a dead link

## Testing

* [x] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made

* [x] Minor documentation fix (typos etc.).
* [ ] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist

* [ ] Requires a change to menu structure (top or left-hand side)/
* [ ] Menu structure has been updated

## Related Issue