### PR TITLE
(#1027) Make "Edit This Page" link valid

### DIFF
--- a/src/components/toc/TableOfContents.astro
+++ b/src/components/toc/TableOfContents.astro
@@ -8,7 +8,8 @@ interface Props {
 }
 
 const { content } = Astro.props;
-const editLink = `https://github.com/${packageJson.author}/${packageJson.name}/edit/master/src/content${Astro.url.pathname}.mdx`;
+const filePath = Astro.url.pathname.endsWith('/') ? Astro.url.pathname.slice(0, -1) : Astro.url.pathname;
+const editLink = `https://github.com/${packageJson.author}/${packageJson.name}/edit/master/src/content/docs${filePath}.mdx`;
 ---
 
 {(content && content.length > 0) && (


### PR DESCRIPTION
## Description Of Changes
This makes a few small changes to ensure that the
"Edit This Page" link is valid on each doc page.

## Motivation and Context
The link is currently broken.

## Testing

* [x] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

1. Go to any doc page, and click the "Edit This Page" button in the right side TOC. It should take you to the correct document to edit.

## Change Types Made
* [x] Minor documentation fix (typos etc.).
* [ ] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist

* [ ] Requires a change to menu structure (top or left-hand side)/
* [ ] Menu structure has been updated

## Related Issue
* #1027

Fixes #1027