### PR TITLE
(ENGTASKS-3807) (doc) Add documentation of new rule CPMR0075

### DIFF
--- a/src/content/docs/en-us/community-repository/moderation/package-validator/rules/cpmr0075.mdx
+++ b/src/content/docs/en-us/community-repository/moderation/package-validator/rules/cpmr0075.mdx
@@ -1,0 +1,27 @@
+---
+order: 75
+xref: cpmr0075
+title: CPMR0075 - Script uses GitHub Comment assets (script)
+description: Information on how to remediate the Chocolatey Package Moderation Rule 0075
+ruleType: Requirement
+---
+import Callout from '@choco/components/Callout.astro';
+import Iframe from '@choco/components/Iframe.astro';
+import Xref from '@components/Xref.astro';
+import PackageValidatorRuleRequirement from '@components/docs/PackageValidatorRuleRequirement.mdx';
+
+<PackageValidatorRuleRequirement />
+
+## Issue
+
+Within one or more of the automation scripts, one or more URLs were found to point to a GitHub comment file or asset.
+
+## Recommended Solution
+
+Use the official download location of files from the software authors that are not part of a GitHub comment.
+This can be URLs on their official web page, from their GitHub releases, or from a third party that is officially endorsed by the software developers.
+
+## Reasoning
+
+Since any user can upload files to a GitHub comment, even without publishing the comment, this can be used as an attack vector by malicious actors.
+To prevent such misuse from happening and affecting our users, it has been decided to disallow these types of URLs.


### PR DESCRIPTION
## Description Of Changes

We are planning to implement a new requirement rule for blacklisting URLs that come from GitHub comments. As this is a new rule without any associated documentation, we need to create the documentation that is related to this rule.

## Motivation and Context

New rules should be fully documented.

## Testing

* [x] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made

~* [ ] Minor documentation fix (typos etc.).~
~* [ ] Major documentation change (refactoring, reformatting or adding documentation to existing page).~
* [x] New documentation page added.
~* [ ] The change I have made should have a video added, and I have raised an issue for this.~

## Change Checklist

~* [ ] Requires a change to menu structure (top or left-hand side)/~
~* [ ] Menu structure has been updated~

## Related Issue

N/A