### PR TITLE
(doc) Document rule CPMR0070 with proper information

### DIFF
--- a/src/content/docs/en-us/community-repository/moderation/package-validator/rules/cpmr0070.mdx
+++ b/src/content/docs/en-us/community-repository/moderation/package-validator/rules/cpmr0070.mdx
@@ -12,16 +12,15 @@ import PackageValidatorRuleNote from '@components/docs/PackageValidatorRuleNote.
 
 <PackageValidatorRuleNote />
 
-<Callout type="info">
-    This page is a stub that has not yet been filled out. If you have questions about this issue, please ask in the review or reach out on [Community Chat](https://ch0.co/community)
-</Callout>
-
 ## Issue
 
-In the nuspec,
+In the nuspec, the `<id>` field has been specified with an underscore (`_`) as part of the package identifier when separating words.
 
 ## Recommended Solution
 
-Please update _ so that _
+Please update the `<id>` field in the `.nuspec` file to ensure that the package identifier does not contain an underscore, and follows our [package naming Guidelines](https://docs.chocolatey.org/en-us/create/create-packages/#naming-your-package)
 
 ## Reasoning
+
+Packages on Chocolatey Community Repository should follow package guidelines and established conventions.
+One of the established conventions is to separate different words using a dash (`-`) instead of an underscore (`_`).


### PR DESCRIPTION
## Description Of Changes

This adds documentation to the CPMR0070 rule to inform users of what the issue is, how to remediate the issue and the reasoning behind it being flagged.

## Motivation and Context

To document stubbed out rules

## Testing

* [x] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made

* [ ] Minor documentation fix (typos etc.).
* [x] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist

* [ ] Requires a change to menu structure (top or left-hand side)/
* [ ] Menu structure has been updated

## Related Issue

- https://github.com/chocolatey-community/chocolatey-community-validation/issues/39