### PR TITLE
(doc) Improves C4B Quickstart Offline Instructions

### DIFF
--- a/src/content/docs/en-us/c4b-environments/quick-start-environment/chocolatey-for-business-quick-start-guide.mdx
+++ b/src/content/docs/en-us/c4b-environments/quick-start-environment/chocolatey-for-business-quick-start-guide.mdx
@@ -89,6 +89,14 @@ export const callout3 = {
 
 <Callout content={callout3}>
     If your C4B server does not have unrestricted access to the internet, you can download the `choco-quickstart-scripts` repository to a Windows machine that is connected to the internet and run `OfflineInstallPreparation.ps1`. This will use Chocolatey to save all of the required assets into the repository folder, which can then be transferred to the target C4B server.
+    - Download [choco-quickstart-scripts by clicking here](https://github.com/chocolatey/choco-quickstart-scripts/archive/refs/heads/main.zip).
+    - Unzip it, e.g.: `Expand-Archive -Path ~\Downloads\choco-quickstart-scripts-main.zip -DestinationPath ~\Downloads\choco-quickstart-scripts`.
+    - Run the OfflineInstallPreparation script, e.g.: `~\Downloads\choco-quickstart-scripts\choco-quickstart-scripts-main\OfflineInstallPreparation.ps1`.
+    - Run the following to zip up your offline bundle: `Compress-Archive -Path ~\Downloads\choco-quickstart-scripts\choco-quickstart-scripts-main\* -DestinationPath ~\Downloads\C4B-Files.zip`.
+    - Transfer the `C4B-Files.zip` from your downloads folder to your offline system. All further steps will be carried out on the offline system.
+    - Run `Expand-Archive -Path \path\to\C4B-Files.zip -DestinationPath C:\choco-setup\files -Force` on your offline system.
+    - Run `Set-Location "$env:SystemDrive\choco-setup\files"; Set-ExecutionPolicy Bypass Process; .\Start-C4bSetup.ps1` on your offline system.
+    - Proceed to Step 2!
 </Callout>
 
 ### Step 1: Begin C4B Setup


### PR DESCRIPTION
## Description Of Changes
Adds more detailed steps for running an offline install of the quick-start guide on two systems.

## Motivation and Context
Ryan raised that the C4B offline instructions didn't clarify enough. These new steps cover most bases.

## Testing

* [x] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made

* ~[ ] Minor documentation fix (typos etc.).~
* [x] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* ~[ ] New documentation page added.~
* ~[ ] The change I have made should have a video added, and I have raised an issue for this.~

## Change Checklist

* ~[ ] Requires a change to menu structure (top or left-hand side)/~
* ~[ ] Menu structure has been updated~
