### PR TITLE
Added Nexus Upgrade doc to Azure docs

### DIFF
--- a/src/content/docs/en-us/c4b-environments/azure/upgrading-nexus.mdx
+++ b/src/content/docs/en-us/c4b-environments/azure/upgrading-nexus.mdx
@@ -1,0 +1,26 @@
+---
+order: 32
+xref: c4b-azure-upgrading-nexus
+title: Upgrading Nexus
+description: A guide to upgrading Sonatype Nexus in the Chocolatey for Business Azure Environment
+---
+import Callout from '@choco/components/Callout.astro';
+import Iframe from '@choco/components/Iframe.astro';
+import Xref from '@components/Xref.astro';
+
+## Upgrade Nexus in the Azure Environment
+
+This document outlines the process for upgrading Nexus running inside our Azure Environment.
+
+If your server is restricted from access to the Chocolatey Community Repository, <Xref title="internalize the package to your internal repository" value="package-internalizer" />.
+
+## Instructions
+
+1. Internalize the nexus-repository package and push to your internal repository
+2. choco upgrade the nexus-repository package (Example command provided below)
+
+### Example Upgrade Command:
+
+```powershell
+choco upgrade nexus-repository -y
+```


### PR DESCRIPTION
In this commit I added upgrade documentation for Sonatype Nexus in the Azure documentation in preparation for upgrading Nexus due to database migration.

## Description Of Changes
Added upgrade documentation for Sonatype Nexus to the Azure documentation.

## Motivation and Context
With Nexus' migration from OrientDB to H2 we needed to include upgrade documentation for environments other than the Quick Start Environment. This is the first step of those additions.

## Testing

* [X] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [ ] Minor documentation fix (typos etc.).
* [ ] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [X] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist

* [ ] Requires a change to menu structure (top or left-hand side)/
* [X] Menu structure has been updated

