### PR TITLE
(#1031) Update wording of custom install location

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,11 @@
 # build output
 dist/
+bin/
+cache/
+input/
+obj/
+output/
+tools/
 
 # generated types
 .astro/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -92,6 +92,9 @@
         "windirstat",
         "xcopy"
     ],
+    "cSpell.enableFiletypes": [
+        "mdx"
+    ],
     "languageToolLinter.languageTool.ignoredWordsInWorkspace": [
         "format-filesize",
         "get-packageparameters",

--- a/src/content/docs/en-us/choco/setup.mdx
+++ b/src/content/docs/en-us/choco/setup.mdx
@@ -714,14 +714,15 @@ See <Xref title="Installing Chocolatey Behind a Proxy Server" value="proxy-setti
 
 ### Installing to a different location
 
-1. Create a __machine__ level (__user__ level will also work) environment variable named `ChocolateyInstall` and set it to the folder you want Chocolatey to install to prior to installation (this environment variable must be set globally or available to PowerShell- it is not enough to simply make it available to your current command prompt session).
+The Chocolatey installation script looks for the `ChocolateyInstall` environment variable in order to identify where it should install to. If this environment varialbe does not exist, it will install Chocolatey to the default location. In order to install to a non-default location, you should set this variable in a way that it is available in the process that will be running the install script.
+
+1. Create an environment variable named `ChocolateyInstall` and set it to the folder you want Chocolatey to install to prior to installation.
 1. Don't use `"C:\Chocolatey"` unless necessary.
-1. Create the folder manually.
 1. If you have already installed (and want to change the location after the fact):
-  * Follow the above steps.
-  * Install Chocolatey again.
-  * Copy/Move over the items from the old lib/bin directory.
-  * Delete your old install directory.
+    * Follow the above steps.
+    * Install Chocolatey again.
+    * Copy/Move over the items from the old lib/bin directory.
+    * Delete your old install directory.
 
 <Callout type="info">
     There is one really important consideration when installing Chocolatey to a non-default location: Chocolatey only locks down the permissions to Admins when installed to the default location `%PROGRAMDATA%\Chocolatey`, which means the same thing as `%SystemDrive%\ProgramData\Chocolatey`.

--- a/src/content/docs/en-us/choco/setup.mdx
+++ b/src/content/docs/en-us/choco/setup.mdx
@@ -714,7 +714,9 @@ See <Xref title="Installing Chocolatey Behind a Proxy Server" value="proxy-setti
 
 ### Installing to a different location
 
-The Chocolatey installation script looks for the `ChocolateyInstall` environment variable in order to identify where it should install to. If this environment varialbe does not exist, it will install Chocolatey to the default location. In order to install to a non-default location, you should set this variable in a way that it is available in the process that will be running the install script.
+The Chocolatey installation script looks for the `ChocolateyInstall` environment variable in order to identify where it should install to. If this environment variable does not exist, it will install Chocolatey to the default location. In order to install to a non-default location, you should set this variable in a way that it is available in the process that will be running the install script. For example you could set the environment variable through the [Windows GUI](https://www.howtogeek.com/787217/how-to-edit-environment-variables-on-windows-10-or-11/), or you could use `setx`](https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/setx).
+
+You can validate that PowerShell has the environment variable by running: `Write-Host $env:ChocolateyInstall`
 
 1. Create an environment variable named `ChocolateyInstall` and set it to the folder you want Chocolatey to install to prior to installation.
 1. Don't use `"C:\Chocolatey"` unless necessary.


### PR DESCRIPTION
## Description Of Changes

Updates the wording of the custom install location documents to clarify that the ChocolateyInstall variable must be available to the process that is installing Chocolatey.

## Motivation and Context

The previous wording was ambiguous.

## Testing

* [x] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made

* [ ] ~Minor documentation fix (typos etc.).~
* [x] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] ~New documentation page added.~
* [ ] ~The change I have made should have a video added, and I have raised an issue for this.~

## Change Checklist

* [ ] Requires a change to menu structure (top or left-hand side)/
* [ ] Menu structure has been updated

## Related Issue

* Fixes #1031
* ENGTASKS-3856
