### PR TITLE
(#1028) docs update - fix emojis

### DIFF
--- a/src/content/docs/en-us/central-management/usage/api/index.mdx
+++ b/src/content/docs/en-us/central-management/usage/api/index.mdx
@@ -11,7 +11,7 @@ import Xref from '@components/Xref.astro';
 ## Description
 
 As of CCM v0.4.0, the API for Chocolatey Central Management is exposed via Swagger.
-The API documentation and examples can be reached from your CCM dashboard by selecting the :gear: **API** option on the left sidebar.
+The API documentation and examples can be reached from your CCM dashboard by selecting the ⚙ **API** option on the left sidebar.
 The information contained there is referenced here, but you can additionally try out the various API endpoints directly from the Swagger API page for your own CCM environment.
 
 <Callout type="warning">
@@ -52,7 +52,7 @@ Invoke-WebRequest -Uri "https://$CcmServerHostname/$endpointUrl" -Method $Method
 ## Endpoints
 
 Below is a list of the API endpoints available for CCM as of v0.10.0.
-For more detailed information on the API endpoints and their parameters for your version of CCM, select the :gear: **API** option from the sidebar on the Central Management dashboard, or navigate to `https://CCM_SERVER_HOSTNAME/swagger/`.
+For more detailed information on the API endpoints and their parameters for your version of CCM, select the ⚙ **API** option from the sidebar on the Central Management dashboard, or navigate to `https://CCM_SERVER_HOSTNAME/swagger/`.
 
 ### AuditLog
 

--- a/src/content/docs/en-us/central-management/usage/website/administration/audit-logs.mdx
+++ b/src/content/docs/en-us/central-management/usage/website/administration/audit-logs.mdx
@@ -29,7 +29,7 @@ Once the required filters have been set, pressing the `Refresh` button will show
 
 ![Operation logs tab within the Audit logs section of the Administration | Settings page](/images/ccm-playwright/administration/audit-logs/left-menu-active.png)
 
-It is possible to see all available information for an operation by clicking the :mag: button to the left-hand side of the table.
+It is possible to see all available information for an operation by clicking the 🔍 button to the left-hand side of the table.
 
 If required, the available results can be exported to an Excel document using the `Export | Export to Excel` button.
 This will generate a file named something similar to the following `Chocolatey_AuditLogs_20231122_095144.xlsx`.

--- a/src/content/docs/en-us/central-management/usage/website/administration/roles.mdx
+++ b/src/content/docs/en-us/central-management/usage/website/administration/roles.mdx
@@ -28,18 +28,18 @@ Next you'll want to click over to Permissions. This window will allow you to sel
 
 ![Creating New Role Setting Permissions](/images/ccm-playwright/administration/roles/modal-new-role-tab-permissions.png)
 
-Click :floppy_disk: **Save** to close the window and create the new role.
+Click 💾 **Save** to close the window and create the new role.
 
 ## Editing a Role
 
 <Callout type="info">
-    If you do not see the **Edit** menu entry or the :gear: **Actions** buttons, please see your Administrator to determine if your account has the _Edit Roles_ permission.
+    If you do not see the **Edit** menu entry or the ⚙ **Actions** buttons, please see your Administrator to determine if your account has the _Edit Roles_ permission.
 </Callout>
 
 On the main Roles page, find the role you want to edit.
 You can also use _Select Permissions (0)_ to filter the Roles listed based on them having the permissions you select.
 
-Select the :gear: **Actions** button on the left-hand side of the role, and then select **Edit** to open the _Edit Group_ window.
+Select the ⚙ **Actions** button on the left-hand side of the role, and then select **Edit** to open the _Edit Group_ window.
 
 ![Edit menu entry in role actions flyout menu](/images/ccm-playwright/administration/roles/table-row-button-action-dropdown-menu-edit.png)
 
@@ -48,14 +48,14 @@ From the **Edit Role** window, you can modify the name, set it to be the Default
 ## Deleting a Role
 
 <Callout type="info">
-    If you do not see the **Delete** menu entry or the :gear: **Actions** buttons, please see your Administrator to determine if your account has the _Edit Roles_ permissions.
+    If you do not see the **Delete** menu entry or the ⚙ **Actions** buttons, please see your Administrator to determine if your account has the _Edit Roles_ permissions.
     
     Roles labelled **Static** cannot be deleted.
     
     You cannot delete a Role if the account you are using also has the Role assigned to it.
 </Callout>
 
-On the main Roles page, find the role you want to delete. You can also use _Select Permissions (0)_ to filter the roles listed based on permission. Similar to the [Edit Role](#editing-a-role) action, select the :gear: **Actions** button on the left-hand side of the role, and select **Delete**. You will be prompted to confirm the deletion.
+On the main Roles page, find the role you want to delete. You can also use _Select Permissions (0)_ to filter the roles listed based on permission. Similar to the [Edit Role](#editing-a-role) action, select the ⚙ **Actions** button on the left-hand side of the role, and select **Delete**. You will be prompted to confirm the deletion.
 
 ## Pre-Configured Roles
 

--- a/src/content/docs/en-us/central-management/usage/website/administration/sensitive-variables.mdx
+++ b/src/content/docs/en-us/central-management/usage/website/administration/sensitive-variables.mdx
@@ -20,14 +20,14 @@ The **Sensitive Variables** page can be accessed from the Administration section
 1. From the Chocolatey Central Management Dashboard, select `Administration` > `Sensitive Variables` from the left sidebar.
 
     ![Chocolatey Central Management dashboard, arrow pointing to Sensitive Variables menu in the left sidebar entry.](/images/ccm-playwright/dashboard/left-menu-nested-sensitive-variables.png)
-1. Select the :heavy_plus_sign: **Create new sensitive variable** button at the top of the page.
+1. Select the ➕ **Create new sensitive variable** button at the top of the page.
 
     ![CCM Sensitive Variables page, arrow pointing to Create new sensitive variable button](/images/ccm-playwright/administration/sensitive-variables/button-create-new-sensitive-variable.png)
 1. Fill in the details and click Save.
 
     ![Fill in Sensitive Variables information](/images/ccm-playwright/administration/sensitive-variables/modal-new-sensitive-variable.png)
 
-Alternatively, variables can also be added from an Deployment Step Advanced script by clicking the :heavy_plus_sign: in the upper right corner.
+Alternatively, variables can also be added from an Deployment Step Advanced script by clicking the ➕ in the upper right corner.
 
 ![Sensitive Variables Added from the Advanced script of a Deployment Step](/images/ccm-playwright/deployment-plans/edit/modal-step-button-create-sensitive-variable.png)
 
@@ -44,7 +44,7 @@ Alternatively, variables can also be added from an Deployment Step Advanced scri
 1. From the Chocolatey Central Management Dashboard, select `Administration` > `Sensitive Variables` from the left sidebar.
 
     ![Central Management dashboard, arrow pointing to Sensitive Variables menu in the left sidebar entry on the CCM Dashboard](/images/ccm-playwright/dashboard/left-menu-nested-sensitive-variables.png)
-1. Select :wastebasket: **Delete** beside the Sensitive Variable you wish to delete.
+1. Select 🗑 **Delete** beside the Sensitive Variable you wish to delete.
 
     ![Sensitive Variables page with arrow to a delete button](/images/ccm-playwright/administration/sensitive-variables/button-quick-action-delete.png)
 

--- a/src/content/docs/en-us/central-management/usage/website/administration/users.mdx
+++ b/src/content/docs/en-us/central-management/usage/website/administration/users.mdx
@@ -32,23 +32,23 @@ Next you'll want to click over to `Roles`. This window will allow you to select 
 
 ![Creating New User Setting Roles](/images/ccm-playwright/administration/users/modal-new-user-tab-roles.png)
 
-Click :floppy_disk: **Save** to close the window and create the new User.
+Click 💾 **Save** to close the window and create the new User.
 A green toast notification will be shown once the operation completes successfully.
 
 ## Editing a User
 
 <Callout type="info">
-    If you do not see the **Edit** menu entry or the :gear: **Actions** buttons, please see your Administrator to determine if your account has the _Editing user_ permission.
+    If you do not see the **Edit** menu entry or the ⚙ **Actions** buttons, please see your Administrator to determine if your account has the _Editing user_ permission.
 </Callout>
 
 On the main Users page, [find](#searching-for-a-user) the User you want to edit.
-Select the :gear: **Actions** button on the left-hand side of the User, and then select **Edit** to open the _Edit User_ window.
+Select the ⚙ **Actions** button on the left-hand side of the User, and then select **Edit** to open the _Edit User_ window.
 
 ![Edit menu entry in User actions flyout menu](/images/ccm-playwright/administration/users/table-row-button-action-dropdown-menu-edit.png)
 
 From the **Edit Role** window, you can modify all the properties for a User, for example, `First Name`, `Phone number`, etc. In addition, you can alter the <Xref title="Roles" value="ccm-administration-roles" /> associated with the User.
 
-Once modifications are complete, click the :floppy_disk: **Save** button.
+Once modifications are complete, click the 💾 **Save** button.
 A green toast notification will be shown once the operation completes successfully.
 
 ## Fine grained permissions
@@ -56,23 +56,23 @@ A green toast notification will be shown once the operation completes successful
 In addition to configuring a set of Roles for an individual User, so can set speicial permissions for an individual User.
 
 On the main Users page, [find](#searching-for-a-user) the User you want to edit.
-Select the :gear: **Actions** button on the left-hand side of the User, and then select **Permission** to open the _Permissions_ window.
+Select the ⚙ **Actions** button on the left-hand side of the User, and then select **Permission** to open the _Permissions_ window.
 
 ![Permissions menu entry in User actions flyout menu](/images/ccm-playwright/administration/users/modal-permissions.png)
 
 From the tree of permissions, check/uncheck the permissions that are needed.
 
-Once modifications are complete, click the :floppy_disk: **Save** button.
+Once modifications are complete, click the 💾 **Save** button.
 A green toast notification will be shown once the operation completes successfully.
 
 ## Deleting a User
 
 <Callout type="info">
-    If you do not see the **Delete** menu entry or the :gear: **Actions** buttons, please see your Administrator to determine if your account has the _Deleting user_ permission.
+    If you do not see the **Delete** menu entry or the ⚙ **Actions** buttons, please see your Administrator to determine if your account has the _Deleting user_ permission.
 </Callout>
 
 On the main Users page, [find](#searching-for-a-user) the User that needs to be deleted.
-Select the :gear: **Actions** button on the left-hand side of the User, and then select **Delete**.
+Select the ⚙ **Actions** button on the left-hand side of the User, and then select **Delete**.
 A prompt will be shown asking `Are you sure?`.
 Click `Cancel` to not continue with the operation.
 Click `Yes` to proceed with the operation.
@@ -81,13 +81,13 @@ A green toast notification will be shown once the operation completes successful
 ## Unlocking a User
 
 <Callout type="info">
-    If you do not see the **Unlock** menu entry or the :gear: **Actions** buttons, please see your Administrator to determine if your account has the _Editing user_ permission.
+    If you do not see the **Unlock** menu entry or the ⚙ **Actions** buttons, please see your Administrator to determine if your account has the _Editing user_ permission.
 </Callout>
 
 If a User enters the wrong login information 5 times, their account will become locked.
 To allow them to attempt to login again, the account will need to be unlocked.
 On the main Users page, [find](#searching-for-a-user) the User that is locked out.
-Select the :gear: **Actions** button on the left-hand side of the User, and then select **Unlock**.
+Select the ⚙ **Actions** button on the left-hand side of the User, and then select **Unlock**.
 A green toast notification will be shown once the operation completes successfully.
 
 ## Searching for a User

--- a/src/content/docs/en-us/central-management/usage/website/computers.mdx
+++ b/src/content/docs/en-us/central-management/usage/website/computers.mdx
@@ -35,7 +35,7 @@ Please see <Xref title="Central Management Client Setup" value="ccm-client" /> f
 </Callout>
 
 From the main Computers page in Central Management, locate the computer of interest in the list or by providing a search term in the table filter.
-Select the :gear: **Actions** menu in the corresponding left-hand column, and click **Details**.
+Select the ⚙ **Actions** menu in the corresponding left-hand column, and click **Details**.
 
 ![Finding a computer's details menu option](/images/ccm-playwright/computers/table-row-button-action-dropdown-menu-details.png)
 
@@ -47,11 +47,11 @@ You will be presented with a list of the installed software packages for the mac
 
 Creating a Draft Deployment Plan for a Computer can be done from two pages:
 
-1. In the leftmost column of the Computer table you will find an :gear: **Actions** menu which will display a **Create New Deployment Plan** option.
+1. In the leftmost column of the Computer table you will find an ⚙ **Actions** menu which will display a **Create New Deployment Plan** option.
 
     ![Finding the Create New Deployment Plan menu entry for a specific Computer on the Computers page](/images/ccm-playwright/computers/table-row-button-action-dropdown-menu-create-new-deployment-plan.png)
 
-1. From the Computer Details page, click the :gear: **Actions** button and select the **Create New Deployment Plan** option.
+1. From the Computer Details page, click the ⚙ **Actions** button and select the **Create New Deployment Plan** option.
 
     ![Button to create a new draft Deployment Plan from the Computer Details page](/images/ccm-playwright/computers/details/button-action-dropdown-menu-create-new-deployment-plan.png)
 
@@ -71,11 +71,11 @@ From here, the Deployment Plan can be edited and deployed as outlined in the <Xr
 
 Upgrading all outdated Software installed on a Computer can be done from two pages:
 
-1. In the leftmost column of the Computer table you will find an :gear: **Actions** menu which will display a **Upgrade Outdated Software** option.
+1. In the leftmost column of the Computer table you will find an ⚙ **Actions** menu which will display a **Upgrade Outdated Software** option.
 
     ![Finding the Upgrade Outdated Software menu entry for a specific Computer on the Computers page](/images/ccm-playwright/computers/table-row-button-action-dropdown-menu-upgrade-outdated-software.png)
 
-1. From the Computer Details page, click the :gear: **Actions** button and select the **Upgrade Outdated Software** option.
+1. From the Computer Details page, click the ⚙ **Actions** button and select the **Upgrade Outdated Software** option.
 
     ![Button to create a new Deployment Plan to upgrade all outdated Software on a Computer from the Computer Details page](/images/ccm-playwright/computers/details/button-action-dropdown-menu-upgrade-outdated-software.png)
 
@@ -104,7 +104,7 @@ From the Computer details page, click the `Export` button and select the `Export
 </Callout>
 
 From the main Computers page in Central Management, locate the computer of interest in the list or by providing a search term in the table filter.
-Select the :gear: **Actions** menu in the corresponding left-hand column, and click **Delete**. You will be prompted to confirm the deletion.
+Select the ⚙ **Actions** menu in the corresponding left-hand column, and click **Delete**. You will be prompted to confirm the deletion.
 
 ![Deleting a computer in Central Management](/images/ccm-playwright/computers/table-row-button-action-dropdown-menu-delete.png)
 

--- a/src/content/docs/en-us/central-management/usage/website/deployments.mdx
+++ b/src/content/docs/en-us/central-management/usage/website/deployments.mdx
@@ -28,7 +28,7 @@ You will also need to have at least one Group of computers already defined.
 
     ![Chocolatey Central Management dashboard, arrow pointing to Deployment Plans menu in the left sidebar](/images/ccm-playwright/dashboard/left-menu-deployment-plans.png)
 
-1. Select the :heavy_plus_sign: **Create New Deployment Plan** button at the top of the page.
+1. Select the ➕ **Create New Deployment Plan** button at the top of the page.
 
     ![Chocolatey Central Management Deployment Plans page, arrow pointing to Create New Deployment Plan button](/images/ccm-playwright/deployment-plans/button-create-new-deployment-plan.png)
 
@@ -45,11 +45,11 @@ You will also need to have at least one Group of computers already defined.
 
         ![Chocolatey Central Management Deployment Step modal, arrow pointing to execution timeout in seconds](/images/ccm-playwright/deployment-plans/edit/modal-step-input-execution-timeout-in-seconds.png)
 
-1. (Optional, Requires Chocolatey Central Management v0.4.0+) Add a schedule by selecting the :heavy_plus_sign: **Add Schedule** button.
+1. (Optional, Requires Chocolatey Central Management v0.4.0+) Add a schedule by selecting the ➕ **Add Schedule** button.
 
     ![Chocolatey Central Management New Deployment Plan page, arrow pointing to Add Schedule button](/images/ccm-playwright/deployment-plans/edit/button-add-schedule.png)
 
-    * Enter a date and time, or click the :calendar: button to pick the date and time from a calendar UI.
+    * Enter a date and time, or click the 📅 button to pick the date and time from a calendar UI.
 
         ![Chocolatey Central Management Deployment Plan schedule picker](/images/ccm-playwright/deployment-plans/edit/calendar-start-date-time.png)
 
@@ -61,7 +61,7 @@ You will also need to have at least one Group of computers already defined.
 
         ![Chocolatey Central Management Deployment Plan Repeat Period](/images/ccm-playwright/deployment-plans/edit/select-repeat-period.png)
 
-1. Select :heavy_plus_sign: **Add Step** to add your first Deployment Step.
+1. Select ➕ **Add Step** to add your first Deployment Step.
 
     ![Chocolatey Central Management Deployment Plan add Deployment Step button](/images/ccm-playwright/deployment-plans/edit/button-add-deployment-step.png)
 
@@ -99,7 +99,7 @@ You will also need to have at least one Group of computers already defined.
 
     ![Chocolatey Central Management Deployment Step Select Target Groups modal](/images/ccm-playwright/deployment-plans/edit/modal-step-select-target-groups.png)
 
-1. Click the :floppy_disk: **Save** button to save the Deployment Step.
+1. Click the 💾 **Save** button to save the Deployment Step.
 
     ![Chocolatey Central Management Deployment Step Save button](/images/ccm-playwright/deployment-plans/edit/modal-step-button-save.png)
 
@@ -109,7 +109,7 @@ You will also need to have at least one Group of computers already defined.
 
     ![Chocolatey Central Management Deployment Step Duplicate button](/images/ccm-playwright/deployment-plans/edit/button-duplicate-step.png)
 
-1. Select :floppy_disk: **Save** to save the changes to the Deployment Plan.
+1. Select 💾 **Save** to save the changes to the Deployment Plan.
 
 <ImportDeploymentPlan />
 

--- a/src/content/docs/en-us/central-management/usage/website/groups.mdx
+++ b/src/content/docs/en-us/central-management/usage/website/groups.mdx
@@ -49,17 +49,17 @@ Then, select the Computer(s) or existing Group(s) you would like to include in t
 
 ![New Group Modal](/images/ccm-playwright/groups/modal-create-new-group.png)
 
-Click :floppy_disk: **Save** to close the modal and create the new Group.
+Click 💾 **Save** to close the modal and create the new Group.
 
 ## Editing a Group
 
 <Callout type="info">
-    If you do not see the **Edit** menu entry or the :gear: **Actions** buttons, consult your administrator to determine if you have the Edit Groups role assigned.
+    If you do not see the **Edit** menu entry or the ⚙ **Actions** buttons, consult your administrator to determine if you have the Edit Groups role assigned.
 </Callout>
 
 On the main Groups page, find the Group you want to edit.
-You can enter a search term in the text field to filter results by typing in part of their Name or Description and clicking the :mag: button.
-Select the :gear: **Actions** button on the left-hand side of the Group, and then select **Edit** to open the _Edit Group_ modal.
+You can enter a search term in the text field to filter results by typing in part of their Name or Description and clicking the 🔍 button.
+Select the ⚙ **Actions** button on the left-hand side of the Group, and then select **Edit** to open the _Edit Group_ modal.
 
 ![Edit menu entry in Group actions flyout menu](/images/ccm-playwright/groups/table-row-button-action-dropdown-menu-edit.png)
 
@@ -68,31 +68,31 @@ From the **Edit Group** modal, you can modify the Group name and description, an
 ## Deleting a Group
 
 <Callout type="info">
-    If you do not see the **Delete** menu entry or the :gear: **Actions** buttons, consult your administrator to determine if you have the appropriate role assigned to your account.
+    If you do not see the **Delete** menu entry or the ⚙ **Actions** buttons, consult your administrator to determine if you have the appropriate role assigned to your account.
 </Callout>
 
 On the main Groups page, find the Group you want to edit.
-You can enter a search term in the text field to filter results by typing in part of their Name or Description and clicking the :mag: button.
-Similar to the [Edit Group](#editing-a-group) action, select the :gear: **Actions** button on the left-hand side of the Group, and instead select **Delete**.
+You can enter a search term in the text field to filter results by typing in part of their Name or Description and clicking the 🔍 button.
+Similar to the [Edit Group](#editing-a-group) action, select the ⚙ **Actions** button on the left-hand side of the Group, and instead select **Delete**.
 You will be prompted to confirm the deletion.
 
 ## Duplicating a Group
 
 <Callout type="info">
-    If you do not see the **Duplicate** menu entry or the :gear: **Actions** buttons, consult your administrator to determine if you have the appropriate role assigned to your account.
+    If you do not see the **Duplicate** menu entry or the ⚙ **Actions** buttons, consult your administrator to determine if you have the appropriate role assigned to your account.
 </Callout>
 
 On the main Groups page, find the Group you want to duplicate.
-You can enter a search term in the text field to filter results by typing in part of their Name or Description and clicking the :mag: button.
-Similar to the [Edit Group](#editing-a-group) action, select the :gear: **Actions** button on the left-hand side of the Group, and instead select **Duplicate**.
+You can enter a search term in the text field to filter results by typing in part of their Name or Description and clicking the 🔍 button.
+Similar to the [Edit Group](#editing-a-group) action, select the ⚙ **Actions** button on the left-hand side of the Group, and instead select **Duplicate**.
 If the Group being duplicated is a system managed Group, a confirmation message will be shown indicating that the duplicated Group will not be system managed.
 A success message will be shown that mentions that the Group was duplicated, and if you have permissions to Edit a Group a dialog to edit this duplicated Group will be shown.
 
 ## Viewing a Group's Details
 
 On the main Groups page, find the group you want to view.
-You can enter a search term in the text field to filter results by typing in part of their Name or Description and clicking the :mag: button.
-Select the :gear: **Actions** button on the left-hand side of the group, and select **Details**.
+You can enter a search term in the text field to filter results by typing in part of their Name or Description and clicking the 🔍 button.
+Select the ⚙ **Actions** button on the left-hand side of the group, and select **Details**.
 
 ![Details menu entry in Group actions flyout menu](/images/ccm-playwright/groups/table-row-button-action-dropdown-menu-details.png)
 
@@ -104,11 +104,11 @@ On the Group Details page, you'll find a searchable list of all Computers and Gr
 
 Creating a Deployment Plan for a Group can be done from two pages:
 
-1. In the leftmost column of the Groups table you will find an :gear: **Actions** menu which will display a **Create New Deployment Plan** option.
+1. In the leftmost column of the Groups table you will find an ⚙ **Actions** menu which will display a **Create New Deployment Plan** option.
 
     ![Finding the Create New Deployment Plan menu entry for a specific Group on the Groups page](/images/ccm-playwright/groups/table-row-button-action-dropdown-menu-create-new-deployment-plan.png)
 
-1. From the Group Details page, click the :gear: **Actions** button and select the **Create New Deployment Plan** option.
+1. From the Group Details page, click the ⚙ **Actions** button and select the **Create New Deployment Plan** option.
 
     ![Button to create a new Draft Deployment Plan for a Group from the Group Details page](/images/ccm-playwright/groups/details/button-action-dropdown-menu-create-new-deployment-plan.png)
 

--- a/src/content/docs/en-us/central-management/usage/website/groups.mdx
+++ b/src/content/docs/en-us/central-management/usage/website/groups.mdx
@@ -13,7 +13,7 @@ A Group may contain one or more Computers, and/or other Groups.
 Currently, Groups are entirely self-contained, and cannot be directly mapped from Active Directory Groups.
 
 The **Groups** page can be accessed from the left-hand navigation menu by selecting the **Groups** menu item.
-If you do not see this menu entry, verify with your administrator whether yourhas the `View Groups` role assigned.
+If you do not see this menu entry, verify with your administrator whether your group has the `View Groups` role assigned.
 
 ![Groups menu entry on the Chocolatey Central Management Dashboard](/images/ccm-playwright/dashboard/left-menu-groups.png)
 

--- a/src/content/docs/en-us/central-management/usage/website/reports.mdx
+++ b/src/content/docs/en-us/central-management/usage/website/reports.mdx
@@ -21,13 +21,13 @@ If there is no Outdated Software, a report cannot be generated.
 When generating an Outdated Software Report, a snapshot of the current Outdated Software will be captured for the report.
 Generated reports will be displayed in a list, showing the date and time they were created.
 
-Reports can be exported from this screen via the :gear: **Actions** menu, and selecting the desired export type.
+Reports can be exported from this screen via the ⚙ **Actions** menu, and selecting the desired export type.
 
 ![Outdated Reports export to Excel](/images/ccm-playwright/reports/outdated-software/table-row-button-action-dropdown-menu-export-to-excel.png)
 
 ![Outdated Reports export to PDF](/images/ccm-playwright/reports/outdated-software/table-row-button-action-dropdown-menu-export-to-pdf.png)
 
-When clicking on the date and time for a report, or selecting the :gear: **Actions** menu and then **Details**, the Outdated Software Details screen will be shown.
+When clicking on the date and time for a report, or selecting the ⚙ **Actions** menu and then **Details**, the Outdated Software Details screen will be shown.
 The report will display the name and version of any Outdated Software, along with any Computers that each Outdated Software is installed on.
 
 ![Outdated Software Details view](/images/ccm-playwright/reports/outdated-software/details/screen.png)

--- a/src/content/docs/en-us/central-management/usage/website/software.mdx
+++ b/src/content/docs/en-us/central-management/usage/website/software.mdx
@@ -23,7 +23,7 @@ The Software main page lists all installed software in any computers that have c
 
 ## Upgrade Individual Software
 
-In the leftmost column of the Software table you will find an :gear: **Actions** menu which will display an **Upgrade** option on outdated Software.
+In the leftmost column of the Software table you will find an ⚙ **Actions** menu which will display an **Upgrade** option on outdated Software.
 
 ![Finding the Upgrade menu entry for a specific Software entry](/images/ccm-playwright/software/table-row-button-action-dropdown-menu-upgrade.png)
 
@@ -33,7 +33,7 @@ From here, the Deployment Plan can be edited and deployed as outlined in the <Xr
 
 ## Uninstall Individual Software
 
-In the leftmost column of the Software table you will find an :gear: **Actions** menu which will display an **Uninstall** option.
+In the leftmost column of the Software table you will find an ⚙ **Actions** menu which will display an **Uninstall** option.
 
 ![Finding the Upgrade menu entry for a specific Software entry](/images/ccm-playwright/software/table-row-button-action-dropdown-menu-uninstall.png)
 
@@ -57,7 +57,7 @@ From here, the Deployment Plan can be edited and deployed as outlined in the <Xr
 
 ## Software Details
 
-In the leftmost column of the Software table you will find an :gear: **Actions** menu which will display a **Details** option.
+In the leftmost column of the Software table you will find an ⚙ **Actions** menu which will display a **Details** option.
 Clicking this option will take you to the **Software Details** page.
 
 ![Finding the Details menu entry for a specific Software entry](/images/ccm-playwright/software/table-row-button-action-dropdown-menu-details.png)


### PR DESCRIPTION
## Description Of Changes
Emotions (`:gear:`, `:floppy_disk:`, `:mag:`,  `:heavy_plus_sign:`, `:calendar`, `:wastebasket:`) were replaced with Unicode ones (⚙💾🔍➕📅🗑).


## Motivation and Context
Motivation was to improve the user experience and ensure consistent visual representation across different platforms and devices. Previously, emoticons were not displaying, which could lead to confusion or misinterpretation of the documentation. 

## Testing

* [x] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

Pages that were validated:
- http://localhost:5086/en-us/central-management/usage/api
- http://localhost:5086/en-us/central-management/usage/website/groups
- http://localhost:5086/en-us/central-management/usage/website/reports
- http://localhost:5086/en-us/central-management/usage/website/software
- http://localhost:5086/en-us/central-management/usage/website/computers
- http://localhost:5086/en-us/central-management/usage/website/deployments
- http://localhost:5086/en-us/central-management/usage/website/administration/roles
- http://localhost:5086/en-us/central-management/usage/website/administration/users
- http://localhost:5086/en-us/central-management/usage/website/administration/audit-logs
- http://localhost:5086/en-us/central-management/usage/website/administration/sensitive-variables



## Change Types Made
* [x] Minor documentation fix (typos etc.).
* [ ] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.

## Change Checklist

* [ ] Requires a change to menu structure (top or left-hand side)/
* [ ] Menu structure has been updated
