### PR TITLE
(doc) Remove incorrect line about extensions

### DIFF
--- a/src/content/docs/en-us/guides/create/create-extension-package.mdx
+++ b/src/content/docs/en-us/guides/create/create-extension-package.mdx
@@ -132,8 +132,6 @@ Open the `example.extension.nuspec` file in VS Code and modify the metadata as a
 
 That's all you need!
 
-You may notice that all of the example packages above end with `.extension`. This is not required for an extension package by Chocolatey itself, but it is how we easily classify extension packages on the Chocolatey Community Repository.
-
 #### Creating Your Install Script
 
 As we mentioned earlier, there's no need for an install script in an extension package - Chocolatey CLI handles putting the extension in the right place!


### PR DESCRIPTION
## Description Of Changes

Remove line from the guide about creating Extension packages, as it is incorrect.

## Motivation and Context

The .extension file extension is a requirement when creating extension packages. It is this file extension that causes Chocolatey CLI to extract the files into the extensions folder, in the same way that the .hook file extension that causes files to be extracted into the hooks folder, and then the .template file extension that causes files to be extracted into the templates folder.

## Testing

* [x] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made

* [x] Minor documentation fix (typos etc.).
* [ ] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist

* [ ] Requires a change to menu structure (top or left-hand side)/
* [ ] Menu structure has been updated

## Related Issue

N/A