### PR TITLE
(doc)Remove Hardened Option in QSG

### DIFF
--- a/src/content/docs/en-us/c4b-environments/quick-start-environment/chocolatey-for-business-quick-start-guide.mdx
+++ b/src/content/docs/en-us/c4b-environments/quick-start-environment/chocolatey-for-business-quick-start-guide.mdx
@@ -209,29 +209,25 @@ export const callout4 = {
 
     ```powershell
     Set-Location "$env:SystemDrive\choco-setup\files"
-    .\Set-SslSecurity.ps1 -Thumbprint '<YOUR_CUSTOM_SSL_CERT_THUMBPRINT_HERE>' -Hardened
+    .\Set-SslSecurity.ps1 -Thumbprint '<YOUR_CUSTOM_SSL_CERT_THUMBPRINT_HERE>'
     ```
 
     <Callout type="warning">
         If you are using your own SSL certificate, be sure to place this certificate in the `Local Machine > Personal` certificate store before running the above script, and ensure that the private key is exportable.
     </Callout>
 
-    <Callout type="info">
-        You may have noticed the `-Hardened` parameter we've added above. When using a custom SSL certificate, this parameter will further secure access to your C4B Server. A Role and User credential will be configured to limit access to your Nexus repositories. As well, CCM Client and Service Salts are configured to further encrypt your connection between CCM and your endpoint clients. These additional settings are also incorporated into your `Register-C4bEndpoint.ps1` script for onboarding endpoints. We do require you to enable this option if your C4B Server will be Internet-facing, with a FQDN that resolves to a public IP.
-    </Callout>
-
     **ALTERNATIVE 2 : Wildcard SSL Certificate** - If you have a wildcard certificate, you will also need to provide a DNS name you wish to use for that certificate:
 
     ```powershell
     Set-Location "$env:SystemDrive\choco-setup\files"
-    .\Set-SslSecurity.ps1 -Thumbprint '<YOUR_CUSTOM_SSL_CERT_THUMBPRINT_HERE>' -CertificateDnsName '<YOUR_DESIRED_FQDN_HERE>' -Hardened
+    .\Set-SslSecurity.ps1 -Thumbprint '<YOUR_CUSTOM_SSL_CERT_THUMBPRINT_HERE>' -CertificateDnsName '<YOUR_DESIRED_FQDN_HERE>'
     ```
 
     For example, with a wildcard certificate with a thumbprint of `deee9b2fabb24bdaae71d82286e08de1` you wish to use `chocolatey.foo.org`, the following would be required:
 
     ```powershell
     Set-Location "$env:SystemDrive\choco-setup\files"
-    .\Set-SslSecurity.ps1 -Thumbprint deee9b2fabb24bdaae71d82286e08de1 -CertificateDnsName chocolatey.foo.org -Hardened
+    .\Set-SslSecurity.ps1 -Thumbprint deee9b2fabb24bdaae71d82286e08de1 -CertificateDnsName chocolatey.foo.org
     ```
 
     <br />
@@ -240,6 +236,8 @@ export const callout4 = {
     > <summary><strong>What does this script do? (click to expand)</strong></summary>
     > <ul class="list-style-type-disc">
     > <li>Adds SSL certificate configuration for Nexus and CCM web portals</li>
+    > <li>A Role and User credential are configured to limit access to your Nexus repositories</li>
+    > <li>CCM Client and Service Salts are configured to further encrypt the connection between CCM and your endpoint clients</li>
     > <li>Generates a `Register-C4bEndpoint.ps1` script for you to easily set up endpoint clients</li>
     > <li>Outputs data to a JSON file to pass between scripts</li>
     > <li>Writes a Readme.html file to the Public Desktop with account information for C4B services</li>


### PR DESCRIPTION
## Description Of Changes
Removed the Hardened parameter in SSL commands of the QSG.

## Motivation and Context
This has been removed by https://github.com/chocolatey/choco-quickstart-scripts/pull/279 in QSG

## Testing
* [X] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made
* [X] Minor documentation fix (typos etc.).~
* ~[ ] Major documentation change (refactoring, reformatting or adding documentation to existing page).~
* ~[ ] New documentation page added.~
* ~[ ] The change I have made should have a video added, and I have raised an issue for this.~
    * ~Issue #~

## Change Checklist
* ~[ ] Requires a change to menu structure (top or left-hand side)/~
* ~[ ] Menu structure has been updated~

## Related Issue
https://github.com/chocolatey/choco-quickstart-scripts/issues/105
