### PR TITLE
(#195) Added note chocolatey gui can be used by one user at a time

### DIFF
--- a/src/content/docs/en-us/chocolatey-gui/setup/installation.mdx
+++ b/src/content/docs/en-us/chocolatey-gui/setup/installation.mdx
@@ -15,6 +15,10 @@ following command to install the latest version of Chocolatey GUI:
 choco install chocolateygui
 ```
 
+<Callout type="info">
+Chocolatey GUI is designed to be used by one user at a time on the PC. Multiple users trying to run Chocolatey GUI simultaneously is not supported.
+</Callout>
+
 ## Upgrading Chocolatey GUI
 
 If you already have Chocolatey GUI installed, you can upgrade to the latest


### PR DESCRIPTION
## Description Of Changes
Add note in Chocolatey GUI Docs to reference Chocolatey GUI not supporting being run by multiple users on the same machine.

## Motivation and Context
In latest version of chocolateygui if user attempts to start another instance of chocolateygui, there is no warning inside the powershell window that another instance can not be run. It is good to state the obvious in official documentation.

## Testing

* [ ] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made

* [ ] Minor documentation fix (typos etc.).
* [ ] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist

* [ ] Requires a change to menu structure (top or left-hand side)/
* [ ] Menu structure has been updated

## Related Issue
Fixes #195