### PR TITLE
(docs) Add documentation for new rule CPMR0076

### DIFF
--- a/src/components/docs/PackageValidatorNotImplemented.mdx
+++ b/src/components/docs/PackageValidatorNotImplemented.mdx
@@ -1,0 +1,12 @@
+---
+
+---
+import Callout from '@choco/components/Callout.astro';
+import Iframe from '@choco/components/Iframe.astro';
+import Xref from '@components/Xref.astro';
+
+<Callout type="warning">
+    This rule has not been implemented in Package Validator, and is only available in the Chocolatey Community Validation extension.
+
+    Once it has been implemented in Package Validator, the severity or behavior may be changed in the Chocolatey Community Validation extension.
+</Callout>

--- a/src/content/docs/en-us/community-repository/moderation/package-validator/rules/cpmr0076.mdx
+++ b/src/content/docs/en-us/community-repository/moderation/package-validator/rules/cpmr0076.mdx
@@ -1,0 +1,29 @@
+---
+order: 76
+xref: cpmr0076
+title: CPMR0076 - Raw GitHub Icon URL Is Used (nuspec)
+description: Information on how to remediate the Chocolatey Package Moderation Rule 0076
+ruleType: Requirement
+---
+import Callout from '@choco/components/Callout.astro'
+import Iframe from '@choco/components/Iframe.astro';
+import Xref from '@components/Xref.astro';
+import PackageValidatorRuleRequirement from '@components/docs/PackageValidatorRuleRequirement.mdx';
+import PackageValidatorNotImplemented from '@components/docs/PackageValidatorNotImplemented.mdx';
+
+<PackageValidatorRuleRequirement />
+<PackageValidatorNotImplemented />
+
+## Issue
+
+In the nuspec, the Icon URL has been specified as coming from GitHub or RawGit.
+
+## Recommended Solution
+
+Please update the Icon URL to use an Icon that is coming from a proper CDN instead of GitHub or RawGit.
+There are CDN providers for GitHub links that can be used, like [JSDelivr](https://www.jsdelivr.com/) and [Statically](https://statically.io/).
+
+## Reasoning
+
+GitHub has made it clear that hotlinking to _raw_ files on GitHub should be avoided, as these are not static assets, and RawGit has shut down.
+See the [GitHub Blog](https://github.blog/2013-04-24-heads-up-nosniff-header-support-coming-to-chrome-and-firefox/) for more information.


### PR DESCRIPTION
## Description Of Changes

This adds the new rule for flagging Icon URLs that make use of GitHub or
RawGit URLs in the nuspec file.

This rule is not currently planned for Package Validator, but is useful
to have as it will be implemented in the Chocolatey Community Validator
extension.

## Motivation and Context

To document rules that are implemented in Chocolatey Community Validation extension, and considered for Package Validator.

## Testing

* [x] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made

* [ ] Minor documentation fix (typos etc.).
* [x] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist

* [ ] Requires a change to menu structure (top or left-hand side)/
* [ ] Menu structure has been updated

## Related Issue

- https://github.com/chocolatey/home/issues/16
- https://github.com/chocolatey-community/chocolatey-community-validation/issues/28