### PR TITLE
(doc) Fix typo in sn verification

### DIFF
--- a/src/content/docs/en-us/information/security.mdx
+++ b/src/content/docs/en-us/information/security.mdx
@@ -162,7 +162,7 @@ C:\Program Files (x86)\Microsoft Visual Studio 10.0\VC>sn -T c:\ProgramData\choc
 Microsoft (R) .NET Framework Strong Name Utility  Version 4.0.30319.1
 Copyright (c) Microsoft Corporation.  All rights reserved.
 
-Public key token is 7If 9d02ea9cad655eb
+Public key token is 79d02ea9cad655eb
 ```
 
 - Choco will warn if it is not signed with the right key (the FOSS project has a default key so that it can build appropriately) and require a user to pass `--allow-unofficial-build`. Over time we are going to increase this so that more places will restrict this (those a user can't just go change source of choco on and build).


### PR DESCRIPTION
## Description Of Changes

Remove errant `If` in the directions for verifying the strong naming of Chocolatey CLI

## Motivation and Context

Fixing a typo.

## Testing

* [ ] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made

* [x] Minor documentation fix (typos etc.).
* [ ] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist

* [ ] Requires a change to menu structure (top or left-hand side)/
* [ ] Menu structure has been updated

## Related Issue

N/A. This is a minor typo I found while looking at the Security page.
