### PR TITLE
(#1113) Deployment Plan Edit Page tabbed interface

### DIFF
--- a/src/content/docs/en-us/central-management/usage/website/administration/roles.mdx
+++ b/src/content/docs/en-us/central-management/usage/website/administration/roles.mdx
@@ -28,7 +28,7 @@ Next you'll want to click over to Permissions. This window will allow you to sel
 
 ![Creating New Role Setting Permissions](/images/ccm-playwright/administration/roles/modal-new-role-tab-permissions.png)
 
-Click 💾 **Save** to close the window and create the new role.
+Click **Save** to close the window and create the new role.
 
 ## Editing a Role
 

--- a/src/content/docs/en-us/central-management/usage/website/administration/users.mdx
+++ b/src/content/docs/en-us/central-management/usage/website/administration/users.mdx
@@ -32,7 +32,7 @@ Next you'll want to click over to `Roles`. This window will allow you to select 
 
 ![Creating New User Setting Roles](/images/ccm-playwright/administration/users/modal-new-user-tab-roles.png)
 
-Click 💾 **Save** to close the window and create the new User.
+Click **Save** to close the window and create the new User.
 A green toast notification will be shown once the operation completes successfully.
 
 ## Editing a User
@@ -48,12 +48,12 @@ Select the **Actions** button on the left-hand side of the User, and then select
 
 From the **Edit Role** window, you can modify all the properties for a User, for example, `First Name`, `Phone number`, etc. In addition, you can alter the <Xref title="Roles" value="ccm-administration-roles" /> associated with the User.
 
-Once modifications are complete, click the 💾 **Save** button.
+Once modifications are complete, click the **Save** button.
 A green toast notification will be shown once the operation completes successfully.
 
 ## Fine grained permissions
 
-In addition to configuring a set of Roles for an individual User, so can set speicial permissions for an individual User.
+In addition to configuring a set of Roles for an individual User, so can set special permissions for an individual User.
 
 On the main Users page, [find](#searching-for-a-user) the User you want to edit.
 Select the **Actions** button on the left-hand side of the User, and then select **Permission** to open the _Permissions_ window.
@@ -62,7 +62,7 @@ Select the **Actions** button on the left-hand side of the User, and then select
 
 From the tree of permissions, check/uncheck the permissions that are needed.
 
-Once modifications are complete, click the 💾 **Save** button.
+Once modifications are complete, click the **Save** button.
 A green toast notification will be shown once the operation completes successfully.
 
 ## Deleting a User

--- a/src/content/docs/en-us/central-management/usage/website/deployments.mdx
+++ b/src/content/docs/en-us/central-management/usage/website/deployments.mdx
@@ -32,11 +32,6 @@ You will also need to have at least one Group of computers already defined.
 
     ![Chocolatey Central Management Deployment Plans page, arrow pointing to Create New Deployment Plan button](/images/ccm-playwright/deployment-plans/button-create-new-deployment-plan.png)
 
-1. (Optional) Give the Deployment Plan a custom name by clicking the edit icon displayed next to it and entering a new name.
-   Press **Enter** to save the new name.
-
-    ![Chocolatey Central Management New Deployment Plan page, arrow pointing to the edit title button](/images/ccm-playwright/deployment-plans/edit/button-edit-name.png)
-
 1. (Optional, Requires Chocolatey Central Management v0.11.0+) Add a Deployment Plan execution timeout in seconds to be used by all Deployment Steps.
 
     ![Chocolatey Central Management New Deployment Plan page, arrow pointing to the Deployment Plan execution timeout in seconds setting](/images/ccm-playwright/deployment-plans/edit/input-execution-timeout-in-seconds.png)
@@ -45,23 +40,19 @@ You will also need to have at least one Group of computers already defined.
 
         ![Chocolatey Central Management Deployment Step modal, arrow pointing to execution timeout in seconds](/images/ccm-playwright/deployment-plans/edit/modal-step-input-execution-timeout-in-seconds.png)
 
-1. (Optional, Requires Chocolatey Central Management v0.4.0+) Add a schedule by selecting the ➕ **Add Schedule** button.
+1. (Optional, Requires Chocolatey Central Management v0.4.0+) Add a schedule by selecting the **Schedule** tab.
 
     ![Chocolatey Central Management New Deployment Plan page, arrow pointing to Add Schedule button](/images/ccm-playwright/deployment-plans/edit/button-add-schedule.png)
 
-    * Enter a date and time, or click the 📅 button to pick the date and time from a calendar UI.
+    * Click the calendar button to pick the Start Date Time from a calendar UI. If you'd like to define an optional maintenance window for the Deployment Plan Start Date Time, then you can also set a Last Start Date Time.
 
         ![Chocolatey Central Management Deployment Plan schedule picker](/images/ccm-playwright/deployment-plans/edit/calendar-start-date-time.png)
-
-    * (Optional) If you'd like to define a maintenance window for the Deployment Plan start time, select the **Restrict schedule to a maintenance window** option and enter the ending date and time for the maintenance window.
-
-       ![Chocolatey Central Management Deployment Plan maintenance window option](/images/ccm-playwright/deployment-plans/edit/checkbox-restrict-schedule.png)
 
     * (Optional) If you'd like a Deployment Plan to happen again, on a recurring basis, select how often you'd like the Deployment Plan to recur. Check the [recurring Deployment Plans section for more information](#recurring-deployments)
 
         ![Chocolatey Central Management Deployment Plan Repeat Period](/images/ccm-playwright/deployment-plans/edit/select-repeat-period.png)
 
-1. Select the **Add Step** button to add your first Deployment Step.
+1. Select the **Steps** tab and click the **Add Deployment Step** button to add your first Deployment Step.
 
     ![Chocolatey Central Management Deployment Plan add Deployment Step button](/images/ccm-playwright/deployment-plans/edit/button-add-deployment-step.png)
 
@@ -99,7 +90,7 @@ You will also need to have at least one Group of computers already defined.
 
     ![Chocolatey Central Management Deployment Step Select Target Groups modal](/images/ccm-playwright/deployment-plans/edit/modal-step-select-target-groups.png)
 
-1. Click the 💾 **Save** button to save the Deployment Step.
+1. Click the **Save** button to save the Deployment Step.
 
     ![Chocolatey Central Management Deployment Step Save button](/images/ccm-playwright/deployment-plans/edit/modal-step-button-save.png)
 
@@ -109,7 +100,7 @@ You will also need to have at least one Group of computers already defined.
 
     ![Chocolatey Central Management Deployment Step Duplicate button](/images/ccm-playwright/deployment-plans/edit/button-duplicate-step.png)
 
-1. Select 💾 **Save** to save the changes to the Deployment Plan.
+1. Select **Save** to save the changes to the Deployment Plan.
 
 <ImportDeploymentPlan />
 

--- a/src/content/docs/en-us/central-management/usage/website/groups.mdx
+++ b/src/content/docs/en-us/central-management/usage/website/groups.mdx
@@ -49,7 +49,7 @@ Then, select the Computer(s) or existing Group(s) you would like to include in t
 
 ![New Group Modal](/images/ccm-playwright/groups/modal-create-new-group.png)
 
-Click 💾 **Save** to close the modal and create the new Group.
+Click **Save** to close the modal and create the new Group.
 
 ## Editing a Group
 


### PR DESCRIPTION
## Description Of Changes
This updates wording primarily on the Deployment Plan Edit page to accommodate the new tabbed interface. The screenshots do not currently match the text, but this will be fixed at a later date.


## Motivation and Context
This is needed to reflect accessibility updates in Chocolatey Central Management.

## Testing

* [x] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made
* [x] Minor documentation fix (typos etc.).
* [ ] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist

* [ ] Requires a change to menu structure (top or left-hand side)/
* [ ] Menu structure has been updated

## Related Issue
* #1113 
* PROJ-934
* PROJ-914