### PR TITLE
(fix) Add Dockerfile git safe directory for/app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM node:lts
 WORKDIR /app
 
+RUN git config --global --add safe.directory /app
+
 COPY package.json yarn.lock ./
 
 COPY . .


### PR DESCRIPTION
## Description Of Changes
The docker container doesn't without marking the /app directory as safe.

## Motivation and Context
Added the git safe directory command to mark /app as safe. [Similar change went into blog](https://github.com/chocolatey/blog/pull/332).

## Testing

* [ ] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made

* [ ] Minor documentation fix (typos etc.).
* [ ] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist

* [ ] Requires a change to menu structure (top or left-hand side)/
* [ ] Menu structure has been updated

## Related Issue
N/A