### PR TITLE
(maint) Fix typos in advance client config documentation

### DIFF
--- a/src/content/docs/en-us/c4b-environments/quick-start-environment/advanced-client-configuration.mdx
+++ b/src/content/docs/en-us/c4b-environments/quick-start-environment/advanced-client-configuration.mdx
@@ -8,13 +8,13 @@ import Callout from '@choco/components/Callout.astro';
 import Iframe from '@choco/components/Iframe.astro';
 import Xref from '@components/Xref.astro';
 
-The minimum configuration for a Chocolatey for Business client installs, licenses, and configurations Chocolatey to work with the deployed repository solution and Chocolatey Central Management.
-While this opinionated approach is fine for most situations, flexibility is required for some organizations. This page provides examples of different scnenarios in which you wish to deploy Chocolatey in your organization.
+The minimum configuration for a Chocolatey for Business client installs, licenses, and configures Chocolatey to work with the deployed repository solution and Chocolatey Central Management.
+While this opinionated approach is fine for most situations, flexibility is required for some organizations. This page provides examples of different scenarios in which you wish to deploy Chocolatey in your organization.
 
 <Callout type="info">
     All examples require you to provide the credentials to connect to the repository installed during execution of the Quickstart Guide.
 
-    These credentials are found in the REAME file placed on the Desktop of the server during installation, or wherever you documented them if you changed them after installtion.
+    These credentials are found in the README file placed on the Desktop of the server during installation, or wherever you documented them if you changed them after installation.
 </Callout>
 ## Include Packaging Tools with installation
 


### PR DESCRIPTION


## Description Of Changes

Fix a few typos missed during PR review for advanced client config

## Motivation and Context

Typos are bad

## Testing

* [x] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made


* [x] Minor documentation fix (typos etc.).
* [ ] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist

* [ ] Requires a change to menu structure (top or left-hand side)/
* [ ] Menu structure has been updated

## Related Issue
