### PR TITLE
(doc) Add release notes for CLI, CLE and Agent

### DIFF
--- a/src/components/docs/ChocolateyComponentDependencies.mdx
+++ b/src/components/docs/ChocolateyComponentDependencies.mdx
@@ -13,14 +13,14 @@ Please refer to our <Xref title="Support Lifecycle information" value="chocolate
 
 | Package Name / Dependency      | chocolatey  | chocolatey.extension | chocolateygui |
 | ------------------------------ | ----------- | -------------------- | ------------- |
-| chocolatey v2.4.1              |             |                      |               |
-| chocolatey.extension v6.3.0    | v2.0.0      |                      |               |
-| chocolatey-agent v2.2.1        |             | v6.0.0               |               |
+| chocolatey v2.4.2              |             |                      |               |
+| chocolatey.extension v6.3.1    | v2.0.0      |                      |               |
+| chocolatey-agent v2.2.2        |             | v6.0.0               |               |
 | chocolateygui v2.1.1           | v2.0.0      |                      |               |
 | chocolateygui.extension v2.0.0 |             | v6.0.0               | v2.0.0        |
-| chocolatey v1.4.1              |             |                      |               |
-| chocolatey.extension v5.0.6    | v1.2.0      |                      |               |
-| chocolatey-agent v1.1.4        |             | v4.0.0               |               |
+| chocolatey v1.4.2              |             |                      |               |
+| chocolatey.extension v5.0.7    | v1.2.0      |                      |               |
+| chocolatey-agent v1.1.5        |             | v4.0.0               |               |
 | chocolateygui v1.1.3           | v1.0.0      |                      |               |
 | chocolateygui.extension v1.0.3 |             | v4.0.0               | v1.1.2        |
 

--- a/src/content/docs/en-us/agent/release-notes.mdx
+++ b/src/content/docs/en-us/agent/release-notes.mdx
@@ -35,11 +35,11 @@ This covers the release notes for the Chocolatey Agent Service (`chocolatey-agen
 
 <ChocolateyComponentDependenciesLink />
 
-## 2.2.2 (January 29, 2025) \{#v2.2.2}
+## 2.2.2 (January 30, 2025) \{#v2.2.2}
 
 ### Bug Fix
 
-- [Security] Fix - Prevent usage an option when running in Self-Service mode.
+- [Security] Fix - Prevent use of an option when running in Self-Service mode.
   - See the <Xref title="documentation" value="self-service-anywhere" anchor="background-service-restricted-options" />.
 
 ## 2.2.1 (December 9, 2024) \{#v2.2.1}
@@ -74,15 +74,9 @@ Read our [blog post](https://blog.chocolatey.org/2024/06/announcing-cli-230-cle-
 
 ### Bug Fix
 
-- [Security] Fix - Prevent usage of options when running in Self-Service mode.
+- [Security] Fix - Prevent use of options when running in Self-Service mode.
   - See the [documentation](https://docs.chocolatey.org/en-us/features/self-service-anywhere#background-service-restricted-options).
 
-## 1.1.5 (January 29, 2025) \{#v1.1.5}
-
-### Bug Fix
-
-- [Security] Fix - Prevent usage an option when running in Self-Service mode.
-  - See the <Xref title="documentation" value="self-service-anywhere" anchor="background-service-restricted-options" />.
 
 
 ## 1.1.4 (January 31, 2024) \{#january-31-2024}

--- a/src/content/docs/en-us/agent/release-notes.mdx
+++ b/src/content/docs/en-us/agent/release-notes.mdx
@@ -35,6 +35,13 @@ This covers the release notes for the Chocolatey Agent Service (`chocolatey-agen
 
 <ChocolateyComponentDependenciesLink />
 
+## 2.2.2 (January 29, 2025) \{#v2.2.2}
+
+### Bug Fix
+
+- [Security] Fix - Prevent usage an option when running in Self-Service mode.
+  - See the <Xref title="documentation" value="self-service-anywhere" anchor="background-service-restricted-options" />.
+
 ## 2.2.1 (December 9, 2024) \{#v2.2.1}
 
 ### Bug Fix
@@ -69,6 +76,13 @@ Read our [blog post](https://blog.chocolatey.org/2024/06/announcing-cli-230-cle-
 
 - [Security] Fix - Prevent usage of options when running in Self-Service mode.
   - See the [documentation](https://docs.chocolatey.org/en-us/features/self-service-anywhere#background-service-restricted-options).
+
+## 1.1.5 (January 29, 2025) \{#v1.1.5}
+
+### Bug Fix
+
+- [Security] Fix - Prevent usage an option when running in Self-Service mode.
+  - See the <Xref title="documentation" value="self-service-anywhere" anchor="background-service-restricted-options" />.
 
 
 ## 1.1.4 (January 31, 2024) \{#january-31-2024}

--- a/src/content/docs/en-us/choco/release-notes.mdx
+++ b/src/content/docs/en-us/choco/release-notes.mdx
@@ -24,7 +24,7 @@ This covers changes for the "chocolatey" and "chocolatey.lib" packages, which ar
 
 <ChocolateyComponentDependenciesLink />
 
-## 2.4.2 (Jan 29, 2025) \{#v2.4.2}
+## 2.4.2 (Jan 30, 2025) \{#v2.4.2}
 
 ### Bug Fix
 
@@ -35,8 +35,8 @@ This covers changes for the "chocolatey" and "chocolatey.lib" packages, which ar
 
 ### Bug Fixes
 
-- Fix - Searching for specific version on v3 only feed returns no results - see [#3396](https://github.com/chocolatey/choco/issues/3396).
-- Fix - Credentials from configured source used for a non-configured source when the URL is similar - see [#3565](https://github.com/chocolatey/choco/issues/3565).
+- Fix - Searching for specific version on a NuGet v3 only feed returns no results - see [#3396](https://github.com/chocolatey/choco/issues/3396).
+- Fix - Credentials from configured source are used for a non-configured source when the URL is similar - see [#3565](https://github.com/chocolatey/choco/issues/3565).
 
 
 ## 1.4.2 (Jan 29, 2025) \{#v1.4.2}

--- a/src/content/docs/en-us/choco/release-notes.mdx
+++ b/src/content/docs/en-us/choco/release-notes.mdx
@@ -24,12 +24,27 @@ This covers changes for the "chocolatey" and "chocolatey.lib" packages, which ar
 
 <ChocolateyComponentDependenciesLink />
 
+## 2.4.2 (Jan 29, 2025) \{#v2.4.2}
+
+### Bug Fix
+
+- [Security] Fix - Trace logging is allowed in non-elevated session - see [#3604](https://github.com/chocolatey/choco/issues/3604).
+
+
 ## 2.4.1 (Dec 4, 2024) \{#v2.4.1}
 
 ### Bug Fixes
 
 - Fix - Searching for specific version on v3 only feed returns no results - see [#3396](https://github.com/chocolatey/choco/issues/3396).
 - Fix - Credentials from configured source used for a non-configured source when the URL is similar - see [#3565](https://github.com/chocolatey/choco/issues/3565).
+
+
+## 1.4.2 (Jan 29, 2025) \{#v1.4.2}
+
+### Bug Fix
+
+- [Security] Fix - Trace logging is allowed in non-elevated session - see [#3603](https://github.com/chocolatey/choco/issues/3603).
+
 
 ## 1.4.1 (Dec 4, 2024) \{#v1.4.1}
 

--- a/src/content/docs/en-us/features/self-service-anywhere.mdx
+++ b/src/content/docs/en-us/features/self-service-anywhere.mdx
@@ -79,6 +79,8 @@ Chocolatey CLI allows a number of different options that can be used to configur
   * `--virus-positives-minimum`
 * Added in Chocolatey Agent 2.1.3 and Chocolatey Licensed Extension 6.2.0:
   * `--ignore-pinned`
+* Added in Chocolatey Agent 1.1.5 / 2.2.2 and Chocolatey Licensed Extension 5.0.7 / 6.3.1:
+  * `--trace`
 
 ### See It In Action
 

--- a/src/content/docs/en-us/licensed-extension/release-notes.mdx
+++ b/src/content/docs/en-us/licensed-extension/release-notes.mdx
@@ -45,11 +45,11 @@ Please see <Xref title="Install the Licensed Edition" value="setup-licensed" /> 
 
 <ChocolateyComponentDependenciesLink />
 
-## 6.3.1 (Jan 29, 2025) \{v6.3.1}
+## 6.3.1 (Jan 30, 2025) \{v6.3.1}
 
 ### Bug Fix
 
-- [Security] Fix - Prevent usage an option when running in Self-Service mode.
+- [Security] Fix - Prevent use of an option when running in Self-Service mode.
   - See the <Xref title="documentation" value="self-service-anywhere" anchor="background-service-restricted-options" />.
 
 
@@ -96,7 +96,7 @@ Please see <Xref title="Install the Licensed Edition" value="setup-licensed" /> 
 
 ### Bug Fix
 
-- [Security] Fix - Prevent usage an option when running in Self-Service mode.
+- [Security] Fix - Prevent use of an option when running in Self-Service mode.
   - See the <Xref title="documentation" value="self-service-anywhere" anchor="background-service-restricted-options" />.
 
 

--- a/src/content/docs/en-us/licensed-extension/release-notes.mdx
+++ b/src/content/docs/en-us/licensed-extension/release-notes.mdx
@@ -45,6 +45,14 @@ Please see <Xref title="Install the Licensed Edition" value="setup-licensed" /> 
 
 <ChocolateyComponentDependenciesLink />
 
+## 6.3.1 (Jan 29, 2025) \{v6.3.1}
+
+### Bug Fix
+
+- [Security] Fix - Prevent usage an option when running in Self-Service mode.
+  - See the <Xref title="documentation" value="self-service-anywhere" anchor="background-service-restricted-options" />.
+
+
 ## 6.3.0 (Dec 4, 2024) \{#v6.3.0}
 
 ### Bug Fixes
@@ -83,6 +91,14 @@ Please see <Xref title="Install the Licensed Edition" value="setup-licensed" /> 
 </Callout>
 
 - Fix - An unsupported argument is passed to the Chocolatey Agent when using the API - see [licensed #380](https://github.com/chocolatey/chocolatey-licensed-issues/issues/380).
+
+## 5.0.7 (Jan 29, 2025) \{v5.0.7}
+
+### Bug Fix
+
+- [Security] Fix - Prevent usage an option when running in Self-Service mode.
+  - See the <Xref title="documentation" value="self-service-anywhere" anchor="background-service-restricted-options" />.
+
 
 ## 5.0.6 (February 21, 2024) \{#v5.0.6}
 


### PR DESCRIPTION
## Description Of Changes

This updates the release notes section for Chocolatey CLI, Chocolatey Licensed Extension and Chocolatey Agent to include the changes that has gone into the v2.4.2, v1.4.2, v6.3.1, v5.0.7, v2.2.2, and v1.1.5 versions.

## Motivation and Context

As part of a combined release to address an issue with the --trace option across all Chocolatey products, this commit updates the release notes for all 6 products.

## Testing

* [x] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made

* [ ] Minor documentation fix (typos etc.).
* [x] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist

* [ ] Requires a change to menu structure (top or left-hand side)/
* [ ] Menu structure has been updated

## Related Issue

N/A