### PR TITLE
(doc) Add release notes for CLI, CLE and Agent

### DIFF
--- a/src/components/docs/ChocolateyComponentDependencies.mdx
+++ b/src/components/docs/ChocolateyComponentDependencies.mdx
@@ -13,9 +13,9 @@ Please refer to our <Xref title="Support Lifecycle information" value="chocolate
 
 | Package Name / Dependency      | chocolatey  | chocolatey.extension | chocolateygui |
 | ------------------------------ | ----------- | -------------------- | ------------- |
-| chocolatey v2.4.1              |             |                      |               |
-| chocolatey.extension v6.3.0    | v2.0.0      |                      |               |
-| chocolatey-agent v2.2.1        |             | v6.0.0               |               |
+| chocolatey v2.4.2              |             |                      |               |
+| chocolatey.extension v6.3.1    | v2.0.0      |                      |               |
+| chocolatey-agent v2.2.2        |             | v6.0.0               |               |
 | chocolateygui v2.1.1           | v2.0.0      |                      |               |
 | chocolateygui.extension v2.0.0 |             | v6.0.0               | v2.0.0        |
 | chocolatey v1.4.1              |             |                      |               |

--- a/src/content/docs/en-us/agent/release-notes.mdx
+++ b/src/content/docs/en-us/agent/release-notes.mdx
@@ -35,6 +35,14 @@ This covers the release notes for the Chocolatey Agent Service (`chocolatey-agen
 
 <ChocolateyComponentDependenciesLink />
 
+## 2.2.2 (January 31, 2025) \{#v2.2.2}
+
+### Bug Fix
+
+- [Security] Fix - Prevent use of an option when running in Self-Service mode.
+  - See the <Xref title="documentation" value="self-service-anywhere" anchor="background-service-restricted-options" />.
+
+
 ## 2.2.1 (December 9, 2024) \{#v2.2.1}
 
 ### Bug Fix
@@ -67,7 +75,7 @@ Read our [blog post](https://blog.chocolatey.org/2024/06/announcing-cli-230-cle-
 
 ### Bug Fix
 
-- [Security] Fix - Prevent usage of options when running in Self-Service mode.
+- [Security] Fix - Prevent use of options when running in Self-Service mode.
   - See the [documentation](https://docs.chocolatey.org/en-us/features/self-service-anywhere#background-service-restricted-options).
 
 

--- a/src/content/docs/en-us/choco/release-notes.mdx
+++ b/src/content/docs/en-us/choco/release-notes.mdx
@@ -24,12 +24,19 @@ This covers changes for the "chocolatey" and "chocolatey.lib" packages, which ar
 
 <ChocolateyComponentDependenciesLink />
 
+## 2.4.2 (January 31, 2025) \{#v2.4.2}
+
+### Bug Fix
+
+- [Security] Fix - Trace logging is allowed in non-elevated session - see [#3604](https://github.com/chocolatey/choco/issues/3604).
+
+
 ## 2.4.1 (Dec 4, 2024) \{#v2.4.1}
 
 ### Bug Fixes
 
-- Fix - Searching for specific version on v3 only feed returns no results - see [#3396](https://github.com/chocolatey/choco/issues/3396).
-- Fix - Credentials from configured source used for a non-configured source when the URL is similar - see [#3565](https://github.com/chocolatey/choco/issues/3565).
+- Fix - Searching for specific version on a NuGet v3 only feed returns no results - see [#3396](https://github.com/chocolatey/choco/issues/3396).
+- Fix - Credentials from configured source are used for a non-configured source when the URL is similar - see [#3565](https://github.com/chocolatey/choco/issues/3565).
 
 ## 1.4.1 (Dec 4, 2024) \{#v1.4.1}
 

--- a/src/content/docs/en-us/choco/release-notes.mdx
+++ b/src/content/docs/en-us/choco/release-notes.mdx
@@ -31,20 +31,20 @@ This covers changes for the "chocolatey" and "chocolatey.lib" packages, which ar
 - [Security] Fix - Trace logging is allowed in non-elevated session - see [#3604](https://github.com/chocolatey/choco/issues/3604).
 
 
-## 2.4.1 (Dec 4, 2024) \{#v2.4.1}
+## 2.4.1 (December 4, 2024) \{#v2.4.1}
 
 ### Bug Fixes
 
 - Fix - Searching for specific version on a NuGet v3 only feed returns no results - see [#3396](https://github.com/chocolatey/choco/issues/3396).
 - Fix - Credentials from configured source are used for a non-configured source when the URL is similar - see [#3565](https://github.com/chocolatey/choco/issues/3565).
 
-## 1.4.1 (Dec 4, 2024) \{#v1.4.1}
+## 1.4.1 (December 4, 2024) \{#v1.4.1}
 
 ### Bug Fix
 
 - Fix - Credentials from configured source used for a non-configured source when the URL is similar - see [#3566](https://github.com/chocolatey/choco/issues/3566).
 
-## 2.4.0 (Nov 12, 2024) \{#v2.4.0}
+## 2.4.0 (November 12, 2024) \{#v2.4.0}
 
 ### Deprecated Feature
 

--- a/src/content/docs/en-us/features/self-service-anywhere.mdx
+++ b/src/content/docs/en-us/features/self-service-anywhere.mdx
@@ -79,6 +79,8 @@ Chocolatey CLI allows a number of different options that can be used to configur
   * `--virus-positives-minimum`
 * Added in Chocolatey Agent 2.1.3 and Chocolatey Licensed Extension 6.2.0:
   * `--ignore-pinned`
+* Added in Chocolatey Agent 2.2.2 and Chocolatey Licensed Extension 6.3.1:
+  * `--trace`
 
 ### See It In Action
 

--- a/src/content/docs/en-us/licensed-extension/release-notes.mdx
+++ b/src/content/docs/en-us/licensed-extension/release-notes.mdx
@@ -45,6 +45,14 @@ Please see <Xref title="Install the Licensed Edition" value="setup-licensed" /> 
 
 <ChocolateyComponentDependenciesLink />
 
+## 6.3.1 (January 31, 2025) \{v6.3.1}
+
+### Bug Fix
+
+- [Security] Fix - Prevent use of an option when running in Self-Service mode.
+  - See the <Xref title="documentation" value="self-service-anywhere" anchor="background-service-restricted-options" />.
+
+
 ## 6.3.0 (Dec 4, 2024) \{#v6.3.0}
 
 ### Bug Fixes

--- a/src/content/docs/en-us/licensed-extension/release-notes.mdx
+++ b/src/content/docs/en-us/licensed-extension/release-notes.mdx
@@ -53,7 +53,7 @@ Please see <Xref title="Install the Licensed Edition" value="setup-licensed" /> 
   - See the <Xref title="documentation" value="self-service-anywhere" anchor="background-service-restricted-options" />.
 
 
-## 6.3.0 (Dec 4, 2024) \{#v6.3.0}
+## 6.3.0 (December 4, 2024) \{#v6.3.0}
 
 ### Bug Fixes
 
@@ -1241,7 +1241,7 @@ Pro users now have the ability to download packages (minus internalization). Thi
 - Package Synchronizer:
   -Synchronize to a new location per package version.
 
-## 1.7.0 (Sep 22, 2016) \{#sep-22-2016}
+## 1.7.0 (September 22, 2016) \{#sep-22-2016}
 
 ### Bug Fixes
 
@@ -1262,13 +1262,13 @@ Pro users now have the ability to download packages (minus internalization). Thi
   - Warn of issue with `-UseOriginalLocation` when only using one file.
   - Add `--append-useoriginallocation` and feature internalizeAppendUseOriginalLocation that makes the determination to add to the end of `Install-ChocolateyPackage` when using local resources.
 
-## 1.6.3 (Sep 20, 2016) \{#sep-20-2016}
+## 1.6.3 (September 20, 2016) \{#sep-20-2016}
 
 ### Bug Fix
 
 - Require Chocolatey be upgraded to at least 0.10.1 due to internal incompatibilities that affect this extension.
 
-## 1.6.2 (Sep 19, 2016 - pulled) \{#sep-19-2016 - pulled}
+## 1.6.2 (September 19, 2016 - pulled) \{#sep-19-2016 - pulled}
 
 ### Bug Fix
 
@@ -1279,7 +1279,7 @@ Pro users now have the ability to download packages (minus internalization). Thi
 - Install/upgrade - support MSP (patch files).
 - PackageBuilder - support MSU/MSP files.
 
-## 1.6.1 (Sep 8, 2016) \{#sep-8-2016}
+## 1.6.1 (September 8, 2016) \{#sep-8-2016}
 
 ### Bug Fixes
 
@@ -1287,7 +1287,7 @@ Pro users now have the ability to download packages (minus internalization). Thi
   - Fix - Do not error on missing appsearch table in MSI.
   - Fix - Do not add similarly named items from AppSearch table to template properties more than once.
 
-## 1.6.0 (Sep 8, 2016) \{#sep-8-2016}
+## 1.6.0 (September 8, 2016) \{#sep-8-2016}
 
 Some really big improvements are now available in v1.6.0. We are excited to share them with you!
 
@@ -1330,7 +1330,7 @@ Some really big improvements are now available in v1.6.0. We are excited to shar
   - handle variables in urls set like `${word}`.
   - Append `-UseOriginalLocation` to the end of the arguments passed to `Install-ChocolateyPackage`. Work with splatting properly as well.
 
-## 1.5.1 (Aug 9, 2016) \{#aug-9-2016}
+## 1.5.1 (August 9, 2016) \{#aug-9-2016}
 
 ### Bug Fix
 


### PR DESCRIPTION
## Description Of Changes

This updates the release notes section for Chocolatey CLI, Chocolatey Licensed Extension and Chocolatey Agent to include the changes that has gone into the v2.4.2, v1.4.2, v6.3.1, v5.0.7, v2.2.2, and v1.1.5 versions.

## Motivation and Context

As part of a combined release to address an issue with the --trace option across all Chocolatey products, this commit updates the release notes for all 6 products.

## Testing

* [x] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made

* [ ] Minor documentation fix (typos etc.).
* [x] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist

* [ ] Requires a change to menu structure (top or left-hand side)/
* [ ] Menu structure has been updated

## Related Issue

N/A