### PR TITLE
(doc) Remove outdated warning on rule 52

### DIFF
--- a/src/content/docs/en-us/community-repository/moderation/package-validator/rules/cpmr0052.mdx
+++ b/src/content/docs/en-us/community-repository/moderation/package-validator/rules/cpmr0052.mdx
@@ -12,10 +12,6 @@ import PackageValidatorRuleGuideline from '@components/docs/PackageValidatorRule
 
 <PackageValidatorRuleGuideline />
 
-<Callout type="warning">
-    There is a bug with this check - https://github.com/chocolatey/home/issues/33
-</Callout>
-
 If you have implemented the recommended fixes, you should see this go away on checks after this has been corrected.
 
 ## Issue


### PR DESCRIPTION
## Description Of Changes

This removes the outdated warning about there being a bug in the validation of the dependencies.

This had been fixed a while ago, but the warning was never removed.

## Motivation and Context

The warning is no longer valid, and should not be in the documentation.

## Testing

* [x] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [x] Minor documentation fix (typos etc.).
* [ ] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist

* [ ] Requires a change to menu structure (top or left-hand side)/
* [ ] Menu structure has been updated

## Related Issue

N/A