### PR TITLE
(#1038) Update icons to buttons in the documentation

### DIFF
--- a/src/content/docs/en-us/central-management/usage/website/deployments.mdx
+++ b/src/content/docs/en-us/central-management/usage/website/deployments.mdx
@@ -118,7 +118,7 @@ As mentioned above, when creating a Deployment Plan, it is possible to select a 
 - `Every six months`
 - `Yearly`
 
-Once a Deployment Plan has been assigned a Repeat Period, and it is moved to the [Ready](#ready) state, it will be shown with a slightly different icon:
+Once a Deployment Plan has been assigned a Repeat Period, and it is moved to the [Ready](#ready) state, it will be shown with a slightly different button:
 
 ![Chocolatey Central Management Deployment Plan marked as recurring](/images/ccm-playwright/deployment-plans/table-row-icon-recurring-deployment-plan.png)
 

--- a/src/content/docs/en-us/central-management/usage/website/groups.mdx
+++ b/src/content/docs/en-us/central-management/usage/website/groups.mdx
@@ -23,7 +23,7 @@ If you do not see this menu entry, verify with your administrator whether your g
     This feature is available in Chocolatey Central Management starting with version 0.11.0.
 </Callout>
 
-All Computers present in Chocolatey Central Management are automatically added to a System Managed Group named `All Computers (Automatic Group)`. This Group can not be edited or deleted. It will have a blue lock icon next to the name in the table. Hovering over this lock icon will display a tooltip with more information.
+All Computers present in Chocolatey Central Management are automatically added to a System Managed Group named `All Computers (Automatic Group)`. This Group can not be edited or deleted. It will have a **System Managed** button next to the name in the table. Clicking this button will display a tooltip with more information.
 
 ![The All Computers (Automatic Group) on the Groups page with an arrow pointing to the Group in the table](/images/ccm-playwright/groups/table-row-icon-automatic-group-lock.png)
 


### PR DESCRIPTION


## Description Of Changes
Update any reference to icons in tables that trigger popovers that have been replaced with buttons in the documentation.

## Motivation and Context
This is needed so the documentation is updated with the new buttons instead of the icons.

## Testing

* [x] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made

* [x] Minor documentation fix (typos etc.).
* [ ] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist

* [ ] Requires a change to menu structure (top or left-hand side)/
* [ ] Menu structure has been updated

## Related Issue

Fixes #

