### PR TITLE
(maint) Remove additional callout from install command

### DIFF
--- a/src/content/docs/en-us/choco/commands/install.mdx
+++ b/src/content/docs/en-us/choco/commands/install.mdx
@@ -62,14 +62,6 @@ Installs a package or a list of packages (sometimes specified as a
     choco install <path/to/nupkg>
 ~~~
 
-
-> :choco-info: **NOTE**
->
-> `all` is a special package keyword that will allow you to install
- all packages available on a source. This keyword is not available for
- public repositories like the Chocolatey [Community Repository](https://community.chocolatey.org/packages), and is
- intended to  be used with internal package sources only.
-
 > :choco-info: **NOTE**
 >
 > `all` is a special package keyword that will allow you to install


### PR DESCRIPTION
Removed the additional callout for the `all` special keyword