### PR TITLE
(fix) Correct link and xref syntax on software-vendor page

### DIFF
--- a/src/content/docs/en-us/community-repository/users/software-vendor.mdx
+++ b/src/content/docs/en-us/community-repository/users/software-vendor.mdx
@@ -16,7 +16,7 @@ See the <Xref title="FAQ question" value="ccr-faq" anchor="how-do-i-inspect-the-
 
 ## Does a Chocolatey Community Repository Package Violate Distribution Rights If It Installs My Software?
 
-In most cases, no. Most packages you will find on the <Xref title="Chocolatey Community Repository](https://community.chocolatey.org/packages) use automation scripts to download the software from the [official distribution point" value="legal" anchor="distributions" />.
+In most cases, no. Most packages you will find on the [Chocolatey Community Repository](https://community.chocolatey.org/packages) use automation scripts to download the software from the <Xref title="official distribution point" value="legal" anchor="distributions" />.
 
 If you visit the package page you can view the <Xref title="files included with the package, or download the actual package, to inspect its contents" value="ccr-faq" anchor="how-do-i-inspect-the-contents-of-a-chocolatey-package" />.
 


### PR DESCRIPTION
## Description Of Changes
Fixes the syntax of a markdown link and an Xref link on the software-vendor page.

## Motivation and Context
It looks like this combination of the two different types of links didn't smoothly convert when moving to Astro.

## Testing

* [x] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

Prior to change:
![pre-change](https://github.com/user-attachments/assets/23ea3cc3-be2b-41c7-a5b4-9f0d9bb45f33)

After change:
![post-change](https://github.com/user-attachments/assets/ad76a409-f751-44c6-b097-c1e1e4d53925)

## Change Types Made

* [x] Minor documentation fix (typos etc.).
* [ ] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist

* [ ] Requires a change to menu structure (top or left-hand side)/
* [ ] Menu structure has been updated

## Related Issue

N/A
