### PR TITLE
(docs) Add Windows Server 2025 support dates

### DIFF
--- a/src/content/docs/en-us/chocolatey-components-dependencies-and-support-lifecycle.mdx
+++ b/src/content/docs/en-us/chocolatey-components-dependencies-and-support-lifecycle.mdx
@@ -39,11 +39,12 @@ Once a product reaches the second major release, the following will apply:
 Chocolatey products' support for Windows Operating Systems follows Microsoft's Support Lifecycle: if the Windows version is supported by Microsoft, Chocolatey products are supported on that version of Windows.
 
 <Callout type="info">
-   This information is up-to-date as of 16 January 2025
+   This information is up-to-date as of 6 May 2025
 </Callout>
 
 | Windows Server Operating System                                                                                              | End Of Support    |
 |------------------------------------------------------------------------------------------------------------------------------|-------------------|
+| [Windows Server 2025](https://learn.microsoft.com/en-us/lifecycle/products/windows-server-2025)                              | 10 October 2034   |
 | [Windows Server 2022](https://learn.microsoft.com/en-us/lifecycle/products/windows-server-2022)                              | 14 October 2031   |
 | [Windows Server 2019](https://learn.microsoft.com/en-us/lifecycle/products/windows-server-2019)                              | 9 January 2029    |
 | [Windows Server 2016](https://learn.microsoft.com/en-us/lifecycle/products/windows-server-2016)                              | 12 January 2027   |


### PR DESCRIPTION
## Description Of Changes
Add Windows Server 2025 lifecycle support dates.

## Motivation and Context
It was missing from our documentation.

## Testing

* [x] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made

* [x] Minor documentation fix (typos etc.).
* [ ] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist

* [ ] Requires a change to menu structure (top or left-hand side)/
* [ ] Menu structure has been updated

## Related Issue
N/A