### PR TITLE
(docs) Add Jenkins port to Firewall Rules

### DIFF
--- a/src/content/docs/en-us/c4b-environments/quick-start-environment/firewall-rules.mdx
+++ b/src/content/docs/en-us/c4b-environments/quick-start-environment/firewall-rules.mdx
@@ -30,6 +30,7 @@ These are the ports that are already opened on Windows Firewall in the Quick Sta
 
 | Port  | Application   |
 | :---: | :------------ |
+| 7443  | Jenkins Web UI |
 | 8443  | Nexus Web UI  |
 |  443  | Chocolatey Central Management Dashboard |
 | 24020 | Chocolatey Central Management Service   |


### PR DESCRIPTION
We now ship Jenkins secured with a default port of 7443. This commit adds that information to the table on the Firewall Rules page of the C4B Quick Start Environment documentation.

## Description Of Changes
Added a table entry for the Jenkins port that we default to in Quick Start Guide setup.

## Motivation and Context
We received a ticket about the required ports and this addition to the documentation had not been made yet.

## Testing

* [X] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made

* [X] Minor documentation fix (typos etc.).
* [ ] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #
