### PR TITLE
(doc) Add new features shipping in CLI 2.5.0

### DIFF
--- a/src/content/docs/en-us/configuration.mdx
+++ b/src/content/docs/en-us/configuration.mdx
@@ -103,6 +103,7 @@ A checkbox means this feature is turned on by default.
 * [x] `showDownloadProgress` - Show Download Progress - Show download progress percentages in the CLI.
 * [ ] `useRememberedArgumentsForUpgrades` - Use Remembered Arguments For Upgrades - when running upgrades, use arguments for upgrade that were used for installation ('remembered'). This is helpful when running upgrade for all packages. This is considered in preview and will be flipped to on by default in a future release.
 * [ ] `logValidationResultsOnWarnings` - Log validation results on warnings - Should the validation results be logged if there are warnings?
+* [ ] `alwaysIncludeHeaders` - Include header names when --limit-output is used. Requires Chocolatey CLI 2.5.0+
 
 ### Automatic Uninstaller
 
@@ -123,6 +124,7 @@ A checkbox means this feature is turned on by default.
 * [ ] `skipPackageUpgradesWhenNotInstalled` - Skip Packages Not Installed During Upgrade - if a package is not installed, do not install it during the upgrade process.
 * [ ] `ignoreUnfoundPackagesOnUpgradeOutdated` - Ignore Unfound Packages On Upgrade Outdated - When checking outdated or upgrades, if a package is not found against sources specified, don't report the package at all.
 * [x] `usePackageRepositoryOptimizations` - Turn on optimizations for reducing bandwidth with repository queries during package install/upgrade/outdated operations. Should generally be left enabled, unless a repository needs to support older methods of query. When disabled, this makes queries similar to the way they were done in Chocolatey v0.10.11 and before.
+* [x] `useHttpCache` - Create and use HTTP caches when querying sources. Available in 2.5.0+
 
 ### Security
 


### PR DESCRIPTION
## Description Of Changes

This commit adds information about the two new features that are shipping as part of Chocolatey CLI 2.5.0, namely:

- alwaysIncludeHeaders
- useHttpCache

## Motivation and Context

These new features are shipping in the next release, and they need to be documented.

## Testing

* [x] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made

* [ ] Minor documentation fix (typos etc.).
* [x] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist

* [ ] Requires a change to menu structure (top or left-hand side)/
* [ ] Menu structure has been updated

## Related Issue

N/A - part of the overall 2.5.0 release