### PR TITLE
(maint) Re-ordered release notes

### DIFF
--- a/src/content/docs/en-us/agent/release-notes.mdx
+++ b/src/content/docs/en-us/agent/release-notes.mdx
@@ -85,30 +85,8 @@ Read our [blog post](https://blog.chocolatey.org/2024/06/announcing-cli-230-cle-
 - [Security] Fix - Prevent use of options when running in Self-Service mode.
   - See the [documentation](https://docs.chocolatey.org/en-us/features/self-service-anywhere#background-service-restricted-options).
 
-## 1.1.5 (February 10, 2025) \{#v1.1.5}
-
-### Bug Fix
-
-- [Security] Fix - Prevent use of an option when running in Self-Service mode.
-  - See the <Xref title="documentation" value="self-service-anywhere" anchor="background-service-restricted-options" />.
-
-## 1.1.4 (January 31, 2024) \{#january-31-2024}
-
-### Bug Fix
-
-- [Security] Fix - Prevent usage of options when running in Self-Service mode.
-  - See the [documentation](https://docs.chocolatey.org/en-us/features/self-service-anywhere#background-service-restricted-options).
-
 
 ## 2.1.1 (December 19, 2023) \{#december-19-2023}
-
-### Bug Fix
-
-- [Security] Fix - Prevent usage of options when running in Self-Service mode.
-  - See the [documentation](https://docs.chocolatey.org/en-us/features/self-service-anywhere#background-service-restricted-options).
-
-
-## 1.1.3 (December 19, 2023) \{#december-19-2023}
 
 ### Bug Fix
 
@@ -150,13 +128,6 @@ Read our [blog post](https://blog.chocolatey.org/2024/06/announcing-cli-230-cle-
 
 - Update to use latest releases of Chocolatey products.
 - Migrate from Rx-* packages to System.Reactive.* packages.
-
-
-## 1.1.2 (May 10, 2023) \{#may-10-2023}
-
-### Bug Fix
-
-- Fix - Update version ranges in nuspec file to use maximum inclusive rather than maximum exclusive.
 
 
 ## 2.0.0-beta-20230426 (April 26, 2023)
@@ -238,6 +209,36 @@ See this [list](https://github.com/chocolatey/choco/discussions/2995) for known 
 
 - Upgrade to target version 4.8 of the .NET Framework.
 - Upgrade to target version 2.0.0 of Chocolatey.Lib and version 6.0.0 of Chocolatey.Licensed.Lib assemblies.
+
+
+## 1.1.5 (February 10, 2025) \{#v1.1.5}
+
+### Bug Fix
+
+- [Security] Fix - Prevent use of an option when running in Self-Service mode.
+  - See the <Xref title="documentation" value="self-service-anywhere" anchor="background-service-restricted-options" />.
+
+## 1.1.4 (January 31, 2024) \{#january-31-2024}
+
+### Bug Fix
+
+- [Security] Fix - Prevent usage of options when running in Self-Service mode.
+  - See the [documentation](https://docs.chocolatey.org/en-us/features/self-service-anywhere#background-service-restricted-options).
+
+
+## 1.1.3 (December 19, 2023) \{#december-19-2023}
+
+### Bug Fix
+
+- [Security] Fix - Prevent usage of options when running in Self-Service mode.
+  - See the [documentation](https://docs.chocolatey.org/en-us/features/self-service-anywhere#background-service-restricted-options).
+
+
+## 1.1.2 (May 10, 2023) \{#may-10-2023}
+
+### Bug Fix
+
+- Fix - Update version ranges in nuspec file to use maximum inclusive rather than maximum exclusive.
 
 
 ## 1.1.1 (October 12, 2022) \{#october-12-2022}

--- a/src/content/docs/en-us/choco/release-notes.mdx
+++ b/src/content/docs/en-us/choco/release-notes.mdx
@@ -43,20 +43,6 @@ This covers changes for the "chocolatey" and "chocolatey.lib" packages, which ar
 <a href="https://github.com/LordAro"><img src="https://avatars.githubusercontent.com/u/4007992?v=4" alt="LordAro" height="32" width="32"/></a> <a href="https://github.com/nagten"><img src="https://avatars.githubusercontent.com/u/68544113?v=4" alt="nagten" height="32" width="32"/></a> <a href="https://github.com/gep13"><img src="https://avatars.githubusercontent.com/u/1271146?u=abe1c7adac9206392a54628dd0332850241ba90d&v=4" alt="gep13" height="32" width="32"/></a> 
 
 
-## 1.4.4 (September 3, 2025) \{#v1.4.4}
-
-### Dependency Change
-
-- [Security] Update bundled 7zip executables to v25.01.
-  - See [__#3779__](https://github.com/chocolatey/choco/issues/3779) by [gep13](https://github.com/gep13) resolved in [__!3780__](https://github.com/chocolatey/choco/pull/3780) by [gep13](https://github.com/gep13).
-
-### Contributors
-
-1 contributors made this release possible.
-
-<a href="https://github.com/gep13"><img src="https://avatars.githubusercontent.com/u/1271146?v=4" alt="gep13" height="32" width="32"/></a>
-
-
 ## 2.5.0 (July 9, 2025) \{#v2.5.0}
 
 <Callout type="info">
@@ -154,29 +140,6 @@ Read our [blog post](https://blog.chocolatey.org/2025/07/chocolatey-cli-250-high
 - Fix - Searching for specific version on a NuGet v3 only feed returns no results - see [#3396](https://github.com/chocolatey/choco/issues/3396).
 - Fix - Credentials from configured source are used for a non-configured source when the URL is similar - see [#3565](https://github.com/chocolatey/choco/issues/3565).
 
-## 1.4.3 (February 10, 2025) \{#v1.4.3}
-
-### Bug Fixes
-
-- Fix - Unable to upgrade packages on certain authenticated feeds - see [#3613](https://github.com/chocolatey/choco/issues/3613).
-- Fix - Trace warning is outputted even when `--trace` argument is not used - see [#3621](https://github.com/chocolatey/choco/issues/3621).
-- [Security] Fix - Update bundled 7zip executables to v24.09 - see [#3625](https://github.com/chocolatey/choco/issues/3625).
-
-## 1.4.2 (Unreleased) \{#v1.4.2}
-
-<Callout type="info">
-    Due to a previous bug in 1.4.1, which has been corrected in Chocolatey CLI v1.4.3, the artifacts from the 1.4.2 release have been removed.
-</Callout>
-
-### Bug Fix
-
-- [Security] Fix - Trace logging is allowed in non-elevated session - see [#3603](https://github.com/chocolatey/choco/issues/3603).
-
-## 1.4.1 (December 4, 2024) \{#v1.4.1}
-
-### Bug Fix
-
-- Fix - Credentials from configured source used for a non-configured source when the URL is similar - see [#3566](https://github.com/chocolatey/choco/issues/3566).
 
 ## 2.4.0 (November 12, 2024) \{#v2.4.0}
 
@@ -467,17 +430,6 @@ A fix has been found for this problem, and will be released in a future alpha re
 - Sort list of installed/upgraded packages - see [#3112](https://github.com/chocolatey/choco/issues/3112).
 
 
-## 1.4.0 (May 10, 2023) \{#may-10-2023}
-
-### Bug Fix
-
-- Fix - When no hook scripts are installed you cannot install/upgrade a package on a system using PowerShell 2 - see [#3088](https://github.com/chocolatey/choco/issues/3088).
-
-### Improvement
-
-- Ensure the most recent version of Chocolatey-NuGet.Core package is being used - see [#3150](https://github.com/chocolatey/choco/issues/3150).
-
-
 ## 2.0.0-beta-20230426 (April 26, 2023)
 
 <Callout type="warning">
@@ -587,12 +539,6 @@ In addition to the breaking changes listed in the previous [alpha release](#alph
 - Remove re-instated Chocolatey commands which were added in v1.0.1 - see [#2678](https://github.com/chocolatey/choco/issues/2678).
 
 
-## 1.3.1 (March 14, 2023) \{#march-14-2023}
-
-### Bug Fix
-
-- Fix - `chocolateyBeforeModify.ps1` does not get called for dependent packages - see [#1092](https://github.com/chocolatey/choco/issues/1092).
-
 ## 2.0.0-alpha-20230307 (March 7, 2023) \{#alpha-20230307-march-7-2023}
 
 <Callout type="warning">
@@ -656,20 +602,6 @@ In addition to the breaking changes listed in the previous [alpha release](#alph
 - Fix typos and spelling errors - see [2990](https://github.com/chocolatey/choco/pull/2990).
 
 
-## [1.3.0](https://github.com/chocolatey/choco/milestone/59?closed=1) (February 15, 2023) \{#february-15-2023}
-
-### Deprecated Features
-
-- Deprecate WebPI alternative source - see [#2958](https://github.com/chocolatey/choco/issues/2958).
-- Deprecate usage of direct path to nupkg or nuspec in `choco install` command - see [#2981](https://github.com/chocolatey/choco/issues/2981).
-- Deprecate the `--remove` option in the apikey command - see [#2983](https://github.com/chocolatey/choco/issues/2983).
-- Deprecate `choco config list` including output from features/sources/apikeys etc - see [#2985](https://github.com/chocolatey/choco/issues/2985).
-- Deprecate unnecessary public methods on CygwinService - see [#3026](https://github.com/chocolatey/choco/issues/3026).
-
-### Bug Fixes
-
-- Fix - File not found error when using `--source=cygwin` to install packages - see [#2953](https://github.com/chocolatey/choco/issues/2953).
-
 ## 2.0.0-alpha-20230124 (January 24, 2023) \{#alpha-20230124-january-21-2023}
 
 <Callout type="warning">
@@ -707,6 +639,78 @@ See this [list](https://github.com/chocolatey/choco/discussions/2995) for known 
 
 - Fix broken URLs in repository README file - see [#2888](https://github.com/chocolatey/choco/pull/2888).
 - Update package files to reflect current CCR moderation requirements - see [#2920](https://github.com/chocolatey/choco/issues/2920).
+
+
+## 1.4.4 (September 3, 2025) \{#v1.4.4}
+
+### Dependency Change
+
+- [Security] Update bundled 7zip executables to v25.01.
+  - See [__#3779__](https://github.com/chocolatey/choco/issues/3779) by [gep13](https://github.com/gep13) resolved in [__!3780__](https://github.com/chocolatey/choco/pull/3780) by [gep13](https://github.com/gep13).
+
+### Contributors
+
+1 contributors made this release possible.
+
+<a href="https://github.com/gep13"><img src="https://avatars.githubusercontent.com/u/1271146?v=4" alt="gep13" height="32" width="32"/></a>
+
+
+## 1.4.3 (February 10, 2025) \{#v1.4.3}
+
+### Bug Fixes
+
+- Fix - Unable to upgrade packages on certain authenticated feeds - see [#3613](https://github.com/chocolatey/choco/issues/3613).
+- Fix - Trace warning is outputted even when `--trace` argument is not used - see [#3621](https://github.com/chocolatey/choco/issues/3621).
+- [Security] Fix - Update bundled 7zip executables to v24.09 - see [#3625](https://github.com/chocolatey/choco/issues/3625).
+
+## 1.4.2 (Unreleased) \{#v1.4.2}
+
+<Callout type="info">
+    Due to a previous bug in 1.4.1, which has been corrected in Chocolatey CLI v1.4.3, the artifacts from the 1.4.2 release have been removed.
+</Callout>
+
+### Bug Fix
+
+- [Security] Fix - Trace logging is allowed in non-elevated session - see [#3603](https://github.com/chocolatey/choco/issues/3603).
+
+## 1.4.1 (December 4, 2024) \{#v1.4.1}
+
+### Bug Fix
+
+- Fix - Credentials from configured source used for a non-configured source when the URL is similar - see [#3566](https://github.com/chocolatey/choco/issues/3566).
+
+
+## 1.4.0 (May 10, 2023) \{#may-10-2023}
+
+### Bug Fix
+
+- Fix - When no hook scripts are installed you cannot install/upgrade a package on a system using PowerShell 2 - see [#3088](https://github.com/chocolatey/choco/issues/3088).
+
+### Improvement
+
+- Ensure the most recent version of Chocolatey-NuGet.Core package is being used - see [#3150](https://github.com/chocolatey/choco/issues/3150).
+
+
+## 1.3.1 (March 14, 2023) \{#march-14-2023}
+
+### Bug Fix
+
+- Fix - `chocolateyBeforeModify.ps1` does not get called for dependent packages - see [#1092](https://github.com/chocolatey/choco/issues/1092).
+
+
+## [1.3.0](https://github.com/chocolatey/choco/milestone/59?closed=1) (February 15, 2023) \{#february-15-2023}
+
+### Deprecated Features
+
+- Deprecate WebPI alternative source - see [#2958](https://github.com/chocolatey/choco/issues/2958).
+- Deprecate usage of direct path to nupkg or nuspec in `choco install` command - see [#2981](https://github.com/chocolatey/choco/issues/2981).
+- Deprecate the `--remove` option in the apikey command - see [#2983](https://github.com/chocolatey/choco/issues/2983).
+- Deprecate `choco config list` including output from features/sources/apikeys etc - see [#2985](https://github.com/chocolatey/choco/issues/2985).
+- Deprecate unnecessary public methods on CygwinService - see [#3026](https://github.com/chocolatey/choco/issues/3026).
+
+### Bug Fixes
+
+- Fix - File not found error when using `--source=cygwin` to install packages - see [#2953](https://github.com/chocolatey/choco/issues/2953).
 
 
 ## [1.2.1](https://github.com/chocolatey/choco/milestone/58?closed=1) (December 6, 2022) \{#december-6-2022}

--- a/src/content/docs/en-us/chocolatey-gui-licensed-extension/release-notes.mdx
+++ b/src/content/docs/en-us/chocolatey-gui-licensed-extension/release-notes.mdx
@@ -42,13 +42,6 @@ Please see <Xref title="Install the Licensed Edition" value="setup-chocolatey-gu
 - Update to use latest releases of Chocolatey products.
 
 
-## 1.0.3 (May 10, 2023) \{#may-10-2023}
-
-### Bug Fix
-
-- Fix - Update version ranges in nuspec file to use maximum inclusive rather than maximum exclusive.
-
-
 ## 2.0.0-beta-20230426 (April 26, 2023)
 
 <Callout type="warning">
@@ -106,12 +99,6 @@ See this [list](https://github.com/chocolatey/choco/discussions/2995) for known 
 - Update to use latest beta releases of Chocolatey Components.
 
 
-## 1.0.2 (March 13, 2023) \{#march-13-2023}
-
-### Bug Fixes
-
-- Fix - Chocolatey GUI v1.1.2 crashes on launch with Chocolatey GUI Licensed Extension installed - see [licensed #338](https://github.com/chocolatey/chocolatey-licensed-issues/issues/338).
-
 ## 2.0.0-alpha-20230221 (February 21, 2023) \{#alpha-20230221-february-21-2023}
 
 <Callout type="warning">
@@ -129,6 +116,20 @@ See this [list](https://github.com/chocolatey/choco/discussions/2995) for known 
 ### Breaking Change
 
 - Upgrade to target version 2.0.0 of Chocolatey.Lib and version 2.0.0 of Chocolatey GUI assemblies.
+
+
+## 1.0.3 (May 10, 2023) \{#may-10-2023}
+
+### Bug Fix
+
+- Fix - Update version ranges in nuspec file to use maximum inclusive rather than maximum exclusive.
+
+
+## 1.0.2 (March 13, 2023) \{#march-13-2023}
+
+### Bug Fixes
+
+- Fix - Chocolatey GUI v1.1.2 crashes on launch with Chocolatey GUI Licensed Extension installed - see [licensed #338](https://github.com/chocolatey/chocolatey-licensed-issues/issues/338).
 
 
 ## 1.0.1 (October 12, 2022) \{#october-12-2022}

--- a/src/content/docs/en-us/chocolatey-gui/release-notes.mdx
+++ b/src/content/docs/en-us/chocolatey-gui/release-notes.mdx
@@ -79,13 +79,6 @@ This covers changes for the "chocolateygui" package, which is available as FOSS.
 - Ensure correct usage of ListCommand after upstream changes in Chocolatey CLI - see [#990](https://github.com/chocolatey/ChocolateyGUI/issues/990).
 
 
-## 1.1.3 (May 10, 2023) \{#may-10-2023}
-
-### Bug Fix
-
-- Fix - Update version ranges in nuspec file to use maximum inclusive rather than maximum exclusive - see [#999](https://github.com/chocolatey/ChocolateyGUI/issues/999).
-
-
 ## 2.0.0-beta-20230426 (April 26, 2023)
 
 <Callout type="warning">
@@ -160,12 +153,6 @@ See this [list](https://github.com/chocolatey/choco/discussions/2995) for known 
 - Ensure correct usage of ListCommand after upstream changes in Chocolatey CLI - see [#990](https://github.com/chocolatey/ChocolateyGUI/issues/990).
 
 
-## 1.1.2 (March 8, 2023) \{#march-8-2023}
-
-### Improvements
-
-- Bump LiteDB dependency to 5.0.15 - see [#985](https://github.com/chocolatey/ChocolateyGUI/issues/985).
-
 ## 2.0.0-alpha-20230307 (March 7, 2023) \{#alpha-20230307-march-7-2023}
 
 <Callout type="warning">
@@ -210,6 +197,20 @@ See this [list](https://github.com/chocolatey/choco/discussions/2995) for known 
 ### Breaking Change
 
 - Upgrade to target version 6.4.0 of NuGet.Client and version 2.0.0 of Chocolatey.Lib assemblies - see [#974](https://github.com/chocolatey/ChocolateyGUI/issues/974).
+
+
+## 1.1.3 (May 10, 2023) \{#may-10-2023}
+
+### Bug Fix
+
+- Fix - Update version ranges in nuspec file to use maximum inclusive rather than maximum exclusive - see [#999](https://github.com/chocolatey/ChocolateyGUI/issues/999).
+
+
+## 1.1.2 (March 8, 2023) \{#march-8-2023}
+
+### Improvements
+
+- Bump LiteDB dependency to 5.0.15 - see [#985](https://github.com/chocolatey/ChocolateyGUI/issues/985).
 
 
 ## [1.1.1](https://github.com/chocolatey/ChocolateyGUI/milestone/30?closed=1) (January 26, 2023) \{#january-26-2023}

--- a/src/content/docs/en-us/licensed-extension/release-notes.mdx
+++ b/src/content/docs/en-us/licensed-extension/release-notes.mdx
@@ -92,39 +92,8 @@ Please see <Xref title="Install the Licensed Edition" value="setup-licensed" /> 
 
 - Fix - An unsupported argument is passed to the Chocolatey Agent when using the API - see [licensed #380](https://github.com/chocolatey/chocolatey-licensed-issues/issues/380).
 
-## 5.0.8 (February 10, 2025) \{#v5.0.8}
-
-### Bug Fix
-
-- Fix - Unable to upgrade or install packages on certain authenticated feeds.
-
-## 5.0.7 (Unreleased) \{#v5.0.7}
-
-<Callout type="info">
-    Due to a previous bug in Chocolatey CLI v1.4.1, which has been corrected in Chocolatey CLI v1.4.3 and Chocolatey Licensed Extension 5.0.8, the artifacts from the 5.0.7 release have been removed.
-</Callout>
-
-### Bug Fix
-
-- [Security] Fix - Prevent use of an option when running in Self-Service mode.
-  - See the <Xref title="documentation" value="self-service-anywhere" anchor="background-service-restricted-options" />.
-
-## 5.0.6 (February 21, 2024) \{#v5.0.6}
-
-<Callout type="info">
-    This release addresses a problem that prevented users of Chocolatey GUI and the Background Service (Chocolatey Agent) from installing and upgrading packages.
-</Callout>
-
-- Fix - An unsupported argument is passed to the Chocolatey Agent when using the API - see [licensed #380](https://github.com/chocolatey/chocolatey-licensed-issues/issues/380).
 
 ## 6.1.2 (January 31, 2024) \{#january-31-2024}
-
-### Bug Fixes
-
-- [Security] Fix - Prevent usage of options when running in Self-Service mode.
-  - See the [documentation](https://docs.chocolatey.org/en-us/features/self-service-anywhere#background-service-restricted-options).
-
-## 5.0.5 (January 31, 2024) \{#january-31-2024}
 
 ### Bug Fixes
 
@@ -139,15 +108,6 @@ Please see <Xref title="Install the Licensed Edition" value="setup-licensed" /> 
 - [Security] Fix - Prevent usage of options when running in Self-Service mode.
   - See the [documentation](https://docs.chocolatey.org/en-us/features/self-service-anywhere#background-service-restricted-options).
 - Fix - Unable to disable some features when with a Pro license - see [licensed #364](https://github.com/chocolatey/chocolatey-licensed-issues/issues/364).
-
-
-## 5.0.4 (December 19, 2023) \{#december-19-2023}
-
-### Bug Fixes
-
-- [Security] Fix - Prevent usage of options when running in Self-Service mode.
-  - See the [documentation](https://docs.chocolatey.org/en-us/features/self-service-anywhere#background-service-restricted-options).
-- Fix - Unable to disable some features when with a Pro license - see [licensed #366](https://github.com/chocolatey/chocolatey-licensed-issues/issues/366).
 
 
 ## 6.1.0 (June 29, 2023) \{#june-29-2023}
@@ -214,13 +174,6 @@ Please see <Xref title="Install the Licensed Edition" value="setup-licensed" /> 
 - Intune - When bundling Chocolatey CLI for Intune, package all the Chocolatey products along with it to allow upgrades to occur
 
 
-## 5.0.3 (May 10, 2023) \{#may-10-2023}
-
-### Bug Fix
-
-- Fix - Update version ranges in nuspec file to use maximum inclusive rather than maximum exclusive.
-
-
 ## 6.0.0-beta-20230426 (April 26, 2023)
 
 <Callout type="warning">
@@ -266,13 +219,6 @@ See this [list](https://github.com/chocolatey/choco/discussions/2995) for known 
 - Re-enable Intune support which had been excluded in previous pre-release version.
 - Remove mention of unsupported versions of CLE / CLI from documentation.
 
-
-## 5.0.2 (March 28, 2023) \{#march-28-2023}
-
-### Improvements
-
-- [Security] Bump LiteDB dependency to 5.0.15 - see [licensed #340](https://github.com/chocolatey/chocolatey-licensed-issues/issues/340).
-- [Security] Bump Newtonsoft.Json dependency to 13.0.1 - see [licensed #339](https://github.com/chocolatey/chocolatey-licensed-issues/issues/339).
 
 ## 6.0.0-beta-20230321 (March 21, 2023)
 
@@ -337,6 +283,64 @@ See this [list](https://github.com/chocolatey/choco/discussions/2995) for known 
 
 - Upgrade to target version 4.8 of the .NET Framework.
 - Upgrade to target version 6.4.0 of NuGet.Client and version 2.0.0 of Chocolatey.Lib assemblies.
+
+
+## 5.0.8 (February 10, 2025) \{#v5.0.8}
+
+### Bug Fix
+
+- Fix - Unable to upgrade or install packages on certain authenticated feeds.
+
+## 5.0.7 (Unreleased) \{#v5.0.7}
+
+<Callout type="info">
+    Due to a previous bug in Chocolatey CLI v1.4.1, which has been corrected in Chocolatey CLI v1.4.3 and Chocolatey Licensed Extension 5.0.8, the artifacts from the 5.0.7 release have been removed.
+</Callout>
+
+### Bug Fix
+
+- [Security] Fix - Prevent use of an option when running in Self-Service mode.
+  - See the <Xref title="documentation" value="self-service-anywhere" anchor="background-service-restricted-options" />.
+
+## 5.0.6 (February 21, 2024) \{#v5.0.6}
+
+<Callout type="info">
+    This release addresses a problem that prevented users of Chocolatey GUI and the Background Service (Chocolatey Agent) from installing and upgrading packages.
+</Callout>
+
+- Fix - An unsupported argument is passed to the Chocolatey Agent when using the API - see [licensed #380](https://github.com/chocolatey/chocolatey-licensed-issues/issues/380).
+
+
+## 5.0.5 (January 31, 2024) \{#january-31-2024}
+
+### Bug Fixes
+
+- [Security] Fix - Prevent usage of options when running in Self-Service mode.
+  - See the [documentation](https://docs.chocolatey.org/en-us/features/self-service-anywhere#background-service-restricted-options).
+
+
+## 5.0.4 (December 19, 2023) \{#december-19-2023}
+
+### Bug Fixes
+
+- [Security] Fix - Prevent usage of options when running in Self-Service mode.
+  - See the [documentation](https://docs.chocolatey.org/en-us/features/self-service-anywhere#background-service-restricted-options).
+- Fix - Unable to disable some features when with a Pro license - see [licensed #366](https://github.com/chocolatey/chocolatey-licensed-issues/issues/366).
+
+
+## 5.0.3 (May 10, 2023) \{#may-10-2023}
+
+### Bug Fix
+
+- Fix - Update version ranges in nuspec file to use maximum inclusive rather than maximum exclusive.
+
+
+## 5.0.2 (March 28, 2023) \{#march-28-2023}
+
+### Improvements
+
+- [Security] Bump LiteDB dependency to 5.0.15 - see [licensed #340](https://github.com/chocolatey/chocolatey-licensed-issues/issues/340).
+- [Security] Bump Newtonsoft.Json dependency to 13.0.1 - see [licensed #339](https://github.com/chocolatey/chocolatey-licensed-issues/issues/339).
 
 
 ## 5.0.1 (December 6, 2022) \{#december-6-2022}


### PR DESCRIPTION
## Description Of Changes

To group all the 1.x and 2.x, and 5.x and 6.x releases together, rather then intermingling them based solely on the date that they were released.  

## Motivation and Context

The need for this came up during a conversation with Rob where it was becoming harder and harder to find a specific version in the release notes.  This was happening both when scrolling the headers on the right hand side of the page, as well as when looking through the main content of the document.  By ordering each release based on the version number makes it much easier to find a specific release.

## Testing

* [x] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made

* [ ] Minor documentation fix (typos etc.).
* [x] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist

* [ ] Requires a change to menu structure (top or left-hand side)/
* [ ] Menu structure has been updated

## Related Issue

N/A