### PR TITLE
Fix broken link to CCM blog post

### DIFF
--- a/src/content/docs/en-us/central-management/release-notes.mdx
+++ b/src/content/docs/en-us/central-management/release-notes.mdx
@@ -34,7 +34,7 @@ This covers the release notes for the Chocolatey Central Management (`chocolatey
 
 ## 0.14.0 (April 29, 2025) \{#v0.14.0}
 
-Read our [blog post](https://blog.chocolatey.org/2025/04/central-management-0.14.0-released/) about this release.
+Read our [blog post](https://blog.chocolatey.org/2025/04/announcing-ccm-release-0.14.0/) about this release.
 
 ### Breaking Change
 


### PR DESCRIPTION
A customer brought a broken link on the Chocolatey Central Management Release Notes page that the link to the blog post was broken, resulting in a 404. This commit fixes that link to navigate correctly.

## Description Of Changes
Fixed a broken link on the Chocolatey Central Management Release Notes page.

## Motivation and Context
The link was broken and needed to be fixed for correct navigation to the blog post.

## Testing

* [X] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made

* [X] Minor documentation fix (typos etc.).
* [ ] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist

* [ ] Requires a change to menu structure (top or left-hand side)/
* [ ] Menu structure has been updated

## Related Issue

Fixes #1205
