### PR TITLE
(maint) Fix Extension guide

### DIFF
--- a/src/content/docs/en-us/guides/create/create-extension-package.mdx
+++ b/src/content/docs/en-us/guides/create/create-extension-package.mdx
@@ -47,7 +47,7 @@ You might choose to use this over installing a full PowerShell module if you did
 
 ### Extension Package
 
-An extension package is organised much like any other Chocolatey package - though instead of the scripts within the `tools` directory you may be familiar with, there should be an `extensions` directory.
+An extension package is organized much like any other Chocolatey package - though instead of the scripts within the `tools` directory you may be familiar with, there should be an `extensions` directory.
 
 We'll now run through how to create an extension package, assuming you have an environment set up as in <Xref title="Preparing Your Environment for Package Creation" value="howto-prepare-env" />.
 
@@ -79,6 +79,9 @@ Follow the steps below to get started:
     <summary>Extension package for testing.</summary>
     <tags>extension chocolatey package</tags>
   </metadata>
+  <files>
+    <file src="extensions\**" target="extensions" />
+  </files>
 </package>
 ```
 
@@ -124,6 +127,8 @@ function Set-ConfigValue {
         $Configuration | ConvertTo-Json | Set-Content -Path $Path
     }
 }
+
+Export-ModuleMember -Function Set-ConfigValue
 ```
 
 So, if you browse through the files in VS Code or Explorer, you should see a file structure like this:


### PR DESCRIPTION
- Missing <files> directive in nuspec
- Missing Export-ModuleMember in .psm1

## Description Of Changes

- Missing `<files>` directive in nuspec
- Missing `Export-ModuleMember` in .psm1

## Motivation and Context

The resultant package from the guide needs to _work_

## Testing

* [x] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made

* [x] Minor documentation fix (typos etc.).
* [ ] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist

* [ ] Requires a change to menu structure (top or left-hand side)/
* [ ] Menu structure has been updated

## Related Issue
