### PR TITLE
Update choco template creation tutorial

### DIFF
--- a/src/content/docs/en-us/guides/create/create-template.mdx
+++ b/src/content/docs/en-us/guides/create/create-template.mdx
@@ -55,7 +55,7 @@ We'll use the following for our template metadata. Execute the following in an *
     <version>[[PackageVersion]]</version>
     <owners>SweetTooth</owners>
     <title>template-tutorial (Install)</title>
-    <authors>Chocolatey]</authors>
+    <authors>Chocolatey</authors>
     <tags>template</tags>
     <summary>Tutorial package from template</summary>
     <description>This was built from a template with [[Country]] passed to it.</description>
@@ -90,7 +90,7 @@ choco pack .\template-tutorial\template-tutorial.nuspec
 We can validate that our package used the template correctly by installing it. Run the following in an **elevated** PowerShell window.
 
 ```powershell
-choco install template-tutorial -y
+choco install template-tutorial --source="'.'" -y
 ```
 
 #### Uninstall Your Templated Package


### PR DESCRIPTION
## Description Of Changes
This PR removes a typo `]` included in the example metadata block and adds the source flag to the example `choco install`

## Motivation and Context
The intent of the tutorial is for a user to run the provided commands in series to better understand the concept of chocolatey templating for packages.

If the commands were to be run as is while someone was following along they would be unable to install from the local source.

## Testing

* [X] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

### Typo fix:
<img width="906" height="584" alt="image" src="https://github.com/user-attachments/assets/072d9bf0-bd77-47d1-a17e-ee5b65bbf8a5" />

### Command update:
<img width="971" height="171" alt="image" src="https://github.com/user-attachments/assets/1420d9d3-e2be-4330-a734-59b8d0f47289" />


## Change Types Made


* [X] Minor documentation fix (typos etc.).
* [ ] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist

* [ ] Requires a change to menu structure (top or left-hand side)/
* [ ] Menu structure has been updated

## Related Issue


Fixes #


