### PR TITLE
(#1221) Add images checkbox

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -48,6 +48,8 @@ Please remove all comments before submitting.
 
 * [ ] Requires a change to menu structure (top or left-hand side)/
 * [ ] Menu structure has been updated
+* [ ] Images added to the [img](https://github.com/chocolatey/img) repository?
+    * [ ] PR -
 
 ## Related Issue
 <!-- Make sure you have raised an issue for this pull request before continuing. -->


### PR DESCRIPTION
## Description Of Changes
Added checkbox to the pull request template for any images added to the shared img repository including a checkbox to add the URL to the PR.

## Motivation and Context
This new checkbox is needed to serve as a reminder to add any new images to the img repository and include the URL to the PR.

## Testing

* [ ] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made

* [ ] Minor documentation fix (typos etc.).
* [ ] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist

* [ ] Requires a change to menu structure (top or left-hand side)/
* [ ] Menu structure has been updated

## Related Issue
#1221 

Fixes #1221 
