### PR TITLE
(docs) Remove VirusTotal from known proxy issues

### DIFF
--- a/src/content/docs/en-us/guides/usage/proxy-settings-for-chocolatey.mdx
+++ b/src/content/docs/en-us/guides/usage/proxy-settings-for-chocolatey.mdx
@@ -24,7 +24,6 @@ Chocolatey applies proxy configuration based on the order below:
 Certain Chocolatey products are known to apply different proxy settings depending on circumstances.
 
 * Chocolatey GUI - [Downloading icons does not honor Chocolatey CLI proxy settings](https://github.com/chocolatey/ChocolateyGUI/issues/1013).
-* Chocolatey Licensed Extension - [VirusTotal checking at runtime does not use any proxy](https://github.com/chocolatey/chocolatey-licensed-issues/issues/351).
 * Chocolatey Agent - [Agent communications do not use any proxy configuration](https://github.com/chocolatey/chocolatey-licensed-issues/issues/350).
 
 ## Installing Chocolatey From Behind a Proxy Server


### PR DESCRIPTION
## Description Of Changes

Remove link from the list of known proxy issues.

## Motivation and Context

The issue linked as a known proxy issue is not actually an issue. It was created due to a misunderstanding of how the VirusTotal check was working, and ultimately the VirusTotal check is using the proxy settings.

## Testing

* [ ] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made

* [x] Minor documentation fix (typos etc.).
* [ ] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist

* [ ] Requires a change to menu structure (top or left-hand side)/
* [ ] Menu structure has been updated
* [ ] Images added to the [img](https://github.com/chocolatey/img) repository?
    * [ ] PR -

## Related Issue

N/A