### PR TITLE
(doc) Fix typo in choco install example

### DIFF
--- a/src/content/docs/en-us/choco/commands/install.mdx
+++ b/src/content/docs/en-us/choco/commands/install.mdx
@@ -144,7 +144,7 @@ Alternative to PackageName. This is a list of packages in an xml manifest for Ch
 This specifies the source is Ruby Gems and that we are installing a
  gem. If you do not have ruby installed prior to running this command,
  the command will install that first.
- e.g. `choco install compass -source ruby`
+ e.g. `choco install compass --source ruby`
 
 ### Cygwin
 This specifies the source is Cygwin and that we are installing a cygwin


### PR DESCRIPTION
## Description Of Changes
Fixes a typo in the page for `choco install`.

## Motivation and Context
The current example command is incorrect.

## Testing

* [ ] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made

* [x] Minor documentation fix (typos etc.).
* [ ] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist

* [ ] Requires a change to menu structure (top or left-hand side)/
* [ ] Menu structure has been updated
* [ ] Images added to the [img](https://github.com/chocolatey/img) repository?
    * [ ] PR -

## Related Issue
Fixes #

