### PR TITLE
(doc) Add information about environment variable

### DIFF
--- a/src/content/docs/en-us/create/functions/index.mdx
+++ b/src/content/docs/en-us/create/functions/index.mdx
@@ -117,6 +117,8 @@ Chocolatey makes a number of environment variables available (You can access any
 * ChocolateyPackageName - The name of the package, equivalent to the `<id />` field in the nuspec
 * ChocolateyPackageTitle - The title of the package, equivalent to the `<title />` field in the nuspec
 * ChocolateyPackageVersion - The version of the package, equivalent to the `<version />` field in the nuspec
+* ChocolateyPreviousPackageVersion - The previous version of an already installed package, when performing an upgrade
+  * This environment variable is _only_ available in the `chocolateyInstall.ps1` file, and also the `pre`/`post` `install` hook scripts, when doing an upgrade operation
 
 #### Advanced Environment Variables
 


### PR DESCRIPTION
## Description Of Changes

This commit addresses that, by adding it into the correct location.

## Motivation and Context

When we shipped CLI 2.5.0, we added a new environment variable called ChocolateyPreviousPackageVersion, which stores the version number for the previously installed package version, and this is set when doing a "choco upgrade".  However, this environment variable never made its way into the docs site.

## Testing

* [x] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made

* [x] Minor documentation fix (typos etc.).
* [ ] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist

* [ ] Requires a change to menu structure (top or left-hand side)/
* [ ] Menu structure has been updated
* [ ] Images added to the [img](https://github.com/chocolatey/img) repository?
    * [ ] PR -

## Related Issue

N/A