### PR TITLE
(docs) add checksum and self-service options to docs

### DIFF
--- a/src/content/docs/en-us/choco/commands/cache.mdx
+++ b/src/content/docs/en-us/choco/commands/cache.mdx
@@ -181,6 +181,12 @@ Includes <Xref title="default options/switches" value="choco-commands" anchor="d
      --expired
      Expired - Remove cached items that have expired.
 
+     --use-self-service, --force-self-service
+     Force the command to be handled through the self-service when not 
+       configured to allow this command. This option requires the features for 
+       self-service and self-service command override to be enabled. Business 
+       editions only.
+
 ~~~
 
 <Xref title='Command Reference' value='choco-commands' classes='mb-3 d-block' />

--- a/src/content/docs/en-us/choco/commands/download.mdx
+++ b/src/content/docs/en-us/choco/commands/download.mdx
@@ -227,6 +227,38 @@ Includes <Xref title="default options/switches" value="choco-commands" anchor="d
        of Chocolatey. Overrides the default feature 
        'usePackageRepositoryOptimizations' set to 'True'.
 
+     --ignorechecksum, --ignore-checksum, --ignorechecksums, --ignore-checksums
+     IgnoreChecksum - Ignore checksums provided by the package. Overrides the 
+       default feature 'checksumFiles' set to 'True'.
+       Available in Chocolatey Licensed Extension 7.0.0+
+
+     --allowemptychecksum, --allowemptychecksums, --allow-empty-checksums
+     Allow Empty Checksums - Allow packages to have empty/missing checksums 
+       for downloaded resources from non-secure locations (HTTP, FTP). Use this 
+       switch is not recommended if using sources that download resources from 
+       the internet. Overrides the default feature 'allowEmptyChecksums' set to 
+       'False'.
+       Available in Chocolatey Licensed Extension 7.0.0+
+
+     --allowemptychecksumsecure, --allowemptychecksumssecure, --allow-empty-checksums-secure
+     Allow Empty Checksums Secure - Allow packages to have empty checksums 
+       for downloaded resources from secure locations (HTTPS). Overrides the 
+       default feature 'allowEmptyChecksumsSecure' set to 'True'.
+       Available in Chocolatey Licensed Extension 7.0.0+
+
+     --requirechecksum, --requirechecksums, --require-checksums
+     Require Checksums - Requires packages to have checksums for downloaded 
+       resources (both non-secure and secure). Overrides the default feature 
+       'allowEmptyChecksums' set to 'False' and 'allowEmptyChecksumsSecure' set 
+       to 'True'.
+       Available in Chocolatey Licensed Extension 7.0.0+
+
+     --ignore-dependencies-from-source=VALUE
+     Ignore Dependencies From Source - When downloading a package, ignore any 
+       dependencies that are already present on the provided source. Requires 
+       the friendly name of a configured source.
+       Available in Chocolatey Licensed Extension 7.0.0+
+
      --recompile, --internalize
      Recompile / Internalize - Download all external resources and recompile 
        the package to use the local resources instead. Business editions only.

--- a/src/content/docs/en-us/create/commands/new.mdx
+++ b/src/content/docs/en-us/create/commands/new.mdx
@@ -297,6 +297,12 @@ Includes <Xref title="default options/switches" value="choco-commands" anchor="d
        part of the package id. Default setting is to remove architecture. 
        Available in Business editions only.
 
+     --use-self-service, --force-self-service
+     Force the command to be handled through the self-service when not 
+       configured to allow this command. This option requires the features for 
+       self-service and self-service command override to be enabled. Business 
+       editions only.
+
 ~~~
 
 <Xref title='Command Reference' value='choco-commands' classes='mb-3 d-block' />


### PR DESCRIPTION
## Description Of Changes
- Add documentation for new checksum-related CLI switches:
  - --ignorechecksum / --ignore-checksums
  - --allowemptychecksum / --allow-empty-checksums
  - --allowemptychecksumsecure / --allow-checksums-secure
  - --requirechecksum / --require-checksums
  - Explain availability in Chocolatey Licensed Extension 7.0.0+ and how
  these options override feature defaults Add documentation for 
  --ignore-dependencies-from-source=VALUE to skip dependencies already on a specified source 
  - d --use-self-service / --force-self-service option to new and cache 
  - and docs; document that it forces self-service usage when not 
  - igured and requires the self-service and override features (Business
  - tions only)

## Motivation and Context

- Ensure docs cover new CLI behavior for checksum handling, 
- dependency/source behavior, and self-service enforcement introduced to
- upport licensed/Business features and clearer override semantics.

## Testing

* [x] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made

* [ ] Minor documentation fix (typos etc.).
* [x] Major documentation change (refactoring, reformatting or adding 
documentation to existing page). * [ ] New documentation page added.
* * [ ] The change I have made should have a video added, and I have 
* ised an issue for it.

## Change Checklist

* [ ] Requires a change to menu structure (top or left-hand side)/
* [ ] Menu structure has been updated
* [ ] Images added to the [img](https://github.com/chocolatey/img) repository?

## Related Issue

N/A