### PR TITLE
(maint) Add missing "v" in heading link

### DIFF
--- a/src/content/docs/en-us/licensed-extension/release-notes.mdx
+++ b/src/content/docs/en-us/licensed-extension/release-notes.mdx
@@ -45,7 +45,7 @@ Please see <Xref title="Install the Licensed Edition" value="setup-licensed" /> 
 
 <ChocolateyComponentDependenciesLink />
 
-## 7.0.0 (December 1, 2025) \{#7.0.0}
+## 7.0.0 (December 1, 2025) \{#v7.0.0}
 
 <Callout type="warning">
     Chocolatey Licensed extension now requires Chocolatey CLI v2.6.0 to be able to display additional information about packages.


### PR DESCRIPTION
## Description Of Changes

Add missing "v" in heading link

## Motivation and Context

Without it, the link to the heading does not work.

Also, all the notifications that went out would have had a v in the link.

## Testing

* [x] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [x] Minor documentation fix (typos etc.).
* [ ] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist

* [ ] Requires a change to menu structure (top or left-hand side)/
* [ ] Menu structure has been updated
* [ ] Images added to the [img](https://github.com/chocolatey/img) repository?
    * [ ] PR -

## Related Issue

N/A