### PR TITLE
(#1243) Expand CCM initialisms for clarity

### DIFF
--- a/src/content/docs/en-us/guides/organizations/new-organizational-deployment-guide/client-setup.mdx
+++ b/src/content/docs/en-us/guides/organizations/new-organizational-deployment-guide/client-setup.mdx
@@ -34,9 +34,9 @@ You can download and run the script in one of two ways - fill out the values bel
 
 
 export const clientsetupscenarios = [
-    { id: 'repo,ccm', title: 'Repository and CCM', isActive: true },
+    { id: 'repo,ccm', title: 'Repository and Chocolatey Central Management', isActive: true },
     { id: 'repo', title: 'Repository Only' },
-    { id: 'ccm', title: 'CCM Only' },
+    { id: 'ccm', title: 'Chocolatey Central Management Only' },
     { id: 'none', title: 'No Servers' },
 ];
 


### PR DESCRIPTION
## Description Of Changes

This commit expands the initialisms from CCM to Chocolatey Central Management in the tabs for the Organizational Guide Client Setup.

## Motivation and Context

We're finishing up the new organizational guide in preparation of replacing the old one permanently.

## Testing

* [X] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made

* [X] Minor documentation fix (typos etc.).
* [ ] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist

* [ ] Requires a change to menu structure (top or left-hand side)/
* [ ] Menu structure has been updated
* [ ] Images added to the [img](https://github.com/chocolatey/img) repository?
    * [ ] PR -

## Related Issue
N/A

Fixes #1243 
