### PR TITLE
(maint) Add docker command for Windows to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,12 @@ Once this is complete, run the following from the same terminal:
 docker run -p 5086:5086 -v $(pwd):/app chocolatey-docs-container
 ```
 
+Or on Windows run:
+
+```powershell
+docker run -p 5086:5086 -v ${pwd}:/app chocolatey-docs-container
+```
+
 This will compile the site, and bring up a preview on `http:localhost:5086`. Any changes you make will automatically be hot reloaded.
 
 ## Building the Site for Production


### PR DESCRIPTION
## Description Of Changes
Adds the docker command for Windows.

## Motivation and Context
This command is needed to build the docs site with docker on Windows.

## Testing

* [x] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made

* [x] Minor documentation fix (typos etc.).
* [ ] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist

* [ ] Requires a change to menu structure (top or left-hand side)/
* [ ] Menu structure has been updated
* [ ] Images added to the [img](https://github.com/chocolatey/img) repository?
    * [ ] PR -

## Related Issue

Fixes #