### PR TITLE
(#1275) Clarify certificate usage in Quick Start Guide

### DIFF
--- a/src/content/docs/en-us/c4b-environments/quick-start-environment/chocolatey-for-business-quick-start-guide.mdx
+++ b/src/content/docs/en-us/c4b-environments/quick-start-environment/chocolatey-for-business-quick-start-guide.mdx
@@ -154,7 +154,7 @@ export const callout3 = {
             ```
         </TabsPane>
         <TabsPane content={certificateTabs[2]}>
-            If you are running a bare-minimum proof of concept environment, you can generate a self-signed certificate and use that.
+            If you are running a bare-minimum proof of concept environment and do not have your own certificate, a self-signed certificate will be generated automatically upon deployment.
 
             ```powershell
             Set-Location "$env:SystemDrive\choco-setup\files"


### PR DESCRIPTION
## Description Of Changes

This commit expands the information provided in Step 1: Begin C4B Setup sub-step 2; the Self-Signed Certificate option. It now clarifies that the self-signed certificate will be generated automatically when the script is run.

## Motivation and Context

Before clarifying that the self-signed certificate was created automatically, some users thought they needed to generate a self-signed certificate on their own. This clarification is designed to remedy that.

## Testing

* [X] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made

* [X] Minor documentation fix (typos etc.).
* [ ] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist

* [ ] Requires a change to menu structure (top or left-hand side)/
* [ ] Menu structure has been updated
* [ ] Images added to the [img](https://github.com/chocolatey/img) repository?
    * [ ] PR -
* [ ] All items are complete on the [Definition of Done](https://github.com/chocolatey/home/blob/main/definition-of-done.md).

## Related Issue

Fixes #1275 
