### PR TITLE
(docs) Update package iconUrl guidance

### DIFF
--- a/src/content/docs/en-us/community-repository/moderation/index.mdx
+++ b/src/content/docs/en-us/community-repository/moderation/index.mdx
@@ -51,7 +51,7 @@ Requirements represent the minimum quality of a package that is acceptable. When
 * Tags do not include "chocolatey" (with the exception of the chocolatey packages)
 * When using an `iconUrl`, GitHub raw links are not allowed; linking through a CDN like jsDelivr, Statically, or Githack is required. 
 * When using an `iconUrl`, the icon needs to be hosted at a location that the package maintainer has control over. In most cases this is the package source repository, but can be the software website if the software author is also the package maintainer. 
-* When using an `iconUrl`, the file must end with a specific allowed image extension (`.png`, `.ico`, `.gif`, `.jpg`, `.jpeg`, `.bmp`, `.webp`, or `.svg`). Files with any other extension are not permitted.
+* When using an `iconUrl`, the file must be a permitted image type — `.png`, `.ico`, `.gif`, `.jpg`, `.jpeg`, `.bmp`, `.webp`, or `.svg`. Other image formats are not permitted.
 * Look over the package files
   * If binaries are included in the package, does the maintainer have distribution rights? If they have explicit permission, a copy of that in PDF should be in the package contents.
   * **Install/Uninstall scripts:**
@@ -80,7 +80,7 @@ Guidelines are strong suggestions that improve the quality of a package version.
 * Software that requires a license should include a tag #license. (will become a requirement in Feb 2016)
 * LicenseUrl is nearly a requirement. The only reason it sits in guidelines is that not all software has a url out there containing its license information. We request that in those cases they point to the url for the FOSS license of the software, if they have an open license.
 * Usage of the `iconUrl` is very strongly encouraged, however, the addition of a `iconUrl` is a guideline and something to note for a maintainer to fix up next time. Some software doesn't have a proper icon, in which case an `iconUrl` should not be added. See the requirements section for the requirements if a `iconUrl` is included. 
-* When using an `iconUrl`, the `.png` format is very strongly preferred. If a maintainer uses another valid format (like `.jpg` or `.gif`), encourage them to convert the image to `.png` to align with the repository standard.
+* When using an `iconUrl`, the `.png` image format is very strongly preferred. If a maintainer uses another permitted image format — like `.jpg` or `.gif` — encourage them to convert the image to `.png` to align with the repository standard.
 * Suggest description get really filled out and they take full advantage of the use of markdown.
 * Summary is important, but it doesn't show up on the package page.
 * Tags could always use suggestions to add.

--- a/src/content/docs/en-us/create/create-packages.mdx
+++ b/src/content/docs/en-us/create/create-packages.mdx
@@ -409,7 +409,7 @@ If there is an icon which is suitable for your package, you can specify it in th
 * Use icons with transparent background if available.
 * Don’t use distorted or blurry icons.
 * The package list in the Chocolatey Community Repository shows the icons with a maximum of 48 pixels in width/height. Application logos with very detailed graphics that are barely visible at that dimension are not suitable as package icons.
-* **The `.png` format is _very strongly_ preferred** for your package icons. While other standard image extensions may technically function, using a `.png` ensures consistency and helps with a smooth package approval process.
+* **The `.png` format is _very strongly_ preferred** for your package icons. While other standard image formats may work, using a `.png` ensures consistency and helps with a smooth package approval process.
 * Good sources for package icons are the official desktop icons of the corresponding application you want to make a package of. The icons can be extracted from the app executables using tools like [BeCyIconGrabber](https://community.chocolatey.org/packages/becyicongrabber). Remember to take the icon with 128&nbsp;px or more and save it as `.png` file.
 
 The icon shown on the community.chocolatey.org package page is saved, and served, locally to mitigate against cross scripting attacks and to prevent getting _non HTTPS assets_ errors on the website. Sometimes the page loads faster than the image can be served and the default image gets cached and as a result the new package icon may not be shown until you clear the browser cache for community.chocolatey.org and wait 3 hours before reloading the page.


### PR DESCRIPTION
## Description Of Changes

Updated moderation and package creation docs to strength the guidance regarding `iconUrl` usage.

## Motivation and Context

Clarifies that while other image formats technically function, `.png` is very strongly preferred for consistency and smoother package reviews. This aligns the documentation with the expected community standards.

## Testing

* [x] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made

* [ ] Minor documentation fix (typos etc.).
* [x] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist

* [ ] Requires a change to menu structure (top or left-hand side)/
* [ ] Menu structure has been updated
* [ ] Images added to the [img](https://github.com/chocolatey/img) repository?
    * [ ] PR -
* [ ] All items are complete on the [Definition of Done](https://github.com/chocolatey/home/blob/main/definition-of-done.md).

## Related Issue

N/A