### PR TITLE
(maint) Correction to Chocolatey GUI Branding doc

### DIFF
--- a/src/content/docs/en-us/features/branding.mdx
+++ b/src/content/docs/en-us/features/branding.mdx
@@ -61,10 +61,10 @@ recommended that they are as close as possible to these dimensions.
 #### Location of branding files
 
 Chocolatey GUI looks for custom branding files in the Chocolatey
-installation directory (normally `C:/ProgramData/chocolatey`), and then in a folder
-called `branding/gui`.  i.e. it will look in the following folder:
+installation directory (normally `C:\ProgramData\chocolatey`), and then in a folder
+called `branding\gui`.  i.e. it will look in the following folder:
 
-`C:/ProgramData/chocolatey/branding/gui`
+`C:\ProgramData\chocolatey\branding\gui`
 
 When the branding image files are placed in the `gui` folder and Chocolatey GUI is launched with the Chocolatey GUI Licensed Extension
 installed, a file called `ChocolateyGuiBranding.dll` is created, which contains all the image files as embedded resources.This approach is


### PR DESCRIPTION
## Description Of Changes

When going through the Chocolatey GUI Branding knowledgebase article, I noticed I used the wrong slashes to note directory navigation regarding the location of the branding files. I checked the docs and saw the same error, so this commit corrects the error.

## Motivation and Context

Clarification correction to avoid confusion.

## Testing

* [X] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made

* [X] Minor documentation fix (typos etc.).
* [ ] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist

* [ ] Requires a change to menu structure (top or left-hand side)/
* [ ] Menu structure has been updated
* [ ] Images added to the [img](https://github.com/chocolatey/img) repository?
    * [ ] PR -
* [ ] All items are complete on the [Definition of Done](https://github.com/chocolatey/home/blob/main/definition-of-done.md).

## Related Issue
N/A