### PR TITLE
(doc) Fix source link for Uninstall-ChocolateyZipPackage.ps1

### DIFF
--- a/src/content/docs/en-us/create/functions/uninstall-chocolateyzippackage.mdx
+++ b/src/content/docs/en-us/create/functions/uninstall-chocolateyzippackage.mdx
@@ -101,4 +101,4 @@ This cmdlet supports the common parameters: -Verbose, -Debug, -ErrorAction, -Err
 >
 > This documentation has been automatically generated from `Import-Module "$env:ChocolateyInstall\helpers\chocolateyInstaller.psm1" -Force; Get-Help Uninstall-ChocolateyZipPackage -Full`.
 
-View the source for [Uninstall-ChocolateyZipPackage](https://github.com/chocolatey/choco/blob/master/src/chocolatey.resources/helpers/functions/Uninstall-ChocolateyZipPackage.ps1)
+View the source for [Uninstall-ChocolateyZipPackage](https://github.com/chocolatey/choco/blob/master/src/chocolatey.resources/helpers/functions/UnInstall-ChocolateyZipPackage.ps1)


### PR DESCRIPTION
## Description Of Changes
The link at the bottom of https://docs.chocolatey.org/en-us/create/functions/uninstall-chocolateyzippackage/ is currently as follows but gives a 404:
> View the source for [Uninstall-ChocolateyZipPackage](https://github.com/chocolatey/choco/blob/master/src/chocolatey.resources/helpers/functions/Uninstall-ChocolateyZipPackage.ps1)

This is because the source code for `UnInstall-ChocolateyZipPackage.ps1` has an upper-case `I` in `UnInstall` for some reason, so the correct URL is: https://github.com/chocolatey/choco/blob/master/src/chocolatey.resources/helpers/functions/UnInstall-ChocolateyZipPackage.ps1

## Motivation and Context
Docs website should not contain broken links

## Testing

* [ ] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

No - this is trivial so the new link was simply tested in a web browser.

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [x] Minor documentation fix (typos etc.).
* [ ] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist

* [ ] Requires a change to menu structure (top or left-hand side)/
* [ ] Menu structure has been updated
* [ ] Images added to the [img](https://github.com/chocolatey/img) repository?
    * [ ] PR -
* [ ] All items are complete on the [Definition of Done](https://github.com/chocolatey/home/blob/main/definition-of-done.md).

## Related Issue
<!-- Make sure you have raised an issue for this pull request before continuing. -->

N/A - I found plenty of existing merged PRs to this repo with `(docs)` prefix and no ticket (e.g. PR numbers 1227 1245 1254) so I haven't raised one for now. Having made the commit and got as far as opening this PR though I do now see "Make sure you have raised an issue for this pull request before continuing." in the comment in the PR template. I had previously read [this](https://github.com/chocolatey/choco/blob/develop/CONTRIBUTING.md#prerequisites) which says "Submit the enhancement ticket" and I wasn't sure if that applied to trivial docs fixes. [This](https://github.com/chocolatey/choco/blob/develop/CONTRIBUTING.md#prepare-commits) says "the first line ... should ... be prefixed with the GitHub issue" but then the next bullet point says "If the commit is about documentation, the message should be prefixed with (doc)" so I wonder if CONTRIBUTING.md could be tweaked to clarify whether trivial docs fixes require a ticket or not, to make this more obvious for newcomers?

Note also: I haven't done anything with CLA but this meets the definition of "trivial" per [this](https://github.com/chocolatey/choco/blob/develop/CONTRIBUTING.md#definition-of-trivial-contributions).