### PR TITLE
(#1289) Hide Ansible Env. & ChocoCCM Pages

### DIFF
--- a/src/content/docs/en-us/c4b-environments/ansible/index.mdx
+++ b/src/content/docs/en-us/c4b-environments/ansible/index.mdx
@@ -3,6 +3,7 @@ order: 40
 xref: c4b-ansible
 title: Ansible Environment
 description: Overview of the Chocolatey for Business Ansible Environment
+showInSidebar: false
 ---
 import Callout from '@choco-astro/components/Callout.astro';
 import Iframe from '@choco-astro/components/Iframe.astro';

--- a/src/content/docs/en-us/central-management/chococcm/index.mdx
+++ b/src/content/docs/en-us/central-management/chococcm/index.mdx
@@ -3,8 +3,8 @@ order: 40
 xref: chococcm
 title: ChocoCCM
 description: This is a PowerShell Modules which contains functions or communicating with the Chocolatey Central Management API
+showInSidebar: false
 ---
 import Callout from '@choco-astro/components/Callout.astro';
 import Iframe from '@choco-astro/components/Iframe.astro';
 import Xref from '@components/Xref.astro';
-  


### PR DESCRIPTION
## Description Of Changes
Hides Ansible Environment and ChocoCCM pages.

## Motivation and Context
The Ansible Environment is no longer being maintained. The ChocoCCM PowerShell module is no longer being maintained. 

## Testing
* [X] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made
* ~[ ] Minor documentation fix (typos etc.).~
* [X] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* ~[ ] New documentation page added.~
* ~[ ] The change I have made should have a video added, and I have raised an issue for this.~

## Change Checklist
* [X] Requires a change to menu structure (top or left-hand side)/
* [X] Menu structure has been updated
* ~[ ] Images added to the [img](https://github.com/chocolatey/img) repository?~
* [X] All items are complete on the [Definition of Done](https://github.com/chocolatey/home/blob/main/definition-of-done.md).

## Related Issue
Fixes #1289
