### PR TITLE
(doc) Add missing release note for CLI 2.7.0

### DIFF
--- a/src/content/docs/en-us/choco/release-notes.mdx
+++ b/src/content/docs/en-us/choco/release-notes.mdx
@@ -52,6 +52,11 @@ Read our [blog post](https://blog.chocolatey.org/2026/03/announcing-ccm-0150-cli
 - Capture the source that was being used when searching for packages.
   - See [#3849](https://github.com/chocolatey/choco/issues/3849) by [gep13](https://github.com/gep13), resolved in [!3850](https://github.com/chocolatey/choco/pull/3850) by [gep13](https://github.com/gep13).
 
+### Bug Fix
+
+- Chocolatey does not handle passwords with non ASCII characters when interacting with authenticating sources
+  - See [#3600](https://github.com/chocolatey/choco/issues/3600) by [pfremy](https://github.com/pfremy), resolved in [!3762](https://github.com/chocolatey/choco/pull/3762) by [AdmiringWorm](https://github.com/AdmiringWorm).
+
 ### Contributors
 
 2 contributors made this release possible.


### PR DESCRIPTION
## Description Of Changes
Added a missing entry to the release notes for CLI 2.7.0.

## Motivation and Context
This was missed during the 2.7.0 release due to the milestone not being updated after a PR was merged for this issue.

## Testing

* [x] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [ ] Minor documentation fix (typos etc.).
* [x] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist

* [ ] Requires a change to menu structure (top or left-hand side)/
* [ ] Menu structure has been updated
* [ ] Images added to the [img](https://github.com/chocolatey/img) repository?
    * [ ] PR -
* [x] All items are complete on the [Definition of Done](https://github.com/chocolatey/home/blob/main/definition-of-done.md).

## Related Issue

N/A
