### PR TITLE
(#1303) Retitle release notes pages

### DIFF
--- a/src/content/docs/en-us/agent/release-notes.mdx
+++ b/src/content/docs/en-us/agent/release-notes.mdx
@@ -1,7 +1,7 @@
 ---
 order: 10
 xref: agent-release-notes
-title: Release Notes
+title: Release Notes - Chocolatey Agent
 description: Release Notes for Chocolatey Agent
 ogImage: https://img.chocolatey.org/social-share/release-notes-chocolatey-agent-og.png
 twitterImage: https://img.chocolatey.org/social-share/release-notes-chocolatey-agent-twitter.png

--- a/src/content/docs/en-us/c4b-environments/azure/release-notes.mdx
+++ b/src/content/docs/en-us/c4b-environments/azure/release-notes.mdx
@@ -1,7 +1,7 @@
 ---
 order: 10
 xref: c4b-azure-release-notes
-title: Release Notes
+title: Release Notes - Chocolatey for Business Azure Environment
 description: Release Notes for the Chocolatey for Business Azure Environment
 ogImage: https://img.chocolatey.org/social-share/release-notes-chocolatey-for-business-azure-environment-og.png
 twitterImage: https://img.chocolatey.org/social-share/release-notes-chocolatey-for-business-azure-environment-twitter.png

--- a/src/content/docs/en-us/central-management/chococcm_/release-notes.mdx_
+++ b/src/content/docs/en-us/central-management/chococcm_/release-notes.mdx_
@@ -1,7 +1,7 @@
 ---
 order: 20
 xref: chococcm-release-notes
-title: Release Notes
+title: Release Notes - ChocoCCM
 description: Release Notes for ChocoCCM
 ogImage: https://img.chocolatey.org/social-share/release-notes-choco-ccm-og.png
 twitterImage: https://img.chocolatey.org/social-share/release-notes-choco-ccm-twitter.png

--- a/src/content/docs/en-us/central-management/release-notes.mdx
+++ b/src/content/docs/en-us/central-management/release-notes.mdx
@@ -1,7 +1,7 @@
 ---
 order: 10
 xref: ccm-release-notes
-title: Release Notes
+title: Release Notes - Chocolatey Central Management
 description: Release Notes for Chocolatey Central Management
 ogImage: https://img.chocolatey.org/social-share/release-notes-chocolatey-central-management-og.png
 twitterImage: https://img.chocolatey.org/social-share/release-notes-chocolatey-central-management-twitter.png

--- a/src/content/docs/en-us/choco/release-notes.mdx
+++ b/src/content/docs/en-us/choco/release-notes.mdx
@@ -1,7 +1,7 @@
 ---
 order: 10
 xref: choco-release-notes
-title: Release Notes
+title: Release Notes - Chocolatey CLI
 description: Release Notes for Chocolatey CLI
 ogImage: https://img.chocolatey.org/social-share/release-notes-chocolatey-cli-og.png
 twitterImage: https://img.chocolatey.org/social-share/release-notes-chocolatey-cli-twitter.png

--- a/src/content/docs/en-us/chocolatey-gui-licensed-extension/release-notes.mdx
+++ b/src/content/docs/en-us/chocolatey-gui-licensed-extension/release-notes.mdx
@@ -1,7 +1,7 @@
 ---
 order: 10
 xref: chocolatey-gui-licensed-extension-release-notes
-title: Release Notes
+title: Release Notes - Chocolatey GUI Extension
 description: Release Notes for Chocolatey GUI Extension
 ogImage: https://img.chocolatey.org/social-share/release-notes-chocolatey-gui-licensed-extension-og.png
 twitterImage: https://img.chocolatey.org/social-share/release-notes-chocolatey-gui-licensed-extension-twitter.png

--- a/src/content/docs/en-us/chocolatey-gui/release-notes.mdx
+++ b/src/content/docs/en-us/chocolatey-gui/release-notes.mdx
@@ -1,7 +1,7 @@
 ---
 order: 10
 xref: chocolateygui-release-notes
-title: Release Notes
+title: Release Notes - Chocolatey GUI
 description: Release Notes for Chocolatey GUI
 ogImage: https://img.chocolatey.org/social-share/release-notes-chocolatey-gui-og.png
 twitterImage: https://img.chocolatey.org/social-share/release-notes-chocolatey-gui-twitter.png

--- a/src/content/docs/en-us/chocolatey-gui/user-interface/about/credits.mdx
+++ b/src/content/docs/en-us/chocolatey-gui/user-interface/about/credits.mdx
@@ -1,7 +1,7 @@
 ---
 order: 20
 xref: gui-credits
-title: Credits
+title: About - Credits
 description: Information about tools, software, and frameworks that are used to create Chocolatey GUI
 ---
 import Callout from '@choco-astro/components/Callout.astro';

--- a/src/content/docs/en-us/chocolatey-gui/user-interface/about/history.mdx
+++ b/src/content/docs/en-us/chocolatey-gui/user-interface/about/history.mdx
@@ -1,7 +1,7 @@
 ---
 order: 10
 xref: gui-history
-title: History
+title: About - History
 description: Information about the evolution of Chocolatey GUI
 ---
 import Callout from '@choco-astro/components/Callout.astro';

--- a/src/content/docs/en-us/chocolatey-gui/user-interface/about/release-notes.mdx
+++ b/src/content/docs/en-us/chocolatey-gui/user-interface/about/release-notes.mdx
@@ -1,7 +1,7 @@
 ---
 order: 30
 xref: gui-release-notes
-title: Release Notes
+title: Release Notes (Chocolatey GUI Interface)
 description: Information about what has changed in the current release of Chocolatey GUI
 ---
 import Callout from '@choco-astro/components/Callout.astro';

--- a/src/content/docs/en-us/chocolatey-gui/user-interface/about/release-notes.mdx
+++ b/src/content/docs/en-us/chocolatey-gui/user-interface/about/release-notes.mdx
@@ -1,7 +1,7 @@
 ---
 order: 30
 xref: gui-release-notes
-title: Release Notes (Chocolatey GUI Interface)
+title: About - Release Notes (Chocolatey GUI)
 description: Information about what has changed in the current release of Chocolatey GUI
 ---
 import Callout from '@choco-astro/components/Callout.astro';

--- a/src/content/docs/en-us/information/release-notes/index.mdx
+++ b/src/content/docs/en-us/information/release-notes/index.mdx
@@ -1,7 +1,7 @@
 ---
 order: 10
 xref: release-notes
-title: Release Notes
+title: Release Notes Index
 description: Information about everything that has been released within a Chocolatey component
 ---
 import Callout from '@choco-astro/components/Callout.astro';

--- a/src/content/docs/en-us/licensed-extension/release-notes.mdx
+++ b/src/content/docs/en-us/licensed-extension/release-notes.mdx
@@ -1,7 +1,7 @@
 ---
 order: 10
 xref: licensed-extension-release-notes
-title: Release Notes
+title: Release Notes - Chocolatey Licensed Extension
 description: Release Notes for Chocolatey Licensed Extension
 ogImage: https://img.chocolatey.org/social-share/release-notes-chocolatey-licensed-extension-og.png
 twitterImage: https://img.chocolatey.org/social-share/release-notes-chocolatey-licensed-extension-twitter.png


### PR DESCRIPTION
## Description Of Changes

Re-label release notes pages by including the relevant product name in the title. Also made it clear that the Chocolatey GUI feature page is about that rather than a typical product release notes page.

## Motivation and Context
This helps them to be more discoverable from the search functionality, as they will be distinguishable from one another when multiple entries appear.

## Testing

* [x] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [ ] Minor documentation fix (typos etc.).
* [x] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist

* [ ] Requires a change to menu structure (top or left-hand side)/
* [ ] Menu structure has been updated
* [ ] Images added to the [img](https://github.com/chocolatey/img) repository?
    * [ ] PR -
* [x] All items are complete on the [Definition of Done](https://github.com/chocolatey/home/blob/main/definition-of-done.md).

## Related Issue
<!-- Make sure you have raised an issue for this pull request before continuing. -->

Fixes #1303

<!-- PLEASE REMOVE ALL COMMENTS BEFORE SUBMITTING -->
