### PR TITLE
(build) Update publish action

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -16,9 +16,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository using git
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install, build, and upload site
-        uses: withastro/action@v2
+        uses: withastro/action@v6
 
   deploy:
     needs: build


### PR DESCRIPTION
## Description Of Changes
In the latest release, the requirement for Node bumped to 22+, and the withastro/action@4 step is still using Node 20, which caused the flow to fail. Upgrading to withastro/action@6 automatically uses the needed version of Node, which will allow the flow to build and publish as it should.

## Motivation and Context
The publish workflow is currently failing, which means the changes are not live.

## Testing

* [ ] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

There is not much testing that can be done for this, other than referring to the [withastro/action@6 docs](https://github.com/withastro/action), and seeing that it uses Node 22+.

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [ ] Minor documentation fix (typos etc.).
* [ ] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist

* [ ] Requires a change to menu structure (top or left-hand side)/
* [ ] Menu structure has been updated
* [ ] Images added to the [img](https://github.com/chocolatey/img) repository?
    * [ ] PR -
* [ ] All items are complete on the [Definition of Done](https://github.com/chocolatey/home/blob/main/definition-of-done.md).

## Related Issue
n/a
