### PR TITLE
(maint) Add closed issue to CCM release notes

### DIFF
--- a/src/content/docs/en-us/central-management/release-notes.mdx
+++ b/src/content/docs/en-us/central-management/release-notes.mdx
@@ -52,6 +52,7 @@ Read our [blog post](https://blog.chocolatey.org/2026/03/announcing-ccm-0150-cli
 
 - Display and allow API querying of facts gathered from client computers.
 - Display all package related information in Computer and Software screens.
+- Include a column on Software tables for pinned status - see [#193](https://github.com/chocolatey/chocolatey-licensed-issues/issues/193).
 
 
 ## 0.14.0 (April 29, 2025) \{#v0.14.0}


### PR DESCRIPTION
## Description Of Changes
This adds a link to an issue that was released and closed in Chocolatey Central Management 0.15.0. This issues was missed and needs added to the milestone.

## Motivation and Context
This was included in the release, but missed in the release notes.

## Testing

* [ ] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [x] Minor documentation fix (typos etc.).
* [ ] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist

* [ ] Requires a change to menu structure (top or left-hand side)/
* [ ] Menu structure has been updated
* [ ] Images added to the [img](https://github.com/chocolatey/img) repository?
    * [ ] PR -
* [ ] All items are complete on the [Definition of Done](https://github.com/chocolatey/home/blob/main/definition-of-done.md).

## Related Issue
* PROJ-2613
