### PR TITLE
Add Docs For SkipChocolateyGUI & IncludePackageTools Parameters

### DIFF
--- a/src/content/docs/en-us/guides/organizations/organizational-deployment-guide/client-setup.mdx
+++ b/src/content/docs/en-us/guides/organizations/organizational-deployment-guide/client-setup.mdx
@@ -166,6 +166,22 @@ You can additionally use this script to add configuration, packages, and more.
 
 By passing arguments to `AdditionalConfiguration`, `AdditionalFeatures`, `AdditionalSources`, and `AdditionalPackages` you can additively configure your Chocolatey client - or you can add lines directly to the Client Setup script and deploy that.
 
+### Include Packaging Tools with Installation
+
+Some members of your team may be responsible for maintaining Chocolatey packages in your organization. These tools can be included in the installation by providing the `-IncludePackageTools` parameter.
+
+```powershell
+.\ClientSetup.ps1 @ScriptArgs -IncludePackageTools
+```
+
+### Skip Chocolatey GUI Installation
+
+Some machines within your organization might not require the installation of the self-service Chocolatey GUI application. Examples of these types of machines may include Windows servers with no GUI interface, or digital signage/kiosk thin clients. You can skip installation of the Chocolatey GUI application by providing the `-SkipChocolateyGUI` parameter.
+
+```powershell
+.\ClientSetup.ps1 @ScriptArgs -IncludePackageTools -SkipChocolateyGUI
+```
+
 #### Configuration
 
 You can adjust any Chocolatey configuration value by adding an `-AdditionalConfiguration` argument to your Client Setup script invocation.

--- a/src/content/docs/en-us/guides/organizations/organizational-deployment-guide/client-setup.mdx
+++ b/src/content/docs/en-us/guides/organizations/organizational-deployment-guide/client-setup.mdx
@@ -19,7 +19,7 @@ import OrgGuideClientSetupIntro from '@components/docs/OrgGuideClientSetupIntro.
 Chocolatey provides a suggested installation and configuration script along with the rest of the organizational guide. It's available [in the choco-orgguide-scripts repository](https://github.com/chocolatey/choco-orgguide-scripts/blob/main/ClientSetup.ps1).
 </Callout>
 
-### Usage
+## Usage
 
 You can download and run the script in one of two ways - fill out the values below, and select the tab closest to your environment:
 
@@ -31,7 +31,6 @@ You can download and run the script in one of two ways - fill out the values bel
 | Chocolatey Central Management URL | <DynamicCodeBlockInput name="OrgGuideCcmUrl" defaultValue="https://ccm.example.org:24020/ChocolateyManagementService" /> | Used to communicate with the Chocolatey Central Management service. |
 | Chocolatey Central Management Service Salt | <DynamicCodeBlockInput name="OrgGuideCcmServiceSalt" defaultValue="ServiceCommunicationSalt" /> | Used to secure communication to the Chocolatey Central Management service. |
 | Chocolatey Central Management Client Salt | <DynamicCodeBlockInput name="OrgGuideCcmClientSalt" defaultValue="ClientCommunicationSalt" /> | Used to secure communication to the Chocolatey Central Management service. |
-
 
 export const clientsetupscenarios = [
     { id: 'repo,ccm', title: 'Repository and Chocolatey Central Management', isActive: true },
@@ -160,7 +159,7 @@ You can also save the script to your client machine and run it with the same par
 `}
 </DynamicCodeBlock>
 
-### Setup Modification
+## Setup Modification
 
 You can additionally use this script to add configuration, packages, and more.
 
@@ -182,7 +181,7 @@ Some machines within your organization might not require the installation of the
 .\ClientSetup.ps1 @ScriptArgs -IncludePackageTools -SkipChocolateyGUI
 ```
 
-#### Configuration
+### Configuration
 
 You can adjust any Chocolatey configuration value by adding an `-AdditionalConfiguration` argument to your Client Setup script invocation.
 
@@ -195,7 +194,7 @@ You can adjust any Chocolatey configuration value by adding an `-AdditionalConfi
 
 This can override the base configuration we provide in the client setup.
 
-#### Features
+### Features
 
 You can adjust any Chocolatey feature by adding an `-AdditionalFeatures` argument to your Client Setup script invocation.
 
@@ -207,7 +206,7 @@ You can adjust any Chocolatey feature by adding an `-AdditionalFeatures` argumen
 
 This can override the base features we provide in the client setup.
 
-#### Sources
+### Sources
 
 You can add any additional sources you desire by adding the `-AdditionalSources` argument to your Client Setup script invocation.
 
@@ -231,7 +230,7 @@ Only the `Source` and `Credential` parts of the passed object are required, ever
 
 This can override the sources we create in the client setup.
 
-#### Packages
+### Packages
 
 You can install additional packages during the Client Setup script invocation.
 
@@ -249,6 +248,7 @@ Only the `Id` part of the passed object is required, everything else is optional
 
 If you find yourself wanting to perform more complex installations, e.g. using parameters, we would recommend adding them to the script itself.
 <Xref title="Back To Top" value="organizational-client-setup"/>
+
 ## Next Steps
 
 Select **Start Over** to return to the Organizational Guide introduction page, or select **Previous** to return to Automation Solution setup.


### PR DESCRIPTION
## Description Of Changes
- Add documentation for the SkipChocolateyGUI parameter to the Org Guide Client Setup
- Add documentation for the IncludePackageTools parameter to the Org Guide Client Setup
- Basic Page Linting 

## Motivation and Context
Document changes to ORG Guide Client Setup and ensure the page's right-hand nav loads correctly.

## Testing
* [X] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made
* [X] Minor documentation fix (typos etc.).
* [X] Major documentation change (refactoring, reformatting, or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.

## Change Checklist
* [ ] Requires a change to menu structure (top or left-hand side)/
* [ ] Menu structure has been updated
* [ ] Images added to the [img](https://github.com/chocolatey/img) repository?
* [X] All items are complete on the [Definition of Done](https://github.com/chocolatey/home/blob/main/definition-of-done.md).

## Related Issue
Documents changes done in https://github.com/chocolatey-solutions/choco-orgguide-scripts/issues/3
