### PR TITLE
(docs) Update anchor on Agent release

### DIFF
--- a/src/content/docs/en-us/agent/release-notes.mdx
+++ b/src/content/docs/en-us/agent/release-notes.mdx
@@ -35,7 +35,7 @@ This covers the release notes for the Chocolatey Agent Service (`chocolatey-agen
 
 <ChocolateyProductDependenciesLink />
 
-## 4.1.0 (May, 13, 2026) \{#4.1.0}
+## 4.1.0 (May, 13, 2026) \{#v4.1.0}
 
 Read our [blog post](https://blog.chocolatey.org/2026/05/announcing-ccm-0160-cli-272-cli-146-cle-810-agent-410-gui-310-releases) about this release.
 


### PR DESCRIPTION
## Description Of Changes

Update the anchor on the Agent release notes to have a `v` in it.

## Motivation and Context

Technically speaking, anchors can't start with numbers. And also consistency.

## Testing

* [ ] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made

* [x] Minor documentation fix (typos etc.).
* [ ] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist

* [ ] Requires a change to menu structure (top or left-hand side)/
* [ ] Menu structure has been updated
* [ ] Images added to the [img](https://github.com/chocolatey/img) repository?
    * [ ] PR -
* [ ] All items are complete on the [Definition of Done](https://github.com/chocolatey/home/blob/main/definition-of-done.md).

## Related Issue

N/A