### PR TITLE
(docs) Update anchor on CLI release

### DIFF
--- a/src/content/docs/en-us/choco/release-notes.mdx
+++ b/src/content/docs/en-us/choco/release-notes.mdx
@@ -723,7 +723,7 @@ See this [list](https://github.com/chocolatey/choco/discussions/2995) for known 
 - Fix broken URLs in repository README file - see [#2888](https://github.com/chocolatey/choco/pull/2888).
 - Update package files to reflect current CCR moderation requirements - see [#2920](https://github.com/chocolatey/choco/issues/2920).
 
-## 1.4.6 (May 13, 2026) \{#1.4.6}
+## 1.4.6 (May 13, 2026) \{#v1.4.6}
 
 Read our [blog post](https://blog.chocolatey.org/2026/05/announcing-ccm-0160-cli-272-cli-146-cle-810-agent-410-gui-310-releases) about this release.
 

--- a/src/content/docs/en-us/chocolatey-gui-licensed-extension/release-notes.mdx
+++ b/src/content/docs/en-us/chocolatey-gui-licensed-extension/release-notes.mdx
@@ -38,7 +38,7 @@ Please see <Xref title="Install the Licensed Edition" value="setup-chocolatey-gu
 - Update to version 8.0.0 of Chocolatey Licensed Extension.
 - Update to version 3.0.0 of Chocolatey GUI.
 
-## 2.0.2 (December 4, 2025) \{#2.0.2}
+## 2.0.2 (December 4, 2025) \{#v2.0.2}
 
 ### Bug Fix
 

--- a/src/content/docs/en-us/highlights/00-top-sidebar-highlight.md
+++ b/src/content/docs/en-us/highlights/00-top-sidebar-highlight.md
@@ -4,10 +4,10 @@ xref: highlight-sidebar-top-highlights
 title: Chocolatey product releases
 description: We recently released a new version of multiple Chocolatey Products.
 highlight:
-  postedDateTime: 2026-03-19T00:00:00Z
+  postedDateTime: 2026-05-13T00:00:00Z
   ctaXref: highlights
-  ctaAnchor: march-2026
-  ctaText: View March's highlights
+  ctaAnchor: may-2026
+  ctaText: View May's highlights
   showOnHome: false
   showOnHighlights: false
   showInSidebar: true


### PR DESCRIPTION
## Description Of Changes

Update the anchor on the CLI 1.4.6 release notes to have a `v` in it.

## Motivation and Context

Technically speaking, anchors can't start with numbers. And also consistency.

## Testing

* [ ] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made

* [x] Minor documentation fix (typos etc.).
* [ ] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist

* [ ] Requires a change to menu structure (top or left-hand side)/
* [ ] Menu structure has been updated
* [ ] Images added to the [img](https://github.com/chocolatey/img) repository?
    * [ ] PR -
* [ ] All items are complete on the [Definition of Done](https://github.com/chocolatey/home/blob/main/definition-of-done.md).

## Related Issue

N/A