### PR TITLE
Correct link for RFM requests

### DIFF
--- a/src/content/docs/en-us/community-repository/users/package-triage-process.mdx
+++ b/src/content/docs/en-us/community-repository/users/package-triage-process.mdx
@@ -36,7 +36,7 @@ Package maintainers are unlikely to provide fixes to versions of packages that a
 ## The Triage Process
 
 <Callout type="warning">
-    If the maintainer of the package is in the list below, you do not need to follow these steps. Instead, please contact the <Xref title="Site Admins" value="ccr-faq" anchor="how-do-i-contact-the-site-admins" /> if you wish to become the Maintainer of the package, or raise a <Xref title="Request For Maintainer (RFM) package request" value="package-request" /> if you do not.
+    If the maintainer of the package is in the list below, you do not need to follow these steps. Instead, please contact the <Xref title="Site Admins" value="ccr-faq" anchor="how-do-i-contact-the-site-admins" /> if you wish to become the Maintainer of the package, or raise a **Request for Maintainer (RFM)** request on the [Chocolatey Package Requests](https://github.com/chocolatey/chocolatey-package-requests) repository if you do not.
     
     * needs_new_maintainer
     * dtgm
@@ -54,7 +54,7 @@ If a package needs to be fixed or updated. Here are the steps to follow:
 1. Wait 7 days for a response from the Maintainers.
 1. If the Maintainers have not responded, there are two options:
    1. If you wish to become a Maintainer of the package, please <Xref title="contact the Site Admins" value="ccr-faq" anchor="how-do-i-contact-the-site-admins" />. The Site Admins will follow up with you directly. If the Site Admins add you as a Maintainer of the package, see the <Xref title="Package Maintainer Handover/Switch" value="package-maintainer-handover" /> documentation for more information.
-   1. If you do not wish to become a Maintainer of the package, please raise a <Xref title="Request For Maintainer (RFM) package request" value="package-request" />, including how you contacted the existing Maintainers, links to any issues, discussions or pull requests you raised, and the dates when this contact was initiated. The Repository Administrators will review the request.
+   1. If you do not wish to become a Maintainer of the package, please raise a **Request for Maintainer (RFM)** request on the [Chocolatey Package Requests](https://github.com/chocolatey/chocolatey-package-requests) repository, including how you contacted the existing Maintainers, links to any issues, discussions or pull requests you raised, and the dates when this contact was initiated. The Repository Administrators will review the request.
 
 ### Package Request? Package Missing?
 


### PR DESCRIPTION
## Description Of Changes

The documentation for the Package Triage Process has an incorrect link regarding making Request for Maintainers (RFM) requests. The link currently sends users to the Package Request page in the docs. This commit changes that link to the Chocolatey Package Requests repository in GitHub where the RFM request can be raised.

## Motivation and Context

This was brought to our attention in the Chocolatey Community Moderation Discord channel.

## Testing

* [X] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made

* [X] Minor documentation fix (typos etc.).
* [ ] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist

* [ ] Requires a change to menu structure (top or left-hand side)/
* [ ] Menu structure has been updated
* [ ] Images added to the [img](https://github.com/chocolatey/img) repository?
    * [ ] PR -
* [ ] All items are complete on the [Definition of Done](https://github.com/chocolatey/home/blob/main/definition-of-done.md).

## Related Issue

None.
