### PR TITLE
(docs)Add SkipChocolateyGUI Option to C4B Azure Client Setup Script

### DIFF
--- a/src/content/docs/en-us/c4b-environments/azure/client-setup.mdx
+++ b/src/content/docs/en-us/c4b-environments/azure/client-setup.mdx
@@ -107,7 +107,10 @@ param(
 
     # Allows for the addition of alternative sources after the base configuration  has been applied.
     # Can override base configuration with this parameter
-    [Hashtable[]]$AdditionalSources
+    [Hashtable[]]$AdditionalSources,
+
+    # Allows for the skipping of ChocolateyGUI installation.
+    [Switch]$SkipChocolateyGUI
 )
 $RepositoryCredential = [PSCredential]::new($RepositoryCredential.UserName, $RepositoryCredential.SecurePassword)
 $params = $PSBoundParameters


### PR DESCRIPTION
## Description Of Changes
Documents the addition of the -SkipChocolateyGUI parameter to the ClientSetup.ps1 script used in the C4B Azure Environment.

## Motivation and Context
Allows users of this environment to enroll endpoints with Chocolatey without installing ChocolateyGUI if desired.

## Testing
* [X] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made
* [ ] Minor documentation fix (typos etc.).
* [X] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.

## Change Checklist

* [ ] Requires a change to menu structure (top or left-hand side)/
* [ ] Menu structure has been updated
* [ ] Images added to the [img](https://github.com/chocolatey/img) repository?
* [X] All items are complete on the [Definition of Done](https://github.com/chocolatey/home/blob/main/definition-of-done.md).

## Related Issue
Docs change needed for https://github.com/chocolatey/c4b-azure/pull/178 
