### PR TITLE
(docs) Remove Artifactory from caching/excessive usage docs

### DIFF
--- a/src/content/docs/en-us/community-repository/community-packages-disclaimer.mdx
+++ b/src/content/docs/en-us/community-repository/community-packages-disclaimer.mdx
@@ -25,7 +25,7 @@ A huge thing in Windows ecosystem is copyright law and how it plays into distrib
 You can build a 100% reliable pipeline/workflow within the Chocolatey framework, just not with the community package repository. Building a reliable pipeline is huge. If you are a Windows admin wanting to trust a framework like Chocolatey, you are not going to use the Community Package Repository. Not when your reputation/job is on the line for picking the best options.
 
 <Callout type="info">
-    You can also achieve reliability when reusing community packages, as long as you <Xref title="internalize" value="recompile-packages" /> them. **Internalizing is not the same thing as caching the nupkg files like Artifactory, Cloudsmith, Nexus, ProGet, etc can do.**
+    You can also achieve reliability when reusing community packages, as long as you <Xref title="internalize" value="recompile-packages" /> them. **Internalizing is not the same thing as caching the nupkg files like Cloudsmith, Nexus, ProGet, etc can do.**
 </Callout>
 
 ### Trust / Control
@@ -61,7 +61,7 @@ Another aspect to keep in mind is that the community package repository is meant
 
 To avoid excessive use, please see our <Xref title="organizational deployment guide" value="organizational-deployment-guide" />. Installation of Chocolatey itself and everything else should be from your internal repository and not directly from the community package repository. There are even ways to automate caching (see below) / <Xref title="internalizing" value="recompile-packages" /> (caching and internalizing are entirely different concepts) packages so you still get a pretty good hands off experience.
 
-If you are not able to take advantage of <Xref title="internalizing" value="recompile-packages" /> packages, you can still cache them locally (using package repository solutions like Artifactory, Cloudsmith, Nexus, ProGet, MyGet, etc), which will reduce your direct usage of the community repository.
+If you are not able to take advantage of <Xref title="internalizing" value="recompile-packages" /> packages, you can still cache them locally (using package repository solutions like Cloudsmith, Nexus, ProGet, MyGet, etc), which will reduce your direct usage of the community repository.
 
 <Callout type="info">
     Caching doesn't make the packages you are using from the community repository any more reliable, they may still need to download things from the internet at runtime - but it doesn't put you in a worse place than you already are at because you are already using the community repository directly which has issues identified in this document. If you want to achieve reliability when reusing community packages, you would need to <Xref title="internalize packages" value="recompile-packages" />.


### PR DESCRIPTION
## Description Of Changes
There is an issue where Artifactory is not able to correctly cache requests to the Chocolatey Community Repository.
Removing references to Artifactory in the Excessive Usage docs to avoid confusion.

## Motivation and Context
Usage of Artifactory is resulting in triggering excessive usage blocks and so removing from the docs as an option for avoiding triggering these blocks makes sense.

## Testing

* [x] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made

* [x] Minor documentation fix (typos etc.).
* [ ] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist

* [ ] Requires a change to menu structure (top or left-hand side)/
* [ ] Menu structure has been updated
* [ ] Images added to the [img](https://github.com/chocolatey/img) repository?
    * [ ] PR -
* [ ] All items are complete on the [Definition of Done](https://github.com/chocolatey/home/blob/main/definition-of-done.md).

## Related Issue

N/A