### PR TITLE
Fix malformed code block in Explicit Proxy Settings section

### DIFF
--- a/src/content/docs/en-us/guides/usage/proxy-settings-for-chocolatey.mdx
+++ b/src/content/docs/en-us/guides/usage/proxy-settings-for-chocolatey.mdx
@@ -113,7 +113,7 @@ choco config set --name="'proxyUser'" --value="'<USERNAME>'" #optional
 choco config set --name="'proxyPassword'" --value="'<PASSWORD>'" # optional, will be encrypted in the configuration file
 choco config set --name="'proxyBypassList'" --value="'<REGEX-BYPASS-LIST-COMMA-SEPARATED>'" # optional
 choco config set --name="'proxyBypassOnLocal'" --value="'true'" # optional
-~```
+```
 
 ### Example
 


### PR DESCRIPTION
## Description Of Changes

Fix incorrect Markdown code block termination in the "Explicit Proxy Settings" section by removing an extraneous tilde character.

## Motivation and Context

The current page has a malformed code block due to an extra `~`, which breaks rendering. This change ensures proper formatting and readability.

## Testing

* [ ] I have previewed these changes using the Docker Container or another method before submitting this pull request.

Previewed rendering via GitHub Markdown preview to confirm correct formatting.

## Change Types Made

* [x] Minor documentation fix (typos etc.).
* [ ] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.

## Change Checklist

* [ ] Requires a change to menu structure (top or left-hand side)/
* [ ] Menu structure has been updated
* [ ] Images added to the img repository?
* [ ] All items are complete on the Definition of Done.

## Related Issue

N/A (minor documentation fix)