### PR TITLE
Fix Windows 11 25H2 Enterprise and Education end of support date

### DIFF
--- a/src/content/docs/en-us/chocolatey-products-dependencies-and-support-lifecycle.mdx
+++ b/src/content/docs/en-us/chocolatey-products-dependencies-and-support-lifecycle.mdx
@@ -55,7 +55,7 @@ Chocolatey products' support for Windows Operating Systems follows Microsoft's S
 | [Windows 11 25H2](https://learn.microsoft.com/en-us/lifecycle/products/windows-11-home-and-pro)                              | 12 October 2027   |
 | [Windows 11 24H2](https://learn.microsoft.com/en-us/lifecycle/products/windows-11-home-and-pro)                              | 13 October 2026   |
 | **Enterprise and Education Editions**                                                                                        |                   |
-| [Windows 11 25H2](https://learn.microsoft.com/en-us/lifecycle/products/windows-11-enterprise-and-education)                  | 12 October 2027   |
+| [Windows 11 25H2](https://learn.microsoft.com/en-us/lifecycle/products/windows-11-enterprise-and-education)                  | 10 October 2028   |
 | [Windows 11 24H2](https://learn.microsoft.com/en-us/lifecycle/products/windows-11-enterprise-and-education)                  | 12 October 2027   |
 | [Windows 11 23H2](https://learn.microsoft.com/en-us/lifecycle/products/windows-11-enterprise-and-education)                  | 10 November 2026  |
 | **LTSC Enterprise Editions**                                                                                                 |                   |


### PR DESCRIPTION
## Description Of Changes
Fixed the end of support date for Windows 11 25H2 Enterprise and Education.

## Motivation and Context
The date was incorrect.

## Testing

* [ ] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made

* [x] Minor documentation fix (typos etc.).
* [ ] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist

* [ ] Requires a change to menu structure (top or left-hand side)/
* [ ] Menu structure has been updated
* [ ] Images added to the [img](https://github.com/chocolatey/img) repository?
    * [ ] PR -
* [ ] All items are complete on the [Definition of Done](https://github.com/chocolatey/home/blob/main/definition-of-done.md).

## Related Issue
N/A