### PR TITLE
(#1343) Upgrade choco-theme to 2.9.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@chocolatey-software/playwright": "2.8.0"
   },
   "dependencies": {
-    "@chocolatey-software/docs": "chocolatey/choco-theme#head=choco-theme/2.9.0&workspace=@chocolatey-software/docs"
+    "@chocolatey-software/docs": "2.9.1"
   },
   "resolutions": {
     "@playwright/test": "^1.60.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -461,9 +461,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@chocolatey-software/docs@chocolatey/choco-theme#head=choco-theme/2.9.0&workspace=@chocolatey-software/docs":
-  version: 2.9.0
-  resolution: "@chocolatey-software/docs@https://github.com/chocolatey/choco-theme.git#workspace=%40chocolatey-software%2Fdocs&commit=7b131083bde03f65502250cd639a996b94e58160"
+"@chocolatey-software/docs@npm:2.9.1":
+  version: 2.9.1
+  resolution: "@chocolatey-software/docs@npm:2.9.1"
   dependencies:
     "@docsearch/css": "npm:^4.6.3"
     "@docsearch/js": "npm:^4.6.3"
@@ -473,7 +473,7 @@ __metadata:
     clipboard: "npm:^2.0.11"
     jquery: "npm:^3.7.1"
     prismjs: "npm:^1.30.0"
-  checksum: 10c0/5f58fde9e512bb1e985d331e04ad1fa59baf399bd73a38eb749575eed656c73e0cc9e3cdb2795e78e53a40883dfa53bee862986ad929a71d647b96ab0d66fa0e
+  checksum: 10c0/0c53f5517ac3f40ab6db834be3dcf73b8c9f57e06ec44f4534fe3a6b929d86bc5a1722136dddb2d9336bf978eb8c7083419a47a4ad1936108991493dbd000f95
   languageName: node
   linkType: hard
 
@@ -3831,7 +3831,7 @@ __metadata:
     "@chocolatey-software/assets": "npm:2.0.0"
     "@chocolatey-software/astro": "npm:2.8.0"
     "@chocolatey-software/build-tools": "npm:2.8.0"
-    "@chocolatey-software/docs": "chocolatey/choco-theme#head=choco-theme/2.9.0&workspace=@chocolatey-software/docs"
+    "@chocolatey-software/docs": "npm:2.9.1"
     "@chocolatey-software/playwright": "npm:2.8.0"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## Description Of Changes
This upgrades choco-theme to 2.9.1, with the only change being that a "Effective by 1 January 2027" note added to specific bullet points in the Terms of Service. Release notes can be found at:

https://github.com/chocolatey/choco-theme/releases/tag/2.9.1

## Motivation and Context
We want our Terms of Service to be as clear as possible.

## Testing

* [ ] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

1. Run the website.
2. Ensure that on the Terms of Service page, the bullet points in the photo below match, and they contain the "Effective by 1 January 2027" note.

<img width="430" height="270" alt="Screenshot 2026-06-03 103028" src="https://github.com/user-attachments/assets/30931278-d9e4-4b9b-9da2-0cb63e01f2f6" />

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [x] Minor documentation fix (typos etc.).
* [ ] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist

* [ ] Requires a change to menu structure (top or left-hand side)/
* [ ] Menu structure has been updated
* [ ] Images added to the [img](https://github.com/chocolatey/img) repository?
    * [ ] PR -
* [x] All items are complete on the [Definition of Done](https://github.com/chocolatey/home/blob/main/definition-of-done.md).

## Related Issue
* #1343 
* PROJ-2881
