### PR TITLE
(1346) Artifactory warning for CCR Proxy doc

### DIFF
--- a/src/content/docs/en-us/guides/organizations/proxying-ccr.mdx
+++ b/src/content/docs/en-us/guides/organizations/proxying-ccr.mdx
@@ -44,7 +44,7 @@ export const tabs = [
     </tr>
     <tr>
         <th>New Feed</th>
-        <td>Free/Open Source Chocolatey Packages</td>
+        <td>Chocolatey Community Packages</td>
     </tr>
     <tr>
         <th>Feed Name</th>
@@ -52,12 +52,19 @@ export const tabs = [
     </tr>
 </table>
 
-For more information, visit Inedo ProGet's documentation on [HOWTO: Set Up a Proxy Feed of the Chocolatey Community Repository](https://docs.inedo.com/docs/proget/feeds/chocolatey/howto-chocolatey-proxyccr).
+For more information, visit Inedo ProGet's documentation on [HOWTO: Proxy Packages from the Chocolatey Community Repository in ProGet](https://docs.inedo.com/docs/proget/feeds/chocolatey/howto-chocolatey-proxyccr).
 
     </TabsPane>
     <TabsPane content={tabs[1]}>
 
 #### JFrog Artifactory
+
+<div class="callout callout-warning">
+  <div class="callout-header">WARNING</div>
+  <p>
+    This does not work with the self-hosted version of Artifactory and may result in blocks for excessive usage. However, this may work in the Cloud/SaaS version. JFrog is aware that this does not work with the self-hosted version and once this has been resolved, this warning will be removed. [More information can be found here](https://jfrog.atlassian.net/browse/RTFACT-31207).
+  </p>
+</div>
 
 <table>
     <tr>


### PR DESCRIPTION
## Description Of Changes

This commit adds a warning to the proxy documentation for the JFrog Artifactory repository solution regarding its non-functionality with the self-hosted version. This commit also brings the Inedo ProGet documentation in alignment with referencing the new images in the ProGet interface and latest hyperlinks.

## Motivation and Context

The issue with Artifactory has (supposedly) been addressed in the Cloud/SaaS version, but the self-hosted version is still broken. The warning makes users aware of this. Additionally, Inedo recently made changes to their ProGet interface, and a change to the feed type needed to be made to this documentation to reflect the new name of the feed type. Inedo also changed the hyperlink to their documentation, and that has similarly been addressed.

## Testing

* [X] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [X] Minor documentation fix (typos etc.).
* [ ] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist

* [ ] Requires a change to menu structure (top or left-hand side)/
* [ ] Menu structure has been updated
* [ ] Images added to the [img](https://github.com/chocolatey/img) repository?
    * [ ] PR -
* [ ] All items are complete on the [Definition of Done](https://github.com/chocolatey/home/blob/main/definition-of-done.md).

## Related Issue

Fixes #1346

