### PR TITLE
(docs) Add Chocolatey Product release notes

### DIFF
--- a/src/components/docs/ChocolateyProductDependencies.mdx
+++ b/src/components/docs/ChocolateyProductDependencies.mdx
@@ -13,7 +13,7 @@ Please refer to our <Xref title="Support Lifecycle information" value="chocolate
 
 | Package Name / Dependency      | chocolatey  | chocolatey.extension | chocolateygui |
 | ------------------------------ | ----------- | -------------------- | ------------- |
-| chocolatey v2.7.2              |             |                      |               |
+| chocolatey v2.7.3              |             |                      |               |
 | chocolatey.extension v8.1.0    | v2.7.0      |                      |               |
 | chocolatey-agent v4.1.0        |             | v8.0.0               |               |
 | chocolateygui v3.1.0           | v2.7.0      |                      |               |

--- a/src/components/docs/ChocolateyProductDependencies.mdx
+++ b/src/components/docs/ChocolateyProductDependencies.mdx
@@ -16,7 +16,7 @@ Please refer to our <Xref title="Support Lifecycle information" value="chocolate
 | chocolatey v2.7.3              |             |                      |               |
 | chocolatey.extension v8.1.0    | v2.7.0      |                      |               |
 | chocolatey-agent v4.1.0        |             | v8.0.0               |               |
-| chocolateygui v3.1.0           | v2.7.0      |                      |               |
+| chocolateygui v3.2.0           | v2.7.0      |                      |               |
 | chocolateygui.extension v3.0.0 |             | v8.0.0               | v3.0.0        |
 | chocolatey v1.4.6              |             |                      |               |
 | chocolatey.extension v5.0.8    | v1.2.0      |                      |               |

--- a/src/components/docs/ChocolateyProductDependencies.mdx
+++ b/src/components/docs/ChocolateyProductDependencies.mdx
@@ -14,7 +14,7 @@ Please refer to our <Xref title="Support Lifecycle information" value="chocolate
 | Package Name / Dependency      | chocolatey  | chocolatey.extension | chocolateygui |
 | ------------------------------ | ----------- | -------------------- | ------------- |
 | chocolatey v2.7.3              |             |                      |               |
-| chocolatey.extension v8.1.0    | v2.7.0      |                      |               |
+| chocolatey.extension v8.2.0    | v2.7.0      |                      |               |
 | chocolatey-agent v4.1.0        |             | v8.0.0               |               |
 | chocolateygui v3.2.0           | v2.7.0      |                      |               |
 | chocolateygui.extension v3.0.0 |             | v8.0.0               | v3.0.0        |

--- a/src/content/docs/en-us/choco/release-notes.mdx
+++ b/src/content/docs/en-us/choco/release-notes.mdx
@@ -24,6 +24,19 @@ This covers changes for the "chocolatey" and "chocolatey.lib" packages, which ar
 
 <ChocolateyProductDependenciesLink />
 
+## 2.7.3 (June 10, 2026) \{#v2.7.3}
+
+### Bug Fix
+
+- Corrupted package prevents new package installations.
+  - See [#3875](https://github.com/chocolatey/choco/issues/3875) by [Kylotan](https://github.com/Kylotan), resolved in [!3901](https://github.com/chocolatey/choco/pull/3901) by [vexx32](https://github.com/vexx32).
+
+### Contributors
+
+2 contributors made this release possible.
+
+<a href="https://github.com/Kylotan"><img src="https://avatars.githubusercontent.com/u/1117104?v=4" alt="Profile image for contributor Kylotan" height="32" width="32"/></a> <a href="https://github.com/vexx32"><img src="https://avatars.githubusercontent.com/u/32407840?u=d8213fbf5ef964c29ef7cfda6497c9dddb38cca9&v=4" alt="Profile image for contributor vexx32" height="32" width="32"/></a> 
+
 ## 2.7.2 (May 13, 2026) \{#v2.7.2}
 
 Read our [blog post](https://blog.chocolatey.org/2026/05/announcing-ccm-0160-cli-272-cli-146-cle-810-agent-410-gui-310-releases) about this release.

--- a/src/content/docs/en-us/chocolatey-gui/release-notes.mdx
+++ b/src/content/docs/en-us/chocolatey-gui/release-notes.mdx
@@ -24,6 +24,29 @@ This covers changes for the "chocolateygui" package, which is available as FOSS.
 
 <ChocolateyProductDependenciesLink />
 
+## 3.2.0 (June 10, 2026) \{#v3.2.0}
+
+### Bug Fix
+
+- Gallery URL not available for packages on the Chocolatey Community Repository.
+  - See [#1137](https://github.com/chocolatey/ChocolateyGUI/issues/1137) by [AdmiringWorm](https://github.com/AdmiringWorm), resolved in [!1138](https://github.com/chocolatey/ChocolateyGUI/pull/1138) by [AdmiringWorm](https://github.com/AdmiringWorm).
+
+### Documentation
+
+- (maint) Fix typos in resource strings.
+  - See [!1140](https://github.com/chocolatey/ChocolateyGUI/pull/1140) by [AdmiringWorm](https://github.com/AdmiringWorm).
+
+### Enhancement
+
+- Add Context Menu Item To Allow Packages From Chocolatey Community Repository To Open URL.
+  - See [#728](https://github.com/chocolatey/ChocolateyGUI/issues/728) by [LordMike](https://github.com/LordMike), resolved in [!1139](https://github.com/chocolatey/ChocolateyGUI/pull/1139) by [AdmiringWorm](https://github.com/AdmiringWorm).
+
+### Contributors
+
+2 contributors made this release possible.
+
+<a href="https://github.com/AdmiringWorm"><img src="https://avatars.githubusercontent.com/u/1474648?v=4" alt="Profile image for contributor AdmiringWorm" height="32" width="32"/></a> <a href="https://github.com/LordMike"><img src="https://avatars.githubusercontent.com/u/1027111?v=4" alt="Profile image for contributor LordMike" height="32" width="32"/></a> 
+
 ## 3.1.0 (May 13, 2026) \{#v3.1.0}
 
 Read our [blog post](https://blog.chocolatey.org/2026/05/announcing-ccm-0160-cli-272-cli-146-cle-810-agent-410-gui-310-releases) about this release.

--- a/src/content/docs/en-us/highlights/00-top-sidebar-highlight.md
+++ b/src/content/docs/en-us/highlights/00-top-sidebar-highlight.md
@@ -4,10 +4,10 @@ xref: highlight-sidebar-top-highlights
 title: Chocolatey product releases
 description: We recently released a new version of multiple Chocolatey Products.
 highlight:
-  postedDateTime: 2026-05-13T00:00:00Z
+  postedDateTime: 2026-06-10T00:00:00Z
   ctaXref: highlights
-  ctaAnchor: may-2026
-  ctaText: View May's highlights
+  ctaAnchor: june-2026
+  ctaText: View June's highlights
   showOnHome: false
   showOnHighlights: false
   showInSidebar: true

--- a/src/content/docs/en-us/highlights/2025/02-chocolatey-agent-1.1.5.md
+++ b/src/content/docs/en-us/highlights/2025/02-chocolatey-agent-1.1.5.md
@@ -8,6 +8,6 @@ highlight:
   ctaXref: agent-release-notes
   ctaAnchor: v1.1.5
   ctaText: Read the release notes
-  showOnHome: true
+  showOnHome: false
   showOnHighlights: true
 ---

--- a/src/content/docs/en-us/highlights/2025/02-chocolatey-central-management-0.13.2.md
+++ b/src/content/docs/en-us/highlights/2025/02-chocolatey-central-management-0.13.2.md
@@ -8,6 +8,6 @@ highlight:
   ctaXref: ccm-release-notes
   ctaAnchor: v0.13.2
   ctaText: Read the release notes
-  showOnHome: true
+  showOnHome: false
   showOnHighlights: true
 ---

--- a/src/content/docs/en-us/highlights/2025/02-chocolatey-extension-5.0.8.md
+++ b/src/content/docs/en-us/highlights/2025/02-chocolatey-extension-5.0.8.md
@@ -8,6 +8,6 @@ highlight:
   ctaXref: licensed-extension-release-notes
   ctaAnchor: v5.0.8
   ctaText: Read the release notes
-  showOnHome: true
+  showOnHome: false
   showOnHighlights: true
 ---

--- a/src/content/docs/en-us/highlights/2026/05-chocolatey-cli-1.4.6.md
+++ b/src/content/docs/en-us/highlights/2026/05-chocolatey-cli-1.4.6.md
@@ -8,6 +8,6 @@ highlight:
   ctaXref: choco-release-notes
   ctaAnchor: v1.4.6
   ctaText: Read the release notes
-  showOnHome: true
+  showOnHome: false
   showOnHighlihts: true
 ---

--- a/src/content/docs/en-us/highlights/2026/05-chocolatey-extension-8.1.0.md
+++ b/src/content/docs/en-us/highlights/2026/05-chocolatey-extension-8.1.0.md
@@ -8,6 +8,6 @@ highlight:
   ctaXref: licensed-extension-release-notes
   ctaAnchor: v8.1.0
   ctaText: Read the release notes
-  showOnHome: true
+  showOnHome: false
   showOnHighlights: true
 ---

--- a/src/content/docs/en-us/highlights/2026/05-chocolatey-extension-8.2.0.md
+++ b/src/content/docs/en-us/highlights/2026/05-chocolatey-extension-8.2.0.md
@@ -1,0 +1,13 @@
+---
+order: 0
+xref: highlight-2026-06-10-licensed-extension-8.2.0
+title: What's new in Chocolatey Licensed Extension v8.2.0
+description: Learn all about what's new in Chocolatey Licensed Extension v8.2.0.
+highlight:
+  postedDateTime: 2026-06-10T00:03:20Z
+  ctaXref: licensed-extension-release-notes
+  ctaAnchor: v8.2.0
+  ctaText: Read the release notes
+  showOnHome: true
+  showOnHighlights: true
+---

--- a/src/content/docs/en-us/highlights/2026/05-chocolatey-gui-3.1.0.md
+++ b/src/content/docs/en-us/highlights/2026/05-chocolatey-gui-3.1.0.md
@@ -8,6 +8,6 @@ highlight:
   ctaXref: chocolateygui-release-notes
   ctaAnchor: v3.1.0
   ctaText: Read the release notes
-  showOnHome: true
+  showOnHome: false
   showOnHighlights: true
 ---

--- a/src/content/docs/en-us/highlights/2026/06-chocolatey-cli-2.7.3.md
+++ b/src/content/docs/en-us/highlights/2026/06-chocolatey-cli-2.7.3.md
@@ -1,0 +1,13 @@
+---
+order: 0
+xref: highlight-2026-06-10-chocolatey-cli-2.7.3
+title: What's new in Chocolatey CLI v2.7.3
+description: Learn all about what's new in Chocolatey CLI v2.7.3.
+highlight:
+  postedDateTime: 2026-06-10T00:03:20Z
+  ctaXref: choco-release-notes
+  ctaAnchor: v2.7.3
+  ctaText: Read the release notes
+  showOnHome: true
+  showOnHighlights: true
+---

--- a/src/content/docs/en-us/highlights/2026/06-chocolatey-gui-3.2.0.md
+++ b/src/content/docs/en-us/highlights/2026/06-chocolatey-gui-3.2.0.md
@@ -1,0 +1,13 @@
+---
+order: 0
+xref: highlight-2026-06-10-gui-3.2.0
+title: What's new in Chocolatey GUI v3.2.0
+description: Learn all about what's new in Chocolatey GUI v3.2.0.
+highlight:
+  postedDateTime: 2026-06-10T00:03:20Z
+  ctaXref: chocolateygui-release-notes
+  ctaAnchor: v3.2.0
+  ctaText: Read the release notes
+  showOnHome: true
+  showOnHighlights: true
+---

--- a/src/content/docs/en-us/licensed-extension/release-notes.mdx
+++ b/src/content/docs/en-us/licensed-extension/release-notes.mdx
@@ -45,6 +45,17 @@ Please see <Xref title="Install the Licensed Edition" value="setup-licensed" /> 
 
 <ChocolateyProductDependenciesLink />
 
+## 8.2.0 (June 10, 2026) \{#v8.2.0}
+
+
+### Dependency Change
+
+- Update to support the latest version of `intunewinapputil`.
+
+### Enhancement
+
+- Pin `intunewinapputil` version to a known working version.
+
 ## 8.1.0 (May 13, 2026) \{#v8.1.0}
 
 Read our [blog post](https://blog.chocolatey.org/2026/05/announcing-ccm-0160-cli-272-cli-146-cle-810-agent-410-gui-310-releases) about this release.


### PR DESCRIPTION
## Description Of Changes

- Add Chocolatey CLI v2.7.3 release notes with bug fixes and contributor information
- Add Chocolatey GUI v3.2.0 release notes with bug fixes, documentation updates, and new context menu feature
- Add Licensed Extension v8.2.0 release notes with dependency and enhancement details
- Update product dependencies table to reference latest versions (CLI v2.7.3, GUI v3.2.0, Extension v8.2.0)
- Create highlight documents for each new release announcement
- Update home page highlight visibility to feature current releases and archive previous versions
- Update top sidebar highlight date to June 2026

## Motivation and Context

Document the latest Chocolatey product releases and manage home page visibility to promote current versions while maintaining accurate release information.

## Testing

* [x] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made

* [ ] Minor documentation fix (typos etc.).
* [x] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [x] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.

## Change Checklist

* [ ] Requires a change to menu structure (top or left-hand side).
* [ ] Menu structure has been updated
* [ ] Images added to the [img](https://github.com/chocolatey/img) repository?
* [x] All items are complete on the [Definition of Done](https://github.com/chocolatey/home/blob/main/definition-of-done.md).

## Related Issue

N/A