### PR TITLE
Update dotnet dependency wording for CCM Website

### DIFF
--- a/src/content/docs/en-us/central-management/setup/website.mdx
+++ b/src/content/docs/en-us/central-management/setup/website.mdx
@@ -28,20 +28,20 @@ This is the Chocolatey Central Management website that gives an API and a web la
 * <Xref title="High-level Requirements" value="ccm-setup" anchor="high-level-requirements" />
 * PowerShell 5.1
 * IIS Set up and available
-* dotnet-aspnetcoremodule-v2 version 18.0.24201
-* dotnet-8.0-runtime version 8.0.8
-* dotnet-8.0-aspnetruntime version 8.0.8
+* dotnet-aspnetcoremodule-v2 version 18.0.26139
+* dotnet-8.0-runtime version 8.0.28
+* dotnet-8.0-aspnetruntime version 8.0.28
 
-The Chocolatey Central Management Website is built on ASP.Net Core, and as such we need to ensure that it is installed on the server for proper function. Note that the codebase is currently locked to version `6.x.x` of these packages, and it is critical that you install these right, otherwise you will encounter errors.  At the time of release, the most recent version of these packages was 6.0.5, though we recommend installing the latest versions of these packages.
+The Chocolatey Central Management Website is built on ASP.Net Core, and as such we need to ensure that it is installed on the server for proper function. Note that the codebase is currently locked to version `8.x.x` of these packages, and it is critical that you install these packages correctly, otherwise you will encounter errors.  The current versions of the dependencies (as of **17 JUN 2026**) are listed here, though we recommend installing the latest versions of these packages as they continue to become available.
 
 ### Script for some prerequisites
 
 ```powershell
 choco install IIS-WebServer --source windowsfeatures --no-progress -y
 choco install IIS-ApplicationInit --source windowsfeatures --no-progress -y
-choco install dotnet-aspnetcoremodule-v2 --version 18.0.24201 --no-progress -y
-choco install dotnet-8.0-runtime --version 8.0.8 --no-progress -y
-choco install dotnet-8.0-aspnetruntime --version 8.0.8 --no-progress -y
+choco install dotnet-aspnetcoremodule-v2 --version 18.0.26139 --no-progress -y
+choco install dotnet-8.0-runtime --version 8.0.28 --no-progress -y
+choco install dotnet-8.0-aspnetruntime --version 8.0.28 --no-progress -y
 ```
 
 ## Step 2: Install Chocolatey Central Management Web Package


### PR DESCRIPTION
## Description Of Changes
I have fixed a typo in the docs regarding the codebase lock for CCM, as well as made the changes to the requirements and codeblock to mention and run the installation of the latest dotnet dependencies, respectively, including a date declaration to allow users to know there may eventually be later versions available.

## Motivation and Context
It was brought to my attention that while the requirements and codeblock were brought up-to-date with the CCM shift to .NET 8.0, the blurb about the codebase being locked still said `6.X.X`. The dotnet dependencies listed in the requirements and codeblock were also outdated.

## Testing

* [X] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made

* [X] Minor documentation fix (typos etc.).
* [ ] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist

* [ ] Requires a change to menu structure (top or left-hand side)/
* [ ] Menu structure has been updated
* [ ] Images added to the [img](https://github.com/chocolatey/img) repository?
    * [ ] PR -
* [ ] All items are complete on the [Definition of Done](https://github.com/chocolatey/home/blob/main/definition-of-done.md).

## Related Issue

None.