### PR TITLE
(docs) Make some changes to CCM setup docs

### DIFF
--- a/src/content/docs/en-us/central-management/setup/database.mdx
+++ b/src/content/docs/en-us/central-management/setup/database.mdx
@@ -69,7 +69,7 @@ The quickest option to get going with the database is to use the Chocolatey Comm
 choco install sql-server-express -y
 ```
 
-You will also want to have the management tools installed, which can be installed with:
+You may also want to have the management tools installed, which can be installed with:
 
 ```powershell
 choco install sql-server-management-studio -y

--- a/src/content/docs/en-us/central-management/setup/database.mdx
+++ b/src/content/docs/en-us/central-management/setup/database.mdx
@@ -488,5 +488,3 @@ MODIFY FILE
     SIZE = 200MB);
 GO
 ```
-
-<Xref title="Central Management Setup" value="ccm-setup" />  <Xref title="Chocolatey Central Management" value="central-management" />

--- a/src/content/docs/en-us/central-management/setup/database.mdx
+++ b/src/content/docs/en-us/central-management/setup/database.mdx
@@ -92,10 +92,6 @@ We've prepared a handy script (that may turn into a package later) to help you e
 
 The following is a script for SQL Server Express. You may be configuring a default instance. This should be run on the computer that has SQL Server Express installed as it will have the right binaries necessary for accessing SQL Server programmatically.
 
-<Callout type="warning">
-    This script is SQL Server version dependent! Please see the TODO in the script below and adjust accordingly.
-</Callout>
-
 ```powershell
 # https://docs.microsoft.com/en-us/sql/tools/configuration-manager/tcp-ip-properties-ip-addresses-tab
 Write-Output "SQL Server: Configuring Remote Access on SQL Server Express."
@@ -126,16 +122,24 @@ $tcpPort = $tcpIpAll.IpAddressProperties | Where-Object { $_.Name -eq 'TcpPort' 
 $tcpPort.Value = "1433"
 $tcp.Alter()
 
-# TODO: THIS LINE IS VERSION DEPENDENT! Replace MSSQL16 with whatever version you have
 Write-Output "SQL Server: Setting Mixed Mode Authentication."
-New-ItemProperty 'HKLM:\Software\Microsoft\Microsoft SQL Server\MSSQL16.SQLEXPRESS\MSSQLServer\' -Name 'LoginMode' -Value 2 -Force
-# VERSION DEPENDENT ABOVE
+$SqlBaseKey = 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\'
+$SqlInstances = Get-ItemProperty (Join-Path $SqlBaseKey 'Instance Names\SQL')
+foreach ($instance in $SqlInstances.PSObject.Properties) {
+    # This is not a SQL Instance
+    if ($instance.Name -match 'PS') {
+        continue
+    }
 
-# Set the SQL Server service Startup Type to Automatic
-sc.exe config 'MSSQL$SQLEXPRESS' start=auto
-
-Write-Output "SQL Server: Forcing Restart of Instance."
-Restart-Service -Force 'MSSQL$SQLEXPRESS'
+    Write-Host "SQL Instance: $($instance.Name)"
+    $instanceKey = Join-Path $SqlBaseKey "$($instance.Value)\MSSQLServer\"
+    New-ItemProperty $instanceKey -Name 'LoginMode' -Value 2 -Force
+    $InstanceService = Get-Service -DisplayName "SQL Server ($($instance.Name))"
+    # Set the SQL Server service Startup Type to Automatic using sc.exe as Set-Service does not change it from delayed.
+    sc.exe config $InstanceService.Name start=auto
+    Write-Output "SQL Server: Forcing Restart of Instance."
+    Restart-Service $InstanceService -Force
+}
 
 Write-Output "SQL Server: Setting up SQL Server Browser and starting the service."
 Set-Service 'SQLBrowser' -StartupType Automatic

--- a/src/content/docs/en-us/central-management/setup/index.mdx
+++ b/src/content/docs/en-us/central-management/setup/index.mdx
@@ -129,5 +129,3 @@ Please go back through Step 1 and re-internalize those packages. You may need to
 You need to check the CCM service logs. The agent will always report success when it communicates with the service successfully. The service may reject what it receives, but due to security settings, it won't tell the client about that.
 
 The logs are located at `$env:ChocolateyInstall\logs\ccm-service.log`. If you are on a version of CCM prior to 0.2.0, the log will be located at `$env:ChocolateyInstall\lib\chocolatey-management-service\tools\service\logs\chocolatey.service.host.log`.
-
-<Xref title="Chocolatey Central Management" value="central-management" />

--- a/src/content/docs/en-us/central-management/setup/service.mdx
+++ b/src/content/docs/en-us/central-management/setup/service.mdx
@@ -604,5 +604,3 @@ You may see the following: `System.ServiceModel.AddressAccessDeniedException: HT
 You are attempting to set up a user that is not in the local Administrators group with the Chocolatey Central Management Service. **This is not a supported scenario.**
 
 Please refer to the <Xref title="Chocolatey Central Management Service Windows Account Considerations" value="ccm-service" anchor="chocolatey-central-management-service-windows-account-considerations" /> and select an option that works best for your organization.
-
-<Xref title="Central Management Setup" value="ccm-setup" /> | <Xref title="Chocolatey Central Management" value="central-management" />

--- a/src/content/docs/en-us/central-management/setup/upgrade.mdx
+++ b/src/content/docs/en-us/central-management/setup/upgrade.mdx
@@ -217,8 +217,6 @@ There are two workarounds noted:
 - Delete the appsettings.json file prior to upgrade
 - Do not pass database details if they have not changed during upgrade.
 
-<Xref title="Central Management Setup" value="ccm-setup" /> | <Xref title="Chocolatey Central Management" value="central-management" />
-
 ### When upgrading the CCM website, Chocolatey reports a lot of errors about files being locked, and the CCM website does not function after the upgrade
 
 This is a known issue for v0.6.0 and v0.6.1 releases, and is resolved as of v0.6.2.

--- a/src/content/docs/en-us/central-management/setup/website.mdx
+++ b/src/content/docs/en-us/central-management/setup/website.mdx
@@ -532,8 +532,6 @@ Within the Chocolatey Central Management Website, [SignalR](https://dotnet.micro
 
 In all of these cases, we haven't seen any drop in functionality for the notifications that are sent from the Chocolatey Central Management application.  Our suspicion is that there is a timing issue when attempting to make the connection to the SignalR Hub, which is almost immediately rectified.  Due to the fact that SignalR is a 3rd party integration, we do not believe that there is anything that can be done to resolve this problem, and since the functionality continues to work as expected, these errors in the JavaScript console can safely be ignored.
 
-<Xref title="Central Management Setup" value="ccm-setup" /> | <Xref title="Chocolatey Central Management" value="central-management" />
-
 [required-config]: #what-is-the-minimum-required-configuration-for-the-appsettingsjson-file
 
 ### Current user did not login to the application!

--- a/src/content/docs/en-us/central-management/usage/website/administration/roles.mdx
+++ b/src/content/docs/en-us/central-management/usage/website/administration/roles.mdx
@@ -49,9 +49,9 @@ From the **Edit Role** modal, you can modify the name, set it to be the Default 
 
 <Callout type="info">
     If you do not see the **Delete** menu entry or the **Actions** buttons, please see your Administrator to determine if your account has the _Edit Roles_ permissions.
-    
+
     Roles labelled **Built-in role** cannot be deleted.
-    
+
     You cannot delete a Role if the account you are using also has the Role assigned to it.
 </Callout>
 
@@ -69,9 +69,3 @@ When first browsing to the Roles page, you'll be presented with 4 pre-configured
 These pre-configured roles are labeled **Built-in role** and cannot be deleted. They can however be edited by name, default role selection, and permissions.
 
 We recommend you review the permissions these roles have. Then edit them, if needed, to work within your environment.
-
-## Related Topics
-
-* <Xref title="Chocolatey Central Management" value="central-management" />
-* <Xref title="Chocolatey Central Management - Deployments" value="ccm-deployments" />
-* <Xref title="Chocolatey Central Management - Reports" value="ccm-reports" />

--- a/src/content/docs/en-us/central-management/usage/website/computers.mdx
+++ b/src/content/docs/en-us/central-management/usage/website/computers.mdx
@@ -29,7 +29,7 @@ Please see <Xref title="Central Management Client Setup" value="ccm-client" /> f
 
 <Callout type="info">
     Starting with Chocolatey Central Management 0.10.0, the groups that a computer is a member of is shown in both the table of all computers, as well as on the computer details pages.  By default, this will only show the first 5 group memberships. If there are more group associations:
-    
+
     - The computers table will display a `...` link in the Groups column. Upon hovering this link, a tooltip will be shown with all group memberships.
     - On the computer details page, the group memberships will be shown in table form.
 </Callout>
@@ -128,10 +128,3 @@ You need to check the CCM service logs. The agent will always report success whe
 The logs are located at `$env:ChocolateyInstall\logs\ccm-service.log`. If you are on a version of Chocolatey Central Management prior to 0.2.0, the log will be located at `$env:ChocolateyInstall\lib\chocolatey-management-service\tools\service\logs\chocolatey.service.host.log`.
 
 For more common errors related to checking in, see the <Xref title="setup section (and component setup sub-sections)" value="ccm-setup" /> as they dive deeper into common errors and resolutions related to things such as this.
-
-## Related Topics
-
-* <Xref title="Chocolatey Central Management" value="central-management" />
-* <Xref title="Central Management - Software" value="ccm-software" />
-* <Xref title="Central Management - Groups" value="ccm-groups" />
-* <Xref title="Central Management - Reports" value="ccm-reports" />

--- a/src/content/docs/en-us/central-management/usage/website/deployments.mdx
+++ b/src/content/docs/en-us/central-management/usage/website/deployments.mdx
@@ -468,10 +468,3 @@ export const tabs1 = [
 </TabsPaneContainer>
 
 For more information on when this will be addressed, you can subscribe to the [GitHub issue](https://github.com/chocolatey/chocolatey-licensed-issues/issues/158).
-
-## Related Topics
-
-* <Xref title="Chocolatey Central Management" value="central-management" />
-* <Xref title="Chocolatey Central Management - Groups" value="ccm-groups" />
-* <Xref title="Chocolatey Central Management - Computers" value="ccm-computers" />
-* <Xref title="Chocolatey Central Management - Reports" value="ccm-reports" />

--- a/src/content/docs/en-us/central-management/usage/website/groups.mdx
+++ b/src/content/docs/en-us/central-management/usage/website/groups.mdx
@@ -115,7 +115,7 @@ Creating a Deployment Plan for a Group can be done from two pages:
 
     ![Button to create a new Draft Deployment Plan for a Group from the Group Details page](https://img.chocolatey.org/docs/ccm-playwright/groups/details/button-action-dropdown-menu-create-deployment-plan.png)
 
-Clicking this option will create a New Deployment Plan. This Deployment Plan will create one Deployment Step with the chosen Target Group selected. Upon arriving on the Edit Deployment Plan screen, this Deployment Step will be opened and ready to add a script command. 
+Clicking this option will create a New Deployment Plan. This Deployment Plan will create one Deployment Step with the chosen Target Group selected. Upon arriving on the Edit Deployment Plan screen, this Deployment Step will be opened and ready to add a script command.
 
 ![Automatically created Deployment Plan showing the Deployment Step modal script command area](https://img.chocolatey.org/docs/ccm-playwright/deployment-plans/edit/groups-modal-new-deployment-plan.png)
 
@@ -156,9 +156,3 @@ Once you upgrade to at least CCM v0.2.0, every machine will show that until they
 ### A Computer or Group is not showing as available for deployments, but I have plenty of available licenses
 
 Once you upgrade to Central Management v0.3.0+, you have upgraded the Agent on the machine to v0.11.0+, and it has successfully completed a check in, then that messaging should go away. Note that clients do not get a message back that there was a failure as a security feature - you'll need to consult the Central Management Service logs. You can find that at `$env:ChocolateyInstall\logs\ccm-service.log`, or if you are on a version of Chocolatey Central Management prior to 0.2.0, the log will be located at `$env:ChocolateyInstall\lib\chocolatey-management-service\tools\service\logs\chocolatey.service.host.log`.
-
-## Related Topics
-
-* <Xref title="Chocolatey Central Management" value="central-management" />
-* <Xref title="Central Management - Deployments" value="ccm-deployments" />
-* <Xref title="Central Management - Computers" value="ccm-computers" />

--- a/src/content/docs/en-us/central-management/usage/website/software.mdx
+++ b/src/content/docs/en-us/central-management/usage/website/software.mdx
@@ -85,10 +85,3 @@ From the Software Details page, click the **Actions** button and select the **Un
 Clicking this option will create a New Deployment Plan. This Deployment Plan will create one Deployment Step with a <Xref title="Temporary Group" value="ccm-groups" anchor="temporary-groups" /> that contains all the Computers the Software is currently installed on.
 
 From here, the Deployment Plan can be edited and deployed as outlined in the <Xref title="Deployment Plan documentation" value="ccm-deployments" />.
-
-## Related Topics
-
-* <Xref title="Central Management - Computers" value="ccm-computers" />
-* <Xref title="Central Management - Reports" value="ccm-reports" />
-
-<Xref title="Chocolatey Central Management" value="central-management" />


### PR DESCRIPTION
## Description Of Changes

Update the script on the CCM database setup page to detect the SQL instances installed, and set them all to use mixed mode.

## Motivation and Context

Instead of having a section of the script that relies on the user catching it and changing it, this takes care of whichever SQL Server is installed.

## Testing

* [x] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.
* [x] I have tested this by installing SQL Server Express 2016 Chocolatey package, then manually installing SQL Server 2017, 2019, and 2022 as separate instances on the same system. Confirmed they all had mixed mode login enabled.

## Change Types Made

* [ ] Minor documentation fix (typos etc.).
* [ ] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist

* [ ] Requires a change to menu structure (top or left-hand side)/
* [ ] Menu structure has been updated
* [ ] Images added to the [img](https://github.com/chocolatey/img) repository?
    * [ ] PR -
* [ ] All items are complete on the [Definition of Done](https://github.com/chocolatey/home/blob/main/definition-of-done.md).

## Related Issue

N/A
