### PR TITLE
Fixing links and errors and removing outdated info

### DIFF
--- a/src/components/docs/ConfigurationManagers.mdx
+++ b/src/components/docs/ConfigurationManagers.mdx
@@ -5,21 +5,21 @@ import Callout from '@choco-astro/components/Callout.astro';
 import Iframe from '@choco-astro/components/Iframe.astro';
 import Xref from '@components/Xref.astro';
 
-For common integrations, it's handy to refer to the table below to know what configuration manager to choose. Most of the implementations below are written and managed by the companies behind the product. These implementations are typically open source and each part could be added by community contributions for those familiar with the code implementations. If you are unable to provide code implementations for adding necessary functionality to the integrations, we find it best if you create issues/tickets with those organizations if you are a customer as you will have more leverage into getting them implemented.
+For common integrations, it's handy to refer to the table below to know what configuration manager to choose. Most of these implementations are written and managed by the organizations behind the product and are typically open source. Each part could be added by community contributions for those familiar with the code implementations. If you are unable to provide code implementations for adding necessary functionality to the integrations, we find it best if you create issues/tickets with those organizations if you are a customer as you will have more leverage in getting them implemented.
 
 <Callout type="info">
     If you are a configuration manager company identified in the table and you have implemented anything in the below or you find our information is incorrect, please let us know so we can get it fixed.
 </Callout>
 
-| Configuration Managers                              | [Ansible][ansible_main] | [Chef][chef_main]  | [PowerShell DSC][dsc_main] | [Puppet][pp_main] | [Salt][salt_main] | [Otter][otter_main] |
-|-----------------------------------------------------|-------------------------|--------------------|----------------------------|-------------------|-------------------|---------------------|
-| Manage Packages                                     | [x][ansible_main]       | [x][chef_main]     | [x][dsc_pkgs]              | [x][pp_pkgs]      | [x][salt_pkgs]    | [x][otter_pkgs]     |
-| <Xref title="Install Chocolatey" value="setup-choco" />              | [x][ansible_main]       | [x][chef_cookbook] | [x][dsc_install]           | [x][pp_install]   | [x][salt_install] | [x][otter_install]  |
-| Install Chocolatey from internal source             | [x][ansible_main]       | [x][chef_cookbook] | [x][dsc_install]           | [x][pp_install]   |                   | [x][otter_install]  |
-| <Xref title="Manage Sources" value="choco-command-source" />         | [x][ansible_source]     | [x][chef_source]   | [x][dsc_source]            | [x][pp_source]    | [x][salt_source]  | [x][otter_source]   |
-| Manage Source Type (Admin/Self-Service)             | [x][ansible_source]     |                    |                            | [x][pp_source]    |                   |                     |
-| <Xref title="Manage Features" value="choco-command-feature" />       | [x][ansible_feature]    |                    | [x][dsc_feature]           | [x][pp_feature]   |                   | [x][otter_feature]  |
-| <Xref title="Manage Config Settings" value="choco-command-config" /> | [x][ansible_config]     | [x][chef_config]   |                            | [x][pp_config]    |                   |                     |
+| Configuration Managers                                                        | [Ansible][ansible_main] | [Chef][chef_main]  | [Puppet][pp_main] | [Salt][salt_main] | [BuildMaster/Otter][otter_main] |
+|-------------------------------------------------------------------------------|-------------------------|--------------------|-------------------|-------------------|---------------------------------|
+| Manage Packages                                                               | [x][ansible_manage]     | [x][chef_manage]   | [x][pp_pkgs]      | [x][salt_main]    | [x][otter_pkgs]                 |
+| <Xref title="Install Chocolatey" value="setup-choco" />                       | [x][ansible_main]       | [x][chef_main]     | [x][pp_install]   | [x][salt_main]    | [x][otter_install]              |
+| Install Chocolatey from internal source                                       | [x][ansible_main]       | [x][chef_main]     | [x][pp_install]   |                   | [x][otter_install]              |
+| <Xref title="Manage Sources" value="choco-command-source" />                  | [x][ansible_source]     | [x][chef_source]   | [x][pp_source]    | [x][salt_main]    | [x][otter_source]               |
+| Manage Source Type (Admin/Self-Service)                                       | [x][ansible_source]     | [x][chef_source]   | [x][pp_source]    |                   |                                 |
+| <Xref title="Manage Features" value="choco-command-feature" />                | [x][ansible_feature]    | [x][chef_feature]  | [x][pp_feature]   |                   | [x][otter_feature]              |
+| <Xref title="Manage Config Settings" value="choco-command-config" />          | [x][ansible_config]     | [x][chef_config]   | [x][pp_config]    |                   |                                 |
 
 <Callout type="info">
     Each *x* is linked to the specific feature documentation.
@@ -27,15 +27,18 @@ For common integrations, it's handy to refer to the table below to know what con
 
 For most of these, those configuration managers have some sort of exec you could use to manage those additional aspects, but it would be best if they supported all aspects of configuration of Chocolatey as part of the provider implementations.
 
-[ansible_main]:https://docs.ansible.com/ansible/latest/modules/win_chocolatey_module.html
-[ansible_source]: https://docs.ansible.com/ansible/latest/modules/win_chocolatey_source_module.html
-[ansible_feature]:https://docs.ansible.com/ansible/latest/modules/win_chocolatey_feature_module.html
-[ansible_config]:https://docs.ansible.com/ansible/latest/modules/win_chocolatey_config_module.html
+[ansible_main]:https://docs.ansible.com/projects/ansible/latest/collections/chocolatey/chocolatey/index.html
+[ansible_source]: https://docs.ansible.com/projects/ansible/latest/collections/chocolatey/chocolatey/win_chocolatey_source_module.html#ansible-collections-chocolatey-chocolatey-win-chocolatey-source-module
+[ansible_feature]:https://docs.ansible.com/projects/ansible/latest/collections/chocolatey/chocolatey/win_chocolatey_feature_module.html#ansible-collections-chocolatey-chocolatey-win-chocolatey-feature-module
+[ansible_config]:https://docs.ansible.com/projects/ansible/latest/collections/chocolatey/chocolatey/win_chocolatey_config_module.html#ansible-collections-chocolatey-chocolatey-win-chocolatey-config-module
+[ansible_manage]:https://docs.ansible.com/projects/ansible/latest/collections/chocolatey/chocolatey/win_chocolatey_module.html#ansible-collections-chocolatey-chocolatey-win-chocolatey-module
 
-[chef_main]:https://docs.chef.io/resource_chocolatey_package.html
+[chef_main]:https://docs.chef.io/client/19/resources/bundled/chocolatey_installer/
 [chef_cookbook]:https://supermarket.chef.io/cookbooks/chocolatey/
-[chef_source]:https://docs.chef.io/resource_chocolatey_source.html
-[chef_config]:https://docs.chef.io/resource_chocolatey_config.html
+[chef_source]:https://docs.chef.io/client/19/resources/bundled/chocolatey_source/
+[chef_config]:https://docs.chef.io/client/19/resources/bundled/chocolatey_config/
+[chef_feature]:https://docs.chef.io/client/19/resources/bundled/chocolatey_feature/
+[chef_manage]:https://docs.chef.io/client/19/resources/bundled/chocolatey_package/
 
 [dsc_main]:https://www.powershellgallery.com/packages/cChoco
 [dsc_pkgs]:https://github.com/chocolatey/cChoco/blob/development/DSCResources/cChocoPackageInstall/cChocoPackageInstall.schema.mof
@@ -44,18 +47,18 @@ For most of these, those configuration managers have some sort of exec you could
 [dsc_feature]:https://github.com/chocolatey/cChoco/blob/master/DSCResources/cChocoFeature/cChocoFeature.schema.mof
 
 [pp_main]:https://forge.puppet.com/puppetlabs/chocolatey
-[pp_pkgs]:https://forge.puppet.com/puppetlabs/chocolatey#package-provider-chocolatey
-[pp_install]:https://forge.puppet.com/puppetlabs/chocolatey#class-chocolatey
-[pp_source]:https://forge.puppet.com/puppetlabs/chocolatey#chocolateysource
-[pp_feature]:https://forge.puppet.com/puppetlabs/chocolatey#chocolateyfeature
-[pp_config]:https://forge.puppet.com/puppetlabs/chocolatey#chocolateyconfig
+[pp_pkgs]:https://forge.puppet.com/modules/puppetlabs/chocolatey/readme#packages
+[pp_install]:https://forge.puppet.com/modules/puppetlabs/chocolatey/readme#manage-chocolatey-installation
+[pp_source]:https://forge.puppet.com/modules/puppetlabs/chocolatey/readme#sources-configuration
+[pp_feature]:https://forge.puppet.com/modules/puppetlabs/chocolatey/readme#features-configuration
+[pp_config]:https://forge.puppet.com/modules/puppetlabs/chocolatey/readme#config-configuration
 
-[salt_main]:https://docs.saltstack.com/en/latest/ref/modules/all/salt.modules.chocolatey.html
+[salt_main]:https://docs.saltproject.io/en/latest/ref/modules/all/salt.modules.chocolatey.html
 [salt_pkgs]:https://docs.saltstack.com/en/latest/ref/modules/all/salt.modules.chocolatey.html#salt.modules.chocolatey.install
 [salt_install]:https://docs.saltstack.com/en/latest/ref/modules/all/salt.modules.chocolatey.html#salt.modules.chocolatey.bootstrap
 [salt_source]:https://docs.saltstack.com/en/latest/ref/modules/all/salt.modules.chocolatey.html#salt.modules.chocolatey.add_source
 
-[otter_main]:https://inedo.com/den/inedox/chocolatey
+[otter_main]:https://buildmaster.inedo.com/applications/15/overview
 [otter_pkgs]:https://github.com/Inedo/inedox-chocolatey/blob/master/Chocolatey/InedoExtension/Configurations/ChocolateyPackageConfiguration.cs
 [otter_install]:https://github.com/Inedo/inedox-chocolatey/blob/master/Chocolatey/InedoExtension/Configurations/ChocolateyInstalledConfiguration.cs
 [otter_source]:https://github.com/Inedo/inedox-chocolatey/blob/master/Chocolatey/InedoExtension/Configurations/ChocolateySourceConfiguration.cs

--- a/src/components/docs/OrgGuideCentralManagement.mdx
+++ b/src/components/docs/OrgGuideCentralManagement.mdx
@@ -17,7 +17,7 @@ import OrgGuideCentralManagementIntro from '@components/docs/OrgGuideCentralMana
 import DynamicCodeBlockInput from '@choco-astro/components/dynamicCodeBlock/DynamicCodeBlockInput.astro';
 import DynamicCodeBlock from '@choco-astro/components/dynamicCodeBlock/DynamicCodeBlock.astro';
 export const ccmInstall = [
-    { id: 'ccm-database', title: 'Chocolatey Cental Management Database', isActive: true },
+    { id: 'ccm-database', title: 'Chocolatey Central Management Database', isActive: true },
     { id: 'ccm-service', title: 'Chocolatey Central Management Service', updateAnchor: true },
     { id: 'ccm-web', title: 'Chocolatey Central Management Website', updateAnchor: true }
 ];

--- a/src/content/docs/en-us/features/integrations.mdx
+++ b/src/content/docs/en-us/features/integrations.mdx
@@ -1,7 +1,7 @@
 ---
 order: 60
 xref: integrations
-title: Integrates with everything
+title: Integrates With Anything
 description: Information on how Chocolatey can integrate with almost every tool
 ---
 import Callout from '@choco-astro/components/Callout.astro';
@@ -9,11 +9,11 @@ import Iframe from '@choco-astro/components/Iframe.astro';
 import Xref from '@components/Xref.astro';
 import ConfigurationManagers from '@components/docs/ConfigurationManagers.mdx';
 
-Chocolatey integrates with several infrastructure automation tools!
+## Summary
+
+Chocolatey can be used with almost every mainstream infrastructure automation tool! Some of the more popular ones are listed below.
 
 With most of these tools, the interface you would interact with Chocolatey would be through the tool or through the interfaces of the tool, like in scripts.
-
-## Summary
 
 ### Chocolatey Integration Implementation with Common Configuration Managers
 
@@ -29,7 +29,7 @@ win_chocolatey:
   source: https://my.internal.repository/api/v2/
 ```
 
-[Read More...](https://docs.ansible.com/ansible/latest/collections/chocolatey/chocolatey/win_chocolatey_source_module.html)
+[Read More...](https://docs.ansible.com/projects/ansible/latest/collections/chocolatey/chocolatey/index.html)
 
 ## Boxstarter
 
@@ -95,13 +95,13 @@ node.default['cpe_choco']['sources']['bacon'] =
 
 Octopus is a friendly deployment automation tool for .NET developers. It integrates with lots of utilities, and they have a template for installing Chocolatey packages: https://library.octopusdeploy.com/step-template/actiontemplate-chocolatey-install-package
 
-[Read more...](https://octopus.com/)
+[Read more...](https://octopus.com/docs/runbooks/runbook-examples/routine/installing-software-chocolatey)
 
-## Otter
+## BuildMaster/Otter
 
-Otter has an [open source Chocolatey extension](https://github.com/Inedo/inedox-chocolatey) that allows installing and uninstalling packages, specifying package versions, chocolatey sources, chocolatey features, and installing chocolatey itself.
+Inedo has an [open source Chocolatey extension](https://github.com/Inedo/inedox-chocolatey) that allows installing and uninstalling packages, specifying package versions, Chocolatey sources, Chocolatey features, and installing Chocolatey itself.
 
-Otter also keeps an inventory of Chocolatey packages installed on any or all servers.
+BuildMaster/Otter also keeps an inventory of Chocolatey packages installed on any or all servers.
 
 ```powershell
 Chocolatey::Ensure-Package
@@ -131,26 +131,7 @@ Chocolatey::Ensure-Feature
 );
 ```
 
-[Read More...](https://inedo.com/den/otter/chocolatey)
-
-## PowerShell DSC
-
-PowerShell DSC (Desired State Configuration) has a cChoco module that can manage both packages and the installation of Chocolatey itself.
-
-```powershell
-  cChocoInstaller installChoco
-  {
-    InstallDir = "c:\ProgramData\chocolatey"
-  }
-
-  cChocoPackageInstaller installGit
-  {
-     Name = "git"
-     DependsOn = "[cChocoInstaller]installChoco"
-  }
-```
-
-[Read More...](http://www.powershellgallery.com/packages/cChoco/)
+[Read More...](https://buildmaster.inedo.com/applications/15/overview)
 
 ## PowerShell PackageManagement
 
@@ -215,7 +196,7 @@ salt '*' chocolatey.bootstrap
 salt '*' chocolatey.install git
 ```
 
-[Read More...](https://docs.saltstack.com/en/latest/ref/modules/all/salt.modules.chocolatey.html)
+[Read More...](https://docs.saltproject.io/en/latest/ref/modules/all/salt.modules.chocolatey.html)
 
 ## System Center Configuration Manager
 

--- a/src/content/docs/en-us/guides/organizations/proxying-ccr.mdx
+++ b/src/content/docs/en-us/guides/organizations/proxying-ccr.mdx
@@ -59,13 +59,6 @@ For more information, visit Inedo ProGet's documentation on [HOWTO: Proxy Packag
 
 #### JFrog Artifactory
 
-<div class="callout callout-warning">
-  <div class="callout-header">WARNING</div>
-  <p>
-    This does not work with the self-hosted version of Artifactory and may result in blocks for excessive usage. However, this may work in the Cloud/SaaS version. JFrog is aware that this does not work with the self-hosted version and once this has been resolved, this warning will be removed. [More information can be found here](https://jfrog.atlassian.net/browse/RTFACT-31207).
-  </p>
-</div>
-
 <table>
     <tr>
         <th>Repository Type</th>


### PR DESCRIPTION
## Description Of Changes
This commit fixes the broken links on our Integrations doc and removes the now archived cChoco module from the integrations list. It also removes the warning placed on the Artifactory tab in the Proxying CCR doc now that JFrog has fixed the corresponding issue, and also corrects a spelling mistake on the CCM doc in the Org Guide.

## Motivation and Context
The links in the Integrations table and on the page had been broken for a while, and the new fix that JFrog implemented to relieve the caching issues on the CCR prompted the PR. The change to the menu on the left-hand side was just a renaming of the Integrations page; no other menu changes were made.

## Testing

* [X] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [X] Minor documentation fix (typos etc.).
* [X] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist

* [X] Requires a change to menu structure (top or left-hand side)/
* [X] Menu structure has been updated
* [ ] Images added to the [img](https://github.com/chocolatey/img) repository?
    * [ ] PR -
* [ ] All items are complete on the [Definition of Done](https://github.com/chocolatey/home/blob/main/definition-of-done.md).

## Related Issue

None.
