### PR TITLE
(doc) CLI 2.7.4 and 1.4.7 releases

### DIFF
--- a/src/components/docs/ChocolateyProductDependencies.mdx
+++ b/src/components/docs/ChocolateyProductDependencies.mdx
@@ -13,12 +13,12 @@ Please refer to our <Xref title="Support Lifecycle information" value="chocolate
 
 | Package Name / Dependency      | chocolatey  | chocolatey.extension | chocolateygui |
 | ------------------------------ | ----------- | -------------------- | ------------- |
-| chocolatey v2.7.3              |             |                      |               |
+| chocolatey v2.7.4              |             |                      |               |
 | chocolatey.extension v8.2.0    | v2.7.0      |                      |               |
 | chocolatey-agent v4.1.0        |             | v8.0.0               |               |
 | chocolateygui v3.2.0           | v2.7.0      |                      |               |
 | chocolateygui.extension v3.0.0 |             | v8.0.0               | v3.0.0        |
-| chocolatey v1.4.6              |             |                      |               |
+| chocolatey v1.4.7              |             |                      |               |
 | chocolatey.extension v5.0.8    | v1.2.0      |                      |               |
 | chocolatey-agent v1.1.5        |             | v4.0.0               |               |
 | chocolateygui v1.1.3           | v1.0.0      |                      |               |

--- a/src/content/docs/en-us/choco/release-notes.mdx
+++ b/src/content/docs/en-us/choco/release-notes.mdx
@@ -24,6 +24,22 @@ This covers changes for the "chocolatey" and "chocolatey.lib" packages, which ar
 
 <ChocolateyProductDependenciesLink />
 
+## 2.7.4 (August 19, 2026) \{#v2.7.4}
+
+### Dependency Changes
+
+- [Security] Upgrade log4net to 3.3.1 in chocolatey.lib.
+  - See [#3915](https://github.com/chocolatey/choco/issues/3915) by [st3phhays](https://github.com/st3phhays), resolved in [!3916](https://github.com/chocolatey/choco/pull/3916) by [st3phhays](https://github.com/st3phhays).
+- [Security] Update bundled 7zip executables to 26.02.
+  - See [#3918](https://github.com/chocolatey/choco/issues/3918) by [AdmiringWorm](https://github.com/AdmiringWorm), resolved in [!3924](https://github.com/chocolatey/choco/pull/3924) by [alexaveldanez](https://github.com/alexaveldanez).
+
+### Contributors
+
+3 contributors made this release possible.
+
+<a href="https://github.com/st3phhays"><img src="https://avatars.githubusercontent.com/u/42750725?v=4" alt="Profile image for contributor st3phhays" height="32" width="32"/></a> <a href="https://github.com/AdmiringWorm"><img src="https://avatars.githubusercontent.com/u/1474648?v=4" alt="Profile image for contributor AdmiringWorm" height="32" width="32"/></a> <a href="https://github.com/alexaveldanez"><img src="https://avatars.githubusercontent.com/u/54651125?u=3d238bd6bbc656f6b8a09985276750aae96b884a&v=4" alt="Profile image for contributor alexaveldanez" height="32" width="32"/></a> 
+
+
 ## 2.7.3 (June 10, 2026) \{#v2.7.3}
 
 ### Bug Fix
@@ -735,6 +751,21 @@ See this [list](https://github.com/chocolatey/choco/discussions/2995) for known 
 
 - Fix broken URLs in repository README file - see [#2888](https://github.com/chocolatey/choco/pull/2888).
 - Update package files to reflect current CCR moderation requirements - see [#2920](https://github.com/chocolatey/choco/issues/2920).
+
+
+## 1.4.7 (August 19, 2026) \{#v1.4.7}
+
+### Dependency Change
+
+- [Security] Update bundled 7zip executables to 26.02.
+  - See [#3928](https://github.com/chocolatey/choco/issues/3928) by [gep13](https://github.com/gep13) resolved in [!3925](https://github.com/chocolatey/choco/pull/3925) by [alexaveldanez](https://github.com/alexaveldanez).
+
+### Contributors
+
+2 contributors made this release possible.
+
+<a href="https://github.com/gep13"><img src="https://avatars.githubusercontent.com/u/1271146?v=4" alt="gep13" height="32" width="32"/></a> <a href="https://github.com/alexaveldanez"><img src="https://avatars.githubusercontent.com/u/54651125?u=3d238bd6bbc656f6b8a09985276750aae96b884a&v=4" alt="alexaveldanez" height="32" width="32"/></a> 
+
 
 ## 1.4.6 (May 13, 2026) \{#v1.4.6}
 

--- a/src/content/docs/en-us/highlights/00-top-sidebar-highlight.md
+++ b/src/content/docs/en-us/highlights/00-top-sidebar-highlight.md
@@ -6,8 +6,8 @@ description: We recently released a new version of multiple Chocolatey Products.
 highlight:
   postedDateTime: 2026-07-08T00:00:00Z
   ctaXref: highlights
-  ctaAnchor: july-2026
-  ctaText: View July's highlights
+  ctaAnchor: august-2026
+  ctaText: View August's highlights
   showOnHome: false
   showOnHighlights: false
   showInSidebar: true

--- a/src/content/docs/en-us/highlights/2026/06-chocolatey-cli-2.7.3.md
+++ b/src/content/docs/en-us/highlights/2026/06-chocolatey-cli-2.7.3.md
@@ -8,6 +8,6 @@ highlight:
   ctaXref: choco-release-notes
   ctaAnchor: v2.7.3
   ctaText: Read the release notes
-  showOnHome: true
+  showOnHome: false
   showOnHighlights: true
 ---

--- a/src/content/docs/en-us/highlights/2026/08-chocolatey-cli-1.4.7.md
+++ b/src/content/docs/en-us/highlights/2026/08-chocolatey-cli-1.4.7.md
@@ -1,0 +1,13 @@
+---
+order: 0
+xref: highlight-2026-08-19-chocolatey-cli-1.4.7
+title: What's new in Chocolatey CLI v1.4.7
+description: Learn all about what's new in Chocolatey CLI v1.4.7.
+highlight:
+  postedDateTime: 2026-08-19T00:03:20Z
+  ctaXref: choco-release-notes
+  ctaAnchor: v1.4.7
+  ctaText: Read the release notes
+  showOnHome: true
+  showOnHighlights: true
+---

--- a/src/content/docs/en-us/highlights/2026/08-chocolatey-cli-2.7.4.md
+++ b/src/content/docs/en-us/highlights/2026/08-chocolatey-cli-2.7.4.md
@@ -1,0 +1,13 @@
+---
+order: 0
+xref: highlight-2026-08-19-chocolatey-cli-2.7.4
+title: What's new in Chocolatey CLI v2.7.4
+description: Learn all about what's new in Chocolatey CLI v2.7.4.
+highlight:
+  postedDateTime: 2026-08-19T00:03:20Z
+  ctaXref: choco-release-notes
+  ctaAnchor: v2.7.4
+  ctaText: Read the release notes
+  showOnHome: true
+  showOnHighlights: true
+---


### PR DESCRIPTION
## Description Of Changes

- Chocolatey CLI v2.7.4 and 1.4.7 release notes section to the documentation, including security releases and contributor acknowledgements

## Motivation and Context

- Communicate the 2.7.4 and 1.4.7 releases and improvements to users and maintainers

## Testing

* [x] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made

* [ ] Minor documentation fix (typos etc.).
* [x] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.

## Change Checklist

* [ ] Requires a change to menu structure (top or left-hand side)/
* [ ] Menu structure has been updated
* [ ] Images added to the [img](https://github.com/chocolatey/img) repository?
    * [ ] PR -
* [x] All items are complete on the [Definition of Done](https://github.com/chocolatey/home/blob/main/definition-of-done.md).

## Related Issue

N/A