### PR TITLE
(#1374)Remove DotNet4.5.2 Package From Internalize Packages Script

### DIFF
--- a/src/content/docs/en-us/central-management/setup/index.mdx
+++ b/src/content/docs/en-us/central-management/setup/index.mdx
@@ -59,7 +59,7 @@ if(!(Test-Path C:\packages)){
 choco download chocolatey chocolateygui --force --source="'https://community.chocolatey.org/api/v2/'" --output-directory="'C:\packages'"
 
 # This is for other Community Related Items
-choco download dotnet4.5.2 dotnetfx --force --internalize --internalize-all-urls --append-use-original-location --source="'https://community.chocolatey.org/api/v2/'" --output-directory="'C:\packages'"
+choco download dotnetfx --force --internalize --internalize-all-urls --append-use-original-location --source="'https://community.chocolatey.org/api/v2/'" --output-directory="'C:\packages'"
 
 
 # This is for SQL Server Express


### PR DESCRIPTION
## Description Of Changes
Remove DotNet4.5.2 Package from Internlaize Script

## Motivation and Context
DotNet4.5.2 is no longer a needed dependency of any current Chocolatey Core Component Packages.

## Testing
* [X] I have previewed these changes using the [Docker Container](https://github.com/chocolatey/docs/tree/master/.devcontainer) or another method before submitting this pull request.

## Change Types Made
* [X] Minor documentation fix (typos etc.).
* [ ] Major documentation change (refactoring, reformatting or adding documentation to existing page).
* [ ] New documentation page added.
* [ ] The change I have made should have a video added, and I have raised an issue for this.
    * Issue #

## Change Checklist

* [ ] Requires a change to menu structure (top or left-hand side)/
* [ ] Menu structure has been updated
* [ ] Images added to the [img](https://github.com/chocolatey/img) repository?
    * [ ] PR -
* [X] All items are complete on the [Definition of Done](https://github.com/chocolatey/home/blob/main/definition-of-done.md).

## Related Issue
Fixes #1374
